### PR TITLE
feat: add interactive session sharing

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,5 @@ strict-peer-dependencies=false
 node-linker=hoisted
 prefer-workspace-packages=true
 prefer-offline=true
+pm-on-fail=ignore
+verify-deps-before-run=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,0 @@
-shamefully-hoist=true
-strict-peer-dependencies=false
-node-linker=hoisted
-prefer-workspace-packages=true
-prefer-offline=true
-pm-on-fail=ignore
-verify-deps-before-run=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+shamefully-hoist=true
+strict-peer-dependencies=false
+node-linker=hoisted
+prefer-workspace-packages=true
+prefer-offline=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add read-only Codex session share links with owner-approved terminal control requests.
 - Install bubblewrap and default interactive Codex sessions to yolo mode with a clean PTY buffer.
 - Keep Escape routed to focused Codex terminals instead of closing the session drawer.
 - Enable the experimental Codex goals feature in provisioned interactive sessions.

--- a/docs/api.md
+++ b/docs/api.md
@@ -218,6 +218,21 @@ Returns all run attempts for a card, newest first.
 
 ## Interactive Sessions
 
+### GET /api/shared-sessions/:id?token=:token
+
+Public read-only endpoint for a generated session share link. Returns the shared interactive session, D1 event scrollback, and `sharedReadOnly: true`. Invalid, disabled, or rotated tokens return `404`.
+
+```json
+{
+  "session": {
+    "id": "IS-105",
+    "sharedReadOnly": true,
+    "canControl": false,
+    "logs": []
+  }
+}
+```
+
 ### POST /api/provision/interactive
 
 Provision hook used by `CRABYARD_INTERACTIVE_PROVISION_URL`. It accepts the same session request payload as the external adapter contract and returns normalized provision status.
@@ -237,7 +252,7 @@ Backends:
 
 ### GET /api/interactive-sessions/:id/pty
 
-Viewer+. Same-origin WebSocket endpoint used by the Ghostty WASM terminal. Crabyard authenticates the browser session, verifies the interactive session is still attachable, then proxies PTY bytes to the configured runner.
+Viewer+. Same-origin WebSocket endpoint used by the Ghostty WASM terminal. Crabyard authenticates the browser session, verifies the interactive session is still attachable, verifies terminal control, then proxies PTY bytes to the configured runner. Owners and maintainers have control by default; other viewers require an approved control request.
 
 Target resolution:
 
@@ -275,14 +290,21 @@ If `CRABYARD_INTERACTIVE_PROVISION_URL` is configured, the Worker posts the requ
 
 Actions:
 
-- `attach`: viewer, mark seen/attached and return the session.
-- `stop`: maintainer, mark stopped.
+- `attach`: viewer with control, mark seen/attached and return the session.
+- `share_link`: owner/maintainer, enable or rotate a public read-only share URL; response includes `shareUrl` once.
+- `disable_share`: owner/maintainer, disable the share URL and clear pending/granted control.
+- `request_control`: viewer, request writable terminal control.
+- `approve_control`: owner/maintainer, grant pending requester 30 minutes of writable terminal control.
+- `deny_control`: owner/maintainer, clear a pending control request.
+- `revoke_control`: owner/maintainer, revoke active delegated control.
+- `stop`: owner/maintainer, mark stopped.
 
 Response:
 
 ```json
 {
-  "session": {}
+  "session": {},
+  "shareUrl": "https://crabyard.openclaw.ai/app/sessions/IS-105?token=..."
 }
 ```
 

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -86,6 +86,7 @@ Attach opens a fullscreen Ghostty WASM grid. Current behavior:
 - Replays D1 event logs into the terminal surface while a live PTY is unavailable.
 - Falls back to a text terminal if Ghostty cannot initialize.
 - Supports focused fullscreen card view.
+- Supports focused share URLs with public read-only event scrollback and owner-approved writable control requests for signed-in viewers.
 
 The Take over action records `controlIntent = "takeover"` and operator only for active runs with takeover capability.
 
@@ -115,6 +116,13 @@ Runner PTY contract:
 - Browser-to-runner messages are terminal input bytes.
 - Runner-to-browser messages are terminal output bytes.
 - The bridge receives `x-crabyard-session`, `x-crabyard-repo`, and `x-crabyard-runtime` headers plus session query parameters.
+
+Session sharing:
+
+- `Share` creates a public read-only URL at `/app/sessions/:id?token=...`.
+- The share token is stored as a hash; generating a new link rotates the old one.
+- Public viewers can scroll the persisted session event buffer without signing in.
+- Writable PTY access still requires a signed-in allowlisted viewer and owner/maintainer approval.
 
 ## Run APIs
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6,7 +6,7 @@ permalink: /spec/
 
 # Crabyard.ai Spec
 
-Status: draft. Deployed subset: Cloudflare Worker, D1/Kysely persistence, GitHub OAuth, admin allowlists, card/run state, repo workflow evaluation, issue/PR previews, diffs, Cloudflare container sandbox provisioning, Ghostty WASM grid, and authenticated PTY WebSocket proxying for interactive sessions.
+Status: draft. Deployed subset: Cloudflare Worker, D1/Kysely persistence, GitHub OAuth, admin allowlists, card/run state, repo workflow evaluation, issue/PR previews, diffs, Cloudflare container sandbox provisioning, Ghostty WASM grid, read-only session share links, and authenticated PTY WebSocket proxying for interactive sessions.
 
 Crabyard.ai is a Cloudflare-native control plane for running Codex sessions in cloud workspaces. It gives OpenClaw maintainers a Linear-like board where each card represents an intent, a live run, and its durable history.
 
@@ -49,6 +49,7 @@ Implemented now:
 - D1 `run_attempts` with heartbeat, stall reconciliation, runtime selection reason, lease fields, operator intent, and runtime capabilities.
 - Runtime adapter descriptor for Container and Crabbox policy.
 - Ghostty WASM fullscreen session grid with D1 event replay and text fallback.
+- Focused Codex session URLs with public read-only share links and owner-approved control requests.
 - `CRABYARD.md` fetch/parse/evaluate admin surface.
 - Card diff metadata and compact patch preview.
 - Worker docs route at `/docs/` plus GitHub Pages docs.
@@ -240,6 +241,8 @@ Attach modes:
 
 - Watch: user sees live terminal/events, no input.
 - Take over: user can type into the Codex CLI PTY session or steer app-server turn.
+- Share: link recipients can read persisted session scrollback without signing in.
+- Request control: signed-in viewers can ask the session owner/maintainer for writable terminal access.
 
 When a user takes over:
 

--- a/migrations/0011_interactive_session_sharing.sql
+++ b/migrations/0011_interactive_session_sharing.sql
@@ -1,0 +1,11 @@
+ALTER TABLE interactive_sessions ADD COLUMN share_mode TEXT NOT NULL DEFAULT 'private';
+ALTER TABLE interactive_sessions ADD COLUMN share_token_hash TEXT;
+ALTER TABLE interactive_sessions ADD COLUMN share_token_preview TEXT;
+ALTER TABLE interactive_sessions ADD COLUMN control_requested_by TEXT;
+ALTER TABLE interactive_sessions ADD COLUMN control_requested_at INTEGER;
+ALTER TABLE interactive_sessions ADD COLUMN controller TEXT;
+ALTER TABLE interactive_sessions ADD COLUMN control_granted_at INTEGER;
+ALTER TABLE interactive_sessions ADD COLUMN control_expires_at INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_interactive_sessions_share_token
+  ON interactive_sessions(share_token_hash);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "deploy": "pnpm build && wrangler d1 migrations apply crabyard-ai --remote && wrangler deploy",
     "lint": "oxlint --ignore-pattern node_modules --ignore-pattern src/generated.ts .",
     "format": "oxfmt --check .",
-    "check": "pnpm build && pnpm lint && pnpm format"
+    "check": "node scripts/generate-assets.mjs && tsgo --noEmit && oxlint --ignore-pattern node_modules --ignore-pattern src/generated.ts . && oxfmt --check ."
   },
   "dependencies": {
     "@cloudflare/sandbox": "0.10.1",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+nodeLinker: hoisted
+shamefullyHoist: true
+strictPeerDependencies: false
+preferWorkspacePackages: true
+preferOffline: true
+pmOnFail: ignore
+verifyDepsBeforeRun: false

--- a/src/app.html
+++ b/src/app.html
@@ -1477,6 +1477,12 @@
       let refPreviewTimer = null;
       let refPreviewSeq = 0;
       let focusedSessionId = null;
+      const loginReturnKey = "crabyard-login-return";
+      restoreSessionReturnUrl();
+      const initialSessionLink = parseSessionLink();
+      let sharedSessionId = initialSessionLink.id;
+      let sharedToken = initialSessionLink.token;
+      let initialSessionOpened = false;
       let ghosttyModulePromise = null;
       let terminalEpoch = 0;
       const terminalHosts = new Map();
@@ -1739,9 +1745,12 @@
 
       function renderUser() {
         const user = state.user;
-        const label = user
-          ? (user.login || user.email || user.subject) + " / " + user.role
-          : "Signed out";
+        const label =
+          !signedIn && sharedToken
+            ? "Sign in for control"
+            : user
+              ? (user.login || user.email || user.subject) + " / " + user.role
+              : "Signed out";
         document.getElementById("user-button").textContent = label;
       }
 
@@ -1801,6 +1810,7 @@
         if (id === "sessions-drawer") {
           terminalEpoch += 1;
           focusedSessionId = null;
+          if (!sharedToken) setSessionUrl(null);
           const grid = document.getElementById("session-grid");
           if (grid) grid.dataset.sessionKey = "";
           disposeMissingTerminals(new Set());
@@ -1814,6 +1824,7 @@
         });
         activeRunId = null;
         focusedSessionId = null;
+        if (!sharedToken) setSessionUrl(null);
         terminalEpoch += 1;
         disposeMissingTerminals(new Set());
       }
@@ -1887,6 +1898,8 @@
 
       function openSessionGrid(id = focusedSessionId) {
         if (id) focusedSessionId = id;
+        const urlSessionId = findInteractiveSession(focusedSessionId) ? focusedSessionId : null;
+        if (urlSessionId || !sharedToken) setSessionUrl(urlSessionId);
         openDrawer("sessions-drawer");
         renderSessionGrid();
       }
@@ -1944,7 +1957,7 @@
 
       function sessionRenderKey(session) {
         return session.kind === "interactive"
-          ? `${session.id}:${session.status}:${session.leaseId || ""}:${session.attachUrl || ""}`
+          ? `${session.id}:${session.status}:${session.leaseId || ""}:${session.attachUrl || ""}:${session.shareMode || ""}:${session.canControl ? "control" : "view"}:${session.controlRequestedBy || ""}:${session.controller || ""}`
           : `${session.id}:${session.lane}:${session.run?.status || ""}`;
       }
 
@@ -1988,14 +2001,38 @@
       function renderInteractiveSessionControls(session) {
         if (isOptimisticInteractiveSession(session)) return "";
         const stopped = ["stopped", "expired", "failed"].includes(session.status);
+        const canManageSession = session.canManage || canMaintain();
+        const canControlSession = session.canControl || canManageSession;
+        const shareButton = canManageSession
+          ? `<button data-interactive-share="${session.id}">${session.shareMode === "link_read" ? "New link" : "Share"}</button>`
+          : "";
+        const unshareButton =
+          canManageSession && session.shareMode === "link_read"
+            ? `<button data-interactive-unshare="${session.id}">Unshare</button>`
+            : "";
+        const requestButton =
+          session.canRequestControl && !session.sharedReadOnly && !stopped
+            ? `<button data-interactive-request-control="${session.id}">${
+                session.controlRequestedBy ? "Control requested" : "Request control"
+              }</button>`
+            : "";
+        const reviewButtons =
+          canManageSession && session.controlRequestedBy
+            ? `<button class="primary" data-interactive-approve-control="${session.id}">Allow</button><button data-interactive-deny-control="${session.id}">Deny</button>`
+            : "";
+        const revokeButton =
+          canManageSession && session.controller
+            ? `<button data-interactive-revoke-control="${session.id}">Revoke</button>`
+            : "";
         const stopButton =
-          canMaintain() && !stopped
+          canManageSession && !stopped
             ? `<button class="danger" data-interactive-stop="${session.id}">Stop</button>`
             : "";
-        const attachButton = stopped
-          ? ""
-          : `<button data-interactive-attach="${session.id}">Attach</button>`;
-        return `${attachButton}${stopButton}`;
+        const attachButton =
+          stopped || !canControlSession
+            ? ""
+            : `<button data-interactive-attach="${session.id}">Attach</button>`;
+        return `${shareButton}${unshareButton}${requestButton}${reviewButtons}${revokeButton}${attachButton}${stopButton}`;
       }
 
       function isOptimisticInteractiveSession(session) {
@@ -2011,6 +2048,9 @@
             <span class="chip">${escapeHtml(session.runtime)}</span>
             <span class="chip merge">${escapeHtml(session.status)}</span>
             <span class="chip">${escapeHtml(session.branch)}</span>
+            ${session.shareMode === "link_read" || session.sharedReadOnly ? `<span class="chip">shared</span>` : ""}
+            ${session.controller ? `<span class="chip">control ${escapeHtml(session.controller)}</span>` : ""}
+            ${session.controlRequestedBy ? `<span class="chip hot">request ${escapeHtml(session.controlRequestedBy)}</span>` : ""}
             ${live ? `<span class="chip hot">seen ${elapsed(session.lastSeenAt || session.updatedAt)}</span>` : ""}
           `;
         }
@@ -2162,6 +2202,8 @@
       function shouldConnectLiveTerminal(session) {
         return (
           session.kind === "interactive" &&
+          session.canControl === true &&
+          session.sharedReadOnly !== true &&
           ["ready", "attached", "detached"].includes(session.status)
         );
       }
@@ -2275,6 +2317,16 @@
           if (session.vncUrl) header.push(`vnc ${session.vncUrl}`);
           if (session.status === "pending_adapter") {
             header.push("runtime adapter not configured yet");
+          }
+          if (session.sharedReadOnly) header.push("read-only shared view");
+          if (session.shareMode === "link_read" && !session.sharedReadOnly) {
+            header.push(`share read-only link ${session.shareTokenPreview || "enabled"}`);
+          }
+          if (session.controlRequestedBy) {
+            header.push(`control requested by ${session.controlRequestedBy}`);
+          }
+          if (session.controller) {
+            header.push(`controller ${session.controller}`);
           }
           if (session.prompt) header.push("", session.prompt);
           const logs =
@@ -2479,10 +2531,12 @@
         if (target.dataset.action === "attach") attachCard(target.dataset.id);
         if (target.dataset.sessionFocus) {
           focusedSessionId = target.dataset.sessionFocus;
+          setSessionUrl(findInteractiveSession(focusedSessionId) ? focusedSessionId : null);
           renderSessionGrid();
         }
         if (target.dataset.sessionUnfocus !== undefined || target.id === "show-all-sessions") {
           focusedSessionId = null;
+          if (!sharedToken) setSessionUrl(null);
           renderSessionGrid();
         }
         if (target.dataset.sessionDetails) openRunDetails(target.dataset.sessionDetails);
@@ -2491,6 +2545,18 @@
         if (target.dataset.interactiveAttach)
           attachInteractiveSession(target.dataset.interactiveAttach);
         if (target.dataset.interactiveStop) stopInteractiveSession(target.dataset.interactiveStop);
+        if (target.dataset.interactiveShare)
+          shareInteractiveSession(target.dataset.interactiveShare);
+        if (target.dataset.interactiveUnshare)
+          interactiveSessionAction(target.dataset.interactiveUnshare, "disable_share");
+        if (target.dataset.interactiveRequestControl)
+          interactiveSessionAction(target.dataset.interactiveRequestControl, "request_control");
+        if (target.dataset.interactiveApproveControl)
+          interactiveSessionAction(target.dataset.interactiveApproveControl, "approve_control");
+        if (target.dataset.interactiveDenyControl)
+          interactiveSessionAction(target.dataset.interactiveDenyControl, "deny_control");
+        if (target.dataset.interactiveRevokeControl)
+          interactiveSessionAction(target.dataset.interactiveRevokeControl, "revoke_control");
         if (target.dataset.createRef) createRefCard(Number(target.dataset.createRef));
         if (target.dataset.remove === "allow") removeAllow(target.dataset.value);
         if (target.dataset.remove === "repo") removeRepo(target.dataset.value);
@@ -2521,7 +2587,10 @@
         if (target.id === "watch") appendRun("watch");
         if (target.id === "stall") appendRun("stall");
         if (target.id === "theme-toggle") setTheme(theme === "dark" ? "light" : "dark");
-        if (target.id === "user-button") logout();
+        if (target.id === "user-button") {
+          if (signedIn) logout();
+          else void beginLogin();
+        }
       });
 
       document.addEventListener("keydown", (event) => {
@@ -2630,7 +2699,7 @@
       });
 
       document.getElementById("github-login").addEventListener("click", () => {
-        location.href = "/login/github";
+        void beginLogin();
       });
 
       async function loadState() {
@@ -2654,9 +2723,18 @@
           document.body.classList.remove("locked");
           document.getElementById("login-screen").hidden = true;
           render();
+          await openInitialSessionLink();
           refreshActiveTerminal();
         } catch (error) {
           if (error.status === 401 || error.status === 403) {
+            if (sharedSessionId && sharedToken) {
+              try {
+                await loadSharedSession();
+              } catch (sharedError) {
+                await showSharedLinkError(sharedError);
+              }
+              return;
+            }
             await loadAuthMethods();
             signedIn = false;
             document.body.classList.add("locked");
@@ -2672,6 +2750,68 @@
             }, 5000);
           }
         }
+      }
+
+      async function loadSharedSession() {
+        const result = await api(
+          `/api/shared-sessions/${encodeURIComponent(sharedSessionId)}?token=${encodeURIComponent(sharedToken)}`,
+          { authOptional: true },
+        );
+        await loadAuthMethods();
+        state = {
+          user: { subject: "shared", login: "shared link", role: "viewer" },
+          auth: authMethods,
+          org: "OpenClaw",
+          cap: 20,
+          retention: "30",
+          merge: "guarded",
+          allow: [],
+          repos: [result.session.repo],
+          workflows: [],
+          cards: [],
+          interactiveSessions: [result.session],
+        };
+        signedIn = false;
+        document.body.classList.remove("locked");
+        document.getElementById("login-screen").hidden = true;
+        focusedSessionId = result.session.id;
+        render();
+        openSessionGrid(result.session.id);
+      }
+
+      async function loadLinkedInteractiveSession(id) {
+        const result = await api(`/api/interactive-sessions/${encodeURIComponent(id)}`);
+        replaceInteractiveSession(result.session);
+        initialSessionOpened = true;
+        focusedSessionId = result.session.id;
+        render();
+        openSessionGrid(result.session.id);
+      }
+
+      async function showSharedLinkError(error) {
+        await loadAuthMethods();
+        signedIn = false;
+        document.body.classList.add("locked");
+        document.getElementById("login-screen").hidden = false;
+        showLogin(
+          error?.status === 404
+            ? "Shared session link is invalid or expired."
+            : error?.message || "Shared session could not be loaded.",
+        );
+      }
+
+      async function beginLogin() {
+        try {
+          if (sharedSessionId) sessionStorage.setItem(loginReturnKey, location.href);
+        } catch {}
+        if (!authMethods.github && !authMethods.token) await loadAuthMethods();
+        if (authMethods.github) {
+          location.href = "/login/github";
+          return;
+        }
+        document.body.classList.add("locked");
+        document.getElementById("login-screen").hidden = false;
+        showLogin("Sign in to request terminal control.");
       }
 
       async function loadAuthMethods() {
@@ -2697,6 +2837,31 @@
         replaceCard(result.card);
         render();
         if (activeRunId === id) refreshActiveTerminal();
+      }
+
+      async function interactiveSessionAction(id, action) {
+        const result = await api(`/api/interactive-sessions/${encodeURIComponent(id)}/actions`, {
+          method: "POST",
+          body: { action },
+        });
+        replaceInteractiveSession(result.session);
+        render();
+        openSessionGrid(id);
+        return result;
+      }
+
+      async function shareInteractiveSession(id) {
+        const result = await interactiveSessionAction(id, "share_link");
+        if (result.shareUrl) {
+          let copied = false;
+          try {
+            if (navigator.clipboard) {
+              await navigator.clipboard.writeText(result.shareUrl);
+              copied = true;
+            }
+          } catch {}
+          if (!copied) window.prompt("Copy share link", result.shareUrl);
+        }
       }
 
       function scheduleRefPreview() {
@@ -2860,9 +3025,82 @@
           updatedAt: now,
           lastSeenAt: now,
           stoppedAt: null,
+          shareMode: "private",
+          shareTokenPreview: null,
+          controlRequestedBy: null,
+          controlRequestedAt: null,
+          controller: null,
+          controlGrantedAt: null,
+          controlExpiresAt: null,
+          canControl: true,
+          canManage: true,
+          canRequestControl: false,
           logs: ["Provisioning Cloudflare Sandbox...", "Starting Codex CLI..."],
           title: `${repo} · ${branch}`,
         };
+      }
+
+      function parseSessionLink() {
+        const match = location.pathname.match(/^\/app\/sessions\/([^/]+)$/);
+        return {
+          id: match ? decodeURIComponent(match[1]) : null,
+          token: new URLSearchParams(location.search).get("token"),
+        };
+      }
+
+      function restoreSessionReturnUrl() {
+        try {
+          const saved = sessionStorage.getItem(loginReturnKey);
+          if (!saved || !history.replaceState) return;
+          const url = new URL(saved, location.origin);
+          if (url.origin !== location.origin || !url.pathname.startsWith("/app/sessions/")) return;
+          if (location.pathname !== "/app" && location.pathname !== "/app/") return;
+          sessionStorage.removeItem(loginReturnKey);
+          history.replaceState(null, "", `${url.pathname}${url.search}`);
+        } catch {}
+      }
+
+      function setSessionUrl(id) {
+        if (!history.replaceState) return;
+        if (id) {
+          const url = new URL(location.href);
+          url.pathname = `/app/sessions/${encodeURIComponent(id)}`;
+          url.search = "";
+          if (sharedToken && id === sharedSessionId) url.searchParams.set("token", sharedToken);
+          history.replaceState(null, "", url);
+          return;
+        }
+        const url = new URL(location.href);
+        url.pathname = "/app";
+        url.search = "";
+        history.replaceState(null, "", url);
+      }
+
+      async function openInitialSessionLink() {
+        if (!sharedSessionId) return;
+        if (!findInteractiveSession(sharedSessionId)) {
+          if (signedIn && (!initialSessionOpened || focusedSessionId === sharedSessionId)) {
+            try {
+              await loadLinkedInteractiveSession(sharedSessionId);
+            } catch (error) {
+              if (error.status !== 403 && error.status !== 404) throw error;
+              sharedSessionId = null;
+              sharedToken = null;
+              focusedSessionId = null;
+              initialSessionOpened = true;
+              setSessionUrl(null);
+            }
+          } else if (!signedIn && sharedToken && !document.body.classList.contains("locked")) {
+            await loadSharedSession();
+          } else if (!initialSessionOpened) {
+            setSessionUrl(null);
+          }
+          return;
+        }
+        if (initialSessionOpened && focusedSessionId !== sharedSessionId) return;
+        initialSessionOpened = true;
+        focusedSessionId = sharedSessionId;
+        openSessionGrid(sharedSessionId);
       }
 
       function showLogin(message) {
@@ -2873,6 +3111,15 @@
 
       setInterval(() => {
         if (signedIn) loadState();
+        else if (sharedSessionId && sharedToken && !document.body.classList.contains("locked")) {
+          loadSharedSession().catch((error) => {
+            if (error.status === 403 || error.status === 404) {
+              void showSharedLinkError(error);
+              return;
+            }
+            console.warn("Shared session refresh failed", error);
+          });
+        }
       }, 15000);
 
       loadState();

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,6 +227,17 @@ type InteractiveSession = {
   updatedAt: number;
   lastSeenAt: number;
   stoppedAt: number | null;
+  shareMode: "private" | "link_read";
+  shareTokenPreview: string | null;
+  controlRequestedBy: string | null;
+  controlRequestedAt: number | null;
+  controller: string | null;
+  controlGrantedAt: number | null;
+  controlExpiresAt: number | null;
+  canControl?: boolean;
+  canManage?: boolean;
+  canRequestControl?: boolean;
+  sharedReadOnly?: boolean;
   logs: string[];
 };
 
@@ -382,6 +393,14 @@ type InteractiveSessionTable = {
   updated_at: number;
   last_seen_at: number;
   stopped_at: number | null;
+  share_mode: "private" | "link_read";
+  share_token_hash: string | null;
+  share_token_preview: string | null;
+  control_requested_by: string | null;
+  control_requested_at: number | null;
+  controller: string | null;
+  control_granted_at: number | null;
+  control_expires_at: number | null;
 };
 
 type RepoWorkflowTable = {
@@ -624,7 +643,12 @@ export default {
         return await api(request, env);
       }
 
-      if (url.pathname === "/" || url.pathname === "/app" || url.pathname === "/app/") {
+      if (
+        url.pathname === "/" ||
+        url.pathname === "/app" ||
+        url.pathname === "/app/" ||
+        url.pathname.startsWith("/app/sessions/")
+      ) {
         return text(APP_HTML, "text/html; charset=utf-8", { vary: "Accept" });
       }
 
@@ -660,6 +684,17 @@ async function api(request: Request, env: RuntimeEnv): Promise<Response> {
     return json(await provisionInteractiveEndpoint(request, env));
   }
 
+  const sharedSessionMatch = url.pathname.match(/^\/api\/shared-sessions\/([^/]+)$/);
+  if (request.method === "GET" && sharedSessionMatch) {
+    return json(
+      await readSharedInteractiveSession(
+        env,
+        decodeURIComponent(sharedSessionMatch[1] ?? ""),
+        url.searchParams.get("token") ?? "",
+      ),
+    );
+  }
+
   const user = await requireUser(request, env);
 
   if (request.method === "GET" && url.pathname === "/api/session") {
@@ -680,15 +715,27 @@ async function api(request: Request, env: RuntimeEnv): Promise<Response> {
     return json(await createInteractiveSession(request, env, user), { status: 201 });
   }
 
+  const interactiveSessionReadMatch = url.pathname.match(/^\/api\/interactive-sessions\/([^/]+)$/);
+  if (request.method === "GET" && interactiveSessionReadMatch) {
+    requireRole(user, "viewer");
+    const session = await readInteractiveSession(
+      env,
+      decodeURIComponent(interactiveSessionReadMatch[1] ?? ""),
+    );
+    if (!session) throw notFound("interactive session not found");
+    return json({ session: decorateInteractiveSession(session, user, env) });
+  }
+
   const interactiveSessionMatch = url.pathname.match(
     /^\/api\/interactive-sessions\/([^/]+)\/actions$/,
   );
   if (request.method === "POST" && interactiveSessionMatch) {
     const body = await readJson<{ action?: string }>(request);
     const action = body.action ?? "";
-    requireRole(user, action === "attach" ? "viewer" : "maintainer");
+    requireRole(user, "viewer");
     return json(
       await mutateInteractiveSession(
+        request,
         env,
         user,
         decodeURIComponent(interactiveSessionMatch[1] ?? ""),
@@ -936,7 +983,7 @@ async function readState(env: RuntimeEnv, user: User): Promise<Record<string, un
       : Promise.resolve([]),
     db.selectFrom("repos").select("repo").where("enabled", "=", 1).orderBy("repo").execute(),
     readCards(env),
-    readInteractiveSessions(env),
+    readInteractiveSessions(env, user),
     user.role === "owner" ? readWorkflowSummaries(env) : Promise.resolve([]),
   ]);
   const repoNames = sortRepos(repos.map((row) => row.repo));
@@ -1002,6 +1049,14 @@ async function createInteractiveSession(
           updated_at: now,
           last_seen_at: now,
           stopped_at: null,
+          share_mode: "private",
+          share_token_hash: null,
+          share_token_preview: null,
+          control_requested_by: null,
+          control_requested_at: null,
+          controller: null,
+          control_granted_at: null,
+          control_expires_at: null,
         })
         .execute();
       await appendInteractiveSessionEvent(env, id, user, "interactive workspace requested", now);
@@ -1052,7 +1107,13 @@ async function createInteractiveSession(
         `interactive session created ${id} repo=${repo} runtime=${runtime}`,
         now,
       );
-      return { session: (await readInteractiveSession(env, id)) as InteractiveSession };
+      return {
+        session: decorateInteractiveSession(
+          (await readInteractiveSession(env, id)) as InteractiveSession,
+          user,
+          env,
+        ),
+      };
     } catch (error) {
       if (!isConstraintError(error) || attempt === 2) throw error;
     }
@@ -1061,15 +1122,21 @@ async function createInteractiveSession(
 }
 
 async function mutateInteractiveSession(
+  request: Request,
   env: RuntimeEnv,
   user: User,
   id: string,
   action: string,
-): Promise<{ session: InteractiveSession }> {
+): Promise<{ session: InteractiveSession; shareUrl?: string }> {
   const session = await readInteractiveSession(env, id);
   if (!session) throw notFound("interactive session not found");
   const now = Date.now();
+  const userActor = actor(user);
+  const canManage = canManageInteractiveSession(user, session);
   if (action === "attach") {
+    if (!canControlInteractiveSession(user, session, now, canGrantDelegatedControl(env, session))) {
+      throw forbidden("terminal control has not been granted");
+    }
     if (["expired", "failed", "stopped"].includes(session.status)) {
       throw badRequest(`session is ${session.status}`);
     }
@@ -1093,15 +1160,215 @@ async function mutateInteractiveSession(
       .where("status", "!=", "stopped")
       .execute();
     await appendInteractiveSessionEvent(env, id, user, message, now);
-    return { session: (await readInteractiveSession(env, id)) as InteractiveSession };
+    return {
+      session: decorateInteractiveSession(
+        (await readInteractiveSession(env, id)) as InteractiveSession,
+        user,
+        env,
+      ),
+    };
+  }
+
+  if (action === "share_link") {
+    if (!canManage) throw forbidden("only the session owner or maintainer can share");
+    const token = shareToken();
+    const tokenHash = await sha256(token);
+    const preview = token.slice(0, 8);
+    await database(env)
+      .updateTable("interactive_sessions")
+      .set({
+        share_mode: "link_read",
+        share_token_hash: tokenHash,
+        share_token_preview: preview,
+        updated_at: now,
+        last_event: "read-only share link enabled",
+      })
+      .where("id", "=", id)
+      .execute();
+    await appendInteractiveSessionEvent(env, id, user, "read-only share link enabled", now);
+    await audit(env, user, `interactive session share enabled ${id}`, now);
+    return {
+      session: decorateInteractiveSession(
+        (await readInteractiveSession(env, id)) as InteractiveSession,
+        user,
+        env,
+      ),
+      shareUrl: shareUrl(request, id, token),
+    };
+  }
+
+  if (action === "disable_share") {
+    if (!canManage) throw forbidden("only the session owner or maintainer can disable sharing");
+    await database(env)
+      .updateTable("interactive_sessions")
+      .set({
+        share_mode: "private",
+        share_token_hash: null,
+        share_token_preview: null,
+        control_requested_by: null,
+        control_requested_at: null,
+        controller: null,
+        control_granted_at: null,
+        control_expires_at: null,
+        updated_at: now,
+        last_event: "session sharing disabled",
+      })
+      .where("id", "=", id)
+      .execute();
+    await appendInteractiveSessionEvent(env, id, user, "session sharing disabled", now);
+    await audit(env, user, `interactive session share disabled ${id}`, now);
+    return {
+      session: decorateInteractiveSession(
+        (await readInteractiveSession(env, id)) as InteractiveSession,
+        user,
+        env,
+      ),
+    };
+  }
+
+  if (action === "request_control") {
+    if (!canGrantDelegatedControl(env, session)) {
+      throw badRequest("delegated terminal control requires a revocable PTY bridge");
+    }
+    if (canControlInteractiveSession(user, session, now, canGrantDelegatedControl(env, session))) {
+      return { session: decorateInteractiveSession(session, user, env) };
+    }
+    if (["expired", "failed", "stopped"].includes(session.status)) {
+      throw badRequest(`session is ${session.status}`);
+    }
+    await database(env)
+      .updateTable("interactive_sessions")
+      .set({
+        control_requested_by: userActor,
+        control_requested_at: now,
+        updated_at: now,
+        last_event: `${userActor} requested terminal control`,
+      })
+      .where("id", "=", id)
+      .execute();
+    await appendInteractiveSessionEvent(
+      env,
+      id,
+      user,
+      `${userActor} requested terminal control`,
+      now,
+    );
+    return {
+      session: decorateInteractiveSession(
+        (await readInteractiveSession(env, id)) as InteractiveSession,
+        user,
+        env,
+      ),
+    };
+  }
+
+  if (action === "approve_control") {
+    if (!canManage) throw forbidden("only the session owner or maintainer can approve control");
+    if (!session.controlRequestedBy) throw badRequest("no pending control request");
+    if (!canGrantDelegatedControl(env, session)) {
+      throw badRequest("delegated terminal control requires a revocable PTY bridge");
+    }
+    const expires = now + 30 * 60 * 1000;
+    await database(env)
+      .updateTable("interactive_sessions")
+      .set({
+        controller: session.controlRequestedBy,
+        control_granted_at: now,
+        control_expires_at: expires,
+        control_requested_by: null,
+        control_requested_at: null,
+        updated_at: now,
+        last_event: `control granted to ${session.controlRequestedBy}`,
+      })
+      .where("id", "=", id)
+      .execute();
+    await appendInteractiveSessionEvent(
+      env,
+      id,
+      user,
+      `control granted to ${session.controlRequestedBy}`,
+      now,
+    );
+    await audit(
+      env,
+      user,
+      `interactive session control granted ${id} to ${session.controlRequestedBy}`,
+      now,
+    );
+    return {
+      session: decorateInteractiveSession(
+        (await readInteractiveSession(env, id)) as InteractiveSession,
+        user,
+        env,
+      ),
+    };
+  }
+
+  if (action === "deny_control") {
+    if (!canManage) throw forbidden("only the session owner or maintainer can deny control");
+    const requester = session.controlRequestedBy;
+    await database(env)
+      .updateTable("interactive_sessions")
+      .set({
+        control_requested_by: null,
+        control_requested_at: null,
+        updated_at: now,
+        last_event: requester
+          ? `control request denied for ${requester}`
+          : "control request denied",
+      })
+      .where("id", "=", id)
+      .execute();
+    await appendInteractiveSessionEvent(
+      env,
+      id,
+      user,
+      requester ? `control request denied for ${requester}` : "control request denied",
+      now,
+    );
+    return {
+      session: decorateInteractiveSession(
+        (await readInteractiveSession(env, id)) as InteractiveSession,
+        user,
+        env,
+      ),
+    };
+  }
+
+  if (action === "revoke_control") {
+    if (!canManage) throw forbidden("only the session owner or maintainer can revoke control");
+    await database(env)
+      .updateTable("interactive_sessions")
+      .set({
+        controller: null,
+        control_granted_at: null,
+        control_expires_at: null,
+        updated_at: now,
+        last_event: "terminal control revoked",
+      })
+      .where("id", "=", id)
+      .execute();
+    await appendInteractiveSessionEvent(env, id, user, "terminal control revoked", now);
+    await audit(env, user, `interactive session control revoked ${id}`, now);
+    return {
+      session: decorateInteractiveSession(
+        (await readInteractiveSession(env, id)) as InteractiveSession,
+        user,
+        env,
+      ),
+    };
   }
 
   if (action === "stop") {
+    if (!canManage) throw forbidden("only the session owner or maintainer can stop");
     await database(env)
       .updateTable("interactive_sessions")
       .set({
         status: "stopped",
         stopped_at: now,
+        controller: null,
+        control_requested_by: null,
+        control_requested_at: null,
         updated_at: now,
         last_event: "interactive workspace stopped",
       })
@@ -1110,7 +1377,13 @@ async function mutateInteractiveSession(
       .execute();
     await appendInteractiveSessionEvent(env, id, user, "interactive workspace stopped", now);
     await audit(env, user, `interactive session stopped ${id}`, now);
-    return { session: (await readInteractiveSession(env, id)) as InteractiveSession };
+    return {
+      session: decorateInteractiveSession(
+        (await readInteractiveSession(env, id)) as InteractiveSession,
+        user,
+        env,
+      ),
+    };
   }
 
   throw badRequest("unknown action");
@@ -1131,9 +1404,21 @@ async function interactiveSessionPty(
   if (["expired", "failed", "stopped"].includes(session.status)) {
     throw badRequest(`session is ${session.status}`);
   }
+  if (
+    !canControlInteractiveSession(user, session, Date.now(), canGrantDelegatedControl(env, session))
+  ) {
+    throw forbidden("terminal control has not been granted");
+  }
+  const canManage = canManageInteractiveSession(user, session);
 
   if (session.leaseId?.startsWith(sandboxLeasePrefix) && env.SANDBOX) {
-    return interactiveSandboxTerminal(request, env, user, session);
+    return interactiveSandboxTerminal(
+      request,
+      env,
+      user,
+      session,
+      canManage ? undefined : () => canControlInteractiveSessionById(env, user, id),
+    );
   }
 
   const target = interactiveTerminalTarget(env, session);
@@ -1161,7 +1446,11 @@ async function interactiveSessionPty(
 
   server.accept();
   upstream.accept();
-  bridgeWebSockets(server, upstream);
+  bridgeWebSockets(
+    server,
+    upstream,
+    canManage ? undefined : () => canControlInteractiveSessionById(env, user, id),
+  );
 
   const now = Date.now();
   await database(env)
@@ -1186,6 +1475,7 @@ async function interactiveSandboxTerminal(
   env: RuntimeEnv,
   user: User,
   session: InteractiveSession,
+  canSendLeft?: () => Promise<boolean>,
 ): Promise<Response> {
   if (!env.SANDBOX) throw serviceUnavailable("Sandbox binding is not configured");
   const sandboxId =
@@ -1212,11 +1502,21 @@ async function interactiveSandboxTerminal(
     "Cloudflare Sandbox terminal connected",
     now,
   );
-  return terminalSession.terminal(request, {
+  const upstreamResponse = await terminalSession.terminal(request, {
     cols: terminalSize(request, "cols", 120),
     rows: terminalSize(request, "rows", 34),
     shell: sandboxStartupScriptPath(session),
   });
+  const upstream = upstreamResponse.webSocket;
+  if (!upstream || upstreamResponse.status !== 101) return upstreamResponse;
+
+  const pair = new WebSocketPair();
+  const client = pair[0];
+  const server = pair[1];
+  server.accept();
+  upstream.accept();
+  bridgeWebSockets(server, upstream, canSendLeft);
+  return new Response(null, { status: 101, webSocket: client });
 }
 
 function interactiveTerminalTarget(
@@ -1295,30 +1595,97 @@ function interactiveTerminalHeaders(
   return headers;
 }
 
-function bridgeWebSockets(left: WebSocket, right: WebSocket): void {
+function bridgeWebSockets(
+  left: WebSocket,
+  right: WebSocket,
+  canSendLeft?: () => Promise<boolean>,
+): void {
+  let leftInputQueue = Promise.resolve();
+  let rightOutputQueue = Promise.resolve();
+  let controlCheckTimer: ReturnType<typeof setInterval> | undefined;
+  let controlCheckInFlight: Promise<void> | undefined;
+  let leftCanSend = true;
+  const stopControlCheck = () => {
+    if (controlCheckTimer !== undefined) clearInterval(controlCheckTimer);
+    controlCheckTimer = undefined;
+  };
+  const verifyControl = async () => {
+    const canSend = canSendLeft ? await canSendLeft().catch(() => false) : true;
+    leftCanSend = canSend;
+    if (!canSend) {
+      stopControlCheck();
+      closePair(left, right, 1008, "terminal control revoked");
+      return false;
+    }
+    return true;
+  };
+  const scheduleControlCheck = () => {
+    if (controlCheckInFlight) return;
+    controlCheckInFlight = verifyControl()
+      .then(() => undefined)
+      .finally(() => {
+        controlCheckInFlight = undefined;
+      });
+  };
+  if (canSendLeft) {
+    controlCheckTimer = setInterval(() => {
+      scheduleControlCheck();
+    }, 5000);
+    scheduleControlCheck();
+  }
   left.addEventListener("message", (event) => {
-    if (right.readyState === WebSocket.OPEN) right.send(event.data);
+    const data = event.data;
+    leftInputQueue = leftInputQueue
+      .catch(() => undefined)
+      .then(async () => {
+        if (left.readyState !== WebSocket.OPEN || right.readyState !== WebSocket.OPEN) return;
+        if (!leftCanSend || !(await verifyControl())) {
+          closePair(left, right, 1008, "terminal control revoked");
+          return;
+        }
+        right.send(data);
+      });
   });
   right.addEventListener("message", (event) => {
-    if (left.readyState === WebSocket.OPEN) left.send(event.data);
+    const data = event.data;
+    rightOutputQueue = rightOutputQueue
+      .catch(() => undefined)
+      .then(async () => {
+        if (left.readyState !== WebSocket.OPEN || right.readyState !== WebSocket.OPEN) return;
+        left.send(data);
+      });
   });
-  const close = (event: CloseEvent, to: WebSocket) => {
-    if (to.readyState === WebSocket.OPEN || to.readyState === WebSocket.CONNECTING) {
-      to.close(event.code || 1000, event.reason || "peer closed");
-    }
-  };
-  left.addEventListener("close", (event) => close(event, right));
-  right.addEventListener("close", (event) => close(event, left));
+  left.addEventListener("close", (event) => {
+    stopControlCheck();
+    closePeer(event, right);
+  });
+  right.addEventListener("close", (event) => {
+    stopControlCheck();
+    closePeer(event, left);
+  });
   left.addEventListener("error", () => {
-    if (right.readyState === WebSocket.OPEN || right.readyState === WebSocket.CONNECTING) {
-      right.close(1011, "peer error");
-    }
+    stopControlCheck();
+    closePair(left, right, 1011, "peer error");
   });
   right.addEventListener("error", () => {
-    if (left.readyState === WebSocket.OPEN || left.readyState === WebSocket.CONNECTING) {
-      left.close(1011, "peer error");
-    }
+    stopControlCheck();
+    closePair(right, left, 1011, "peer error");
   });
+}
+
+function closePeer(event: CloseEvent, to: WebSocket): void {
+  if (to.readyState === WebSocket.OPEN || to.readyState === WebSocket.CONNECTING) {
+    to.close(event.code || 1000, event.reason || "peer closed");
+  }
+}
+
+function closePair(left: WebSocket, right: WebSocket, code: number, reason: string): void {
+  if (left.readyState === WebSocket.OPEN || left.readyState === WebSocket.CONNECTING) {
+    left.close(code, reason);
+  }
+  if (right.readyState === WebSocket.OPEN || right.readyState === WebSocket.CONNECTING) {
+    right.close(code, reason);
+  }
 }
 
 async function provisionInteractiveSession(
@@ -2503,7 +2870,10 @@ async function readRunsForCard(env: RuntimeEnv, cardId: string): Promise<RunAtte
   return rows.map(runAttempt);
 }
 
-async function readInteractiveSessions(env: RuntimeEnv): Promise<InteractiveSession[]> {
+async function readInteractiveSessions(
+  env: RuntimeEnv,
+  user?: User,
+): Promise<InteractiveSession[]> {
   const rows = await database(env)
     .selectFrom("interactive_sessions")
     .selectAll()
@@ -2515,7 +2885,9 @@ async function readInteractiveSessions(env: RuntimeEnv): Promise<InteractiveSess
     env,
     rows.map((row) => row.id),
   );
-  return rows.map((row) => interactiveSession(row, logs.get(row.id) ?? []));
+  return rows.map((row) =>
+    decorateInteractiveSession(interactiveSession(row, logs.get(row.id) ?? []), user, env),
+  );
 }
 
 async function readInteractiveSession(
@@ -2530,6 +2902,39 @@ async function readInteractiveSession(
   if (!row) return null;
   const logs = await readInteractiveSessionLogs(env, [id]);
   return interactiveSession(row, logs.get(id) ?? []);
+}
+
+async function readSharedInteractiveSession(
+  env: RuntimeEnv,
+  id: string,
+  token: string,
+): Promise<{ session: InteractiveSession }> {
+  const row = await database(env)
+    .selectFrom("interactive_sessions")
+    .selectAll()
+    .where("id", "=", id)
+    .where("share_mode", "=", "link_read")
+    .executeTakeFirst();
+  if (!row || !row.share_token_hash || !token) throw notFound("shared session not found");
+  if ((await sha256(token)) !== row.share_token_hash) throw notFound("shared session not found");
+  const logs = await readInteractiveSessionLogs(env, [id]);
+  const session = interactiveSession(row, logs.get(id) ?? []);
+  const activeController = activeDelegatedController(session, Date.now());
+  return {
+    session: {
+      ...session,
+      leaseId: null,
+      attachUrl: null,
+      vncUrl: null,
+      controller: activeController,
+      controlGrantedAt: activeController ? session.controlGrantedAt : null,
+      controlExpiresAt: activeController ? session.controlExpiresAt : null,
+      canControl: false,
+      canManage: false,
+      canRequestControl: false,
+      sharedReadOnly: true,
+    },
+  };
 }
 
 async function readInteractiveSessionLogs(
@@ -3030,8 +3435,104 @@ function interactiveSession(row: InteractiveSessionTable, logs: string[]): Inter
     updatedAt: row.updated_at,
     lastSeenAt: row.last_seen_at,
     stoppedAt: row.stopped_at,
+    shareMode: row.share_mode,
+    shareTokenPreview: row.share_token_preview,
+    controlRequestedBy: row.control_requested_by,
+    controlRequestedAt: row.control_requested_at,
+    controller: row.controller,
+    controlGrantedAt: row.control_granted_at,
+    controlExpiresAt: row.control_expires_at,
     logs,
   };
+}
+
+function decorateInteractiveSession(
+  session: InteractiveSession,
+  user?: User,
+  env?: RuntimeEnv,
+): InteractiveSession {
+  if (!user) return session;
+  const now = Date.now();
+  const delegatedControl = env ? canGrantDelegatedControl(env, session) : true;
+  const canManage = canManageInteractiveSession(user, session);
+  const canControl = canControlInteractiveSession(user, session, now, delegatedControl);
+  const activeController = activeDelegatedController(session, now);
+  return {
+    ...session,
+    leaseId: canControl ? session.leaseId : null,
+    attachUrl: canControl ? session.attachUrl : null,
+    vncUrl: canControl ? session.vncUrl : null,
+    controller: activeController,
+    controlGrantedAt: activeController ? session.controlGrantedAt : null,
+    controlExpiresAt: activeController ? session.controlExpiresAt : null,
+    canManage,
+    canControl,
+    canRequestControl: delegatedControl && !canControl,
+  };
+}
+
+function canManageInteractiveSession(user: User, session: InteractiveSession): boolean {
+  const userActor = actor(user);
+  return session.owner === userActor || user.role === "maintainer" || user.role === "owner";
+}
+
+function canControlInteractiveSession(
+  user: User,
+  session: InteractiveSession,
+  now: number,
+  delegatedControl = true,
+): boolean {
+  if (canManageInteractiveSession(user, session)) return true;
+  if (!delegatedControl) return false;
+  const userActor = actor(user);
+  return (
+    session.controller === userActor &&
+    typeof session.controlExpiresAt === "number" &&
+    session.controlExpiresAt > now
+  );
+}
+
+function activeDelegatedController(session: InteractiveSession, now: number): string | null {
+  if (!session.controller) return null;
+  if (typeof session.controlExpiresAt !== "number" || session.controlExpiresAt <= now) return null;
+  return session.controller;
+}
+
+async function canControlInteractiveSessionById(
+  env: RuntimeEnv,
+  user: User,
+  id: string,
+): Promise<boolean> {
+  const row = await database(env)
+    .selectFrom("interactive_sessions")
+    .selectAll()
+    .where("id", "=", id)
+    .executeTakeFirst();
+  if (!row) return false;
+  const session = interactiveSession(row, []);
+  if (["expired", "failed", "stopped"].includes(session.status)) return false;
+  return canControlInteractiveSession(
+    user,
+    session,
+    Date.now(),
+    canGrantDelegatedControl(env, session),
+  );
+}
+
+function canGrantDelegatedControl(env: RuntimeEnv, session: InteractiveSession): boolean {
+  if (!env.SANDBOX && session.leaseId?.startsWith(sandboxLeasePrefix)) return false;
+  return true;
+}
+
+function shareToken(): string {
+  const first = crypto.randomUUID().replaceAll("-", "");
+  const second = crypto.randomUUID().replaceAll("-", "");
+  return `${first}${second}`;
+}
+
+function shareUrl(request: Request, id: string, token: string): string {
+  const url = new URL(request.url);
+  return `${url.origin}/app/sessions/${encodeURIComponent(id)}?token=${encodeURIComponent(token)}`;
 }
 
 function repoWorkflow(row: RepoWorkflowTable): RepoWorkflow {


### PR DESCRIPTION
## Summary
- add public read-only links for interactive Codex sessions with signed share tokens
- add owner/maintainer controls for sharing, control requests, approval, denial, revocation, and stopping
- bridge sandbox PTY traffic through Crabyard so delegated write access can be enforced and revoked
- document the sharing/control API and update run/spec docs

## Proof
- pnpm check
- codex-review: no actionable findings
