### PR TITLE
feat: add multiplex terminal protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add a multiplexed binary terminal WebSocket protocol for Codex session grids and shared viewers.
 - Add read-only Codex session share links with owner-approved terminal control requests.
 - Install bubblewrap and default interactive Codex sessions to yolo mode with a clean PTY buffer.
 - Keep Escape routed to focused Codex terminals instead of closing the session drawer.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "node scripts/generate-assets.mjs && tsgo --noEmit",
     "build:static": "node scripts/generate-assets.mjs --static",
     "deploy": "pnpm build && wrangler d1 migrations apply crabyard-ai --remote && wrangler deploy",
+    "test": "node --test --experimental-strip-types tests/*.test.ts",
     "lint": "oxlint --ignore-pattern node_modules --ignore-pattern src/generated.ts .",
     "format": "oxfmt --check .",
     "check": "node scripts/generate-assets.mjs && tsgo --noEmit && oxlint --ignore-pattern node_modules --ignore-pattern src/generated.ts . && oxfmt --check ."

--- a/src/app.html
+++ b/src/app.html
@@ -1486,6 +1486,27 @@
       let ghosttyModulePromise = null;
       let terminalEpoch = 0;
       const terminalHosts = new Map();
+      let terminalHubSocket = null;
+      let terminalHubReconnectTimer = null;
+      const terminalMessageType = {
+        hello: 1,
+        welcome: 2,
+        subscribe: 10,
+        unsubscribe: 11,
+        output: 20,
+        event: 22,
+        error: 23,
+        input: 30,
+        resize: 32,
+        controlRevoked: 53,
+        ping: 60,
+        pong: 61,
+      };
+      const terminalSubscribeFlags = {
+        output: 1 << 0,
+        snapshot: 1 << 1,
+        events: 1 << 2,
+      };
 
       function render() {
         renderMetrics();
@@ -2139,16 +2160,23 @@
         const text = terminalText(session);
         if (existing?.mount === mount) {
           if (existing.live) {
+            syncTerminalInputState(session, existing, existing.term);
             if (existing.terminalExited) {
               setTerminalStatus(session.id, existing.terminalExitLabel || "PTY exited");
               return;
             }
-            if (!existing.socket || existing.socket.readyState >= WebSocket.CLOSING) {
+            if (!terminalHubSocket || terminalHubSocket.readyState >= WebSocket.CLOSING) {
               connectTerminalSocket(session, existing, existing.term);
+            } else if (!existing.subscribed) {
+              subscribeTerminalHost(session, existing, existing.term);
             }
             setTerminalStatus(
               session.id,
-              existing.socket?.readyState === WebSocket.OPEN ? "Live PTY" : "PTY bridge",
+              terminalHubSocket?.readyState === WebSocket.OPEN
+                ? existing.canInput
+                  ? "Live PTY"
+                  : "Read-only PTY"
+                : "PTY bridge",
             );
             return;
           }
@@ -2167,8 +2195,9 @@
           if (!mod?.Terminal) throw new Error("Ghostty module missing Terminal");
           mount.innerHTML = "";
           const live = shouldConnectLiveTerminal(session);
+          const canInput = canSendTerminalInput(session);
           const term = new mod.Terminal({
-            disableStdin: !live,
+            disableStdin: !canInput,
             fontSize: focusedSessionId === session.id ? 14 : 13,
             theme: { background: "#101827", foreground: "#e5e7eb" },
           });
@@ -2180,8 +2209,18 @@
             if (typeof fit.observeResize === "function") fit.observeResize();
           }
           if (!live) term.write(text);
-          const host = { mount, term, fit, text, live, socket: null, dataSub: null };
-          if (live && typeof term.onData === "function") {
+          const host = {
+            mount,
+            term,
+            fit,
+            text,
+            live,
+            canInput,
+            sessionId: session.id,
+            subscribed: false,
+            dataSub: null,
+          };
+          if (canInput && typeof term.onData === "function") {
             host.dataSub = term.onData((data) => sendTerminalInput(host, data));
           }
           terminalHosts.set(session.id, host);
@@ -2202,70 +2241,273 @@
       function shouldConnectLiveTerminal(session) {
         return (
           session.kind === "interactive" &&
+          (session.canControl === true ||
+            session.sharedReadOnly === true ||
+            (sharedToken && session.id === sharedSessionId)) &&
+          ["ready", "attached", "detached"].includes(session.status)
+        );
+      }
+
+      function canSendTerminalInput(session) {
+        return (
+          session.kind === "interactive" &&
           session.canControl === true &&
           session.sharedReadOnly !== true &&
           ["ready", "attached", "detached"].includes(session.status)
         );
       }
 
-      function terminalSocketUrl(session, term) {
+      function terminalSocketUrl() {
         const protocol = location.protocol === "https:" ? "wss:" : "ws:";
-        const url = new URL(
-          `${protocol}//${location.host}/api/interactive-sessions/${encodeURIComponent(session.id)}/pty`,
-        );
-        if (term?.cols) url.searchParams.set("cols", String(term.cols));
-        if (term?.rows) url.searchParams.set("rows", String(term.rows));
+        const url = new URL(`${protocol}//${location.host}/api/terminal/ws`);
+        if (sharedSessionId && sharedToken) {
+          url.searchParams.set("shareSession", sharedSessionId);
+          url.searchParams.set("token", sharedToken);
+        }
         return url.toString();
       }
 
       function connectTerminalSocket(session, host, term) {
-        const socket = new WebSocket(terminalSocketUrl(session, term));
-        socket.binaryType = "arraybuffer";
-        host.socket = socket;
-        setTerminalStatus(session.id, "Connecting PTY");
-        socket.addEventListener("open", () => {
-          setTerminalStatus(session.id, "Live PTY");
-          term.focus?.();
-        });
-        socket.addEventListener("message", async (event) => {
-          if (typeof event.data === "string") {
-            handleTerminalControlMessage(host, session.id, event.data);
-            return;
-          }
-          const buffer =
-            event.data instanceof ArrayBuffer ? event.data : await event.data.arrayBuffer();
-          const bytes = new Uint8Array(buffer);
-          term.write(bytes);
-        });
-        socket.addEventListener("close", (event) => {
-          if (host.terminalExited) {
-            setTerminalStatus(session.id, host.terminalExitLabel || "PTY exited");
-            return;
-          }
-          const reason = event.reason || (event.code === 1000 ? "closed" : `closed ${event.code}`);
-          setTerminalStatus(session.id, `PTY ${reason}`);
-        });
-        socket.addEventListener("error", () => setTerminalStatus(session.id, "PTY error"));
+        host.sessionId = session.id;
+        syncTerminalInputState(session, host, term);
+        host.live = true;
+        ensureTerminalHub();
+        subscribeTerminalHost(session, host, term);
       }
 
-      function handleTerminalControlMessage(host, id, data) {
-        try {
-          const message = JSON.parse(data);
-          if (message?.type === "ready") setTerminalStatus(id, "Live PTY");
-          if (message?.type === "exit") {
-            host.terminalExited = true;
-            host.terminalExitLabel = `PTY exited ${message.code ?? ""}`;
-            setTerminalStatus(id, host.terminalExitLabel);
-          }
-        } catch {
-          const host = terminalHosts.get(id);
-          host?.term?.write(data);
+      function syncTerminalInputState(session, host, term) {
+        const canInput = canSendTerminalInput(session);
+        host.canInput = canInput;
+        if (term?.options) term.options.disableStdin = !canInput;
+        if (canInput && !host.dataSub && typeof term?.onData === "function") {
+          host.dataSub = term.onData((data) => sendTerminalInput(host, data));
+        }
+        if (!canInput && host.dataSub) {
+          if (typeof host.dataSub.dispose === "function") host.dataSub.dispose();
+          host.dataSub = null;
         }
       }
 
+      function ensureTerminalHub() {
+        if (terminalHubSocket && terminalHubSocket.readyState < WebSocket.CLOSING) return;
+        if (terminalHubReconnectTimer) {
+          clearTimeout(terminalHubReconnectTimer);
+          terminalHubReconnectTimer = null;
+        }
+        const socket = new WebSocket(terminalSocketUrl());
+        socket.binaryType = "arraybuffer";
+        terminalHubSocket = socket;
+        for (const [id, host] of terminalHosts) {
+          if (host.live) setTerminalStatus(id, "Connecting PTY");
+        }
+        socket.addEventListener("open", () => {
+          sendTerminalFrame("", terminalMessageType.hello);
+          for (const session of sessionItems().filter((item) => item.kind === "interactive")) {
+            const host = terminalHosts.get(session.id);
+            if (host?.live && !host.terminalExited && shouldConnectLiveTerminal(session)) {
+              subscribeTerminalHost(session, host, host.term);
+            }
+          }
+        });
+        socket.addEventListener("message", (event) => {
+          void terminalFrameBytes(event.data).then((bytes) => {
+            const frame = decodeTerminalFrame(bytes);
+            if (frame) handleTerminalHubFrame(frame);
+          });
+        });
+        socket.addEventListener("close", (event) => {
+          if (terminalHubSocket !== socket) return;
+          for (const [id, host] of terminalHosts) {
+            if (!host.live || host.terminalExited) continue;
+            host.subscribed = false;
+            const reason =
+              event.reason || (event.code === 1000 ? "closed" : `closed ${event.code}`);
+            setTerminalStatus(id, `PTY ${reason}`);
+          }
+          terminalHubSocket = null;
+          if ([...terminalHosts.values()].some((host) => host.live && !host.terminalExited)) {
+            terminalHubReconnectTimer = setTimeout(() => ensureTerminalHub(), 1500);
+          }
+        });
+        socket.addEventListener("error", () => {
+          if (terminalHubSocket !== socket) return;
+          for (const [id, host] of terminalHosts) {
+            if (host.live && !host.terminalExited) setTerminalStatus(id, "PTY error");
+          }
+        });
+      }
+
+      function subscribeTerminalHost(session, host, term) {
+        if (!terminalHubSocket || terminalHubSocket.readyState !== WebSocket.OPEN) return;
+        host.subscribed = true;
+        const flags =
+          terminalSubscribeFlags.output |
+          terminalSubscribeFlags.snapshot |
+          terminalSubscribeFlags.events;
+        sendTerminalFrame(
+          session.id,
+          terminalMessageType.subscribe,
+          encodeSubscribePayload(flags, term?.cols, term?.rows),
+        );
+        setTerminalStatus(session.id, host.canInput ? "Live PTY" : "Read-only PTY");
+      }
+
+      async function terminalFrameBytes(data) {
+        if (data instanceof ArrayBuffer) return new Uint8Array(data);
+        if (data instanceof Blob) return new Uint8Array(await data.arrayBuffer());
+        if (typeof data === "string") return new TextEncoder().encode(data);
+        return new Uint8Array(data);
+      }
+
+      function handleTerminalHubFrame(frame) {
+        if (frame.type === terminalMessageType.welcome || frame.type === terminalMessageType.pong)
+          return;
+        const host = terminalHosts.get(frame.sessionId);
+        if (!host) return;
+        if (frame.type === terminalMessageType.output) {
+          host.term?.write(frame.payload);
+          return;
+        }
+        const message = decodeTerminalJson(frame.payload);
+        if (frame.type === terminalMessageType.error) {
+          host.subscribed = false;
+          const label = message?.error || "PTY error";
+          setTerminalStatus(frame.sessionId, label);
+          if (String(label).includes("revoked")) {
+            host.terminalExited = true;
+            host.terminalExitLabel = label;
+          } else {
+            scheduleTerminalResubscribe(frame.sessionId);
+          }
+          return;
+        }
+        if (frame.type === terminalMessageType.controlRevoked) {
+          host.canInput = false;
+          setTerminalStatus(frame.sessionId, "Read-only PTY");
+          return;
+        }
+        if (frame.type !== terminalMessageType.event) return;
+        if (message?.type === "subscribed") {
+          setTerminalStatus(frame.sessionId, message.canInput ? "Live PTY" : "Read-only PTY");
+          if (message.canInput && host.term?.cols && host.term?.rows) {
+            sendTerminalFrame(
+              frame.sessionId,
+              terminalMessageType.resize,
+              encodeResizePayload(host.term.cols, host.term.rows),
+            );
+            host.term?.focus?.();
+          }
+        }
+        if (message?.type === "ready") setTerminalStatus(frame.sessionId, "Live PTY");
+        if (message?.type === "exit") {
+          host.terminalExited = true;
+          host.terminalExitLabel = `PTY ${message.type} ${message.code ?? ""}`.trim();
+          setTerminalStatus(frame.sessionId, host.terminalExitLabel);
+        }
+        if (message?.type === "closed") {
+          host.subscribed = false;
+          host.terminalCloseLabel = `PTY closed ${message.code ?? ""}`.trim();
+          setTerminalStatus(frame.sessionId, host.terminalCloseLabel);
+          if (!host.terminalExited) scheduleTerminalResubscribe(frame.sessionId);
+        }
+      }
+
+      function scheduleTerminalResubscribe(id) {
+        setTimeout(() => {
+          const host = terminalHosts.get(id);
+          const session = findSessionItem(id);
+          if (
+            host?.live &&
+            !host.subscribed &&
+            !host.terminalExited &&
+            session?.kind === "interactive" &&
+            shouldConnectLiveTerminal(session) &&
+            terminalHubSocket?.readyState === WebSocket.OPEN
+          ) {
+            subscribeTerminalHost(session, host, host.term);
+          }
+        }, 1500);
+      }
+
       function sendTerminalInput(host, data) {
-        if (host.socket?.readyState !== WebSocket.OPEN) return;
-        host.socket.send(typeof data === "string" ? new TextEncoder().encode(data) : data);
+        if (!host.canInput || terminalHubSocket?.readyState !== WebSocket.OPEN) return;
+        const payload = typeof data === "string" ? new TextEncoder().encode(data) : data;
+        sendTerminalFrame(host.sessionId, terminalMessageType.input, payload);
+      }
+
+      function sendTerminalFrame(sessionId, type, payload = new Uint8Array()) {
+        if (terminalHubSocket?.readyState !== WebSocket.OPEN) return;
+        terminalHubSocket.send(encodeTerminalFrame({ type, sessionId, payload }));
+      }
+
+      function encodeTerminalFrame({ type, sessionId = "", payload = new Uint8Array() }) {
+        const sessionBytes = new TextEncoder().encode(sessionId);
+        const frame = new Uint8Array(12 + sessionBytes.length + payload.length);
+        const view = new DataView(frame.buffer);
+        let offset = 0;
+        view.setUint16(offset, 0x5943, true);
+        offset += 2;
+        view.setUint8(offset, 1);
+        offset += 1;
+        view.setUint8(offset, type);
+        offset += 1;
+        view.setUint32(offset, sessionBytes.length, true);
+        offset += 4;
+        frame.set(sessionBytes, offset);
+        offset += sessionBytes.length;
+        view.setUint32(offset, payload.length, true);
+        offset += 4;
+        frame.set(payload, offset);
+        return frame;
+      }
+
+      function decodeTerminalFrame(bytes) {
+        if (bytes.byteLength < 12) return null;
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        let offset = 0;
+        if (view.getUint16(offset, true) !== 0x5943) return null;
+        offset += 2;
+        if (view.getUint8(offset) !== 1) return null;
+        offset += 1;
+        const type = view.getUint8(offset);
+        offset += 1;
+        const sessionLength = view.getUint32(offset, true);
+        offset += 4;
+        if (offset + sessionLength + 4 > bytes.byteLength) return null;
+        const sessionId = new TextDecoder().decode(bytes.subarray(offset, offset + sessionLength));
+        offset += sessionLength;
+        const payloadLength = view.getUint32(offset, true);
+        offset += 4;
+        if (offset + payloadLength > bytes.byteLength) return null;
+        return { type, sessionId, payload: bytes.subarray(offset, offset + payloadLength) };
+      }
+
+      function encodeSubscribePayload(flags, cols, rows) {
+        const hasSize = Number.isFinite(cols) && Number.isFinite(rows);
+        const payload = new Uint8Array(hasSize ? 20 : 12);
+        const view = new DataView(payload.buffer);
+        view.setUint32(0, flags >>> 0, true);
+        if (hasSize) {
+          view.setUint32(12, cols >>> 0, true);
+          view.setUint32(16, rows >>> 0, true);
+        }
+        return payload;
+      }
+
+      function encodeResizePayload(cols, rows) {
+        const payload = new Uint8Array(8);
+        const view = new DataView(payload.buffer);
+        view.setUint32(0, cols >>> 0, true);
+        view.setUint32(4, rows >>> 0, true);
+        return payload;
+      }
+
+      function decodeTerminalJson(payload) {
+        try {
+          return JSON.parse(new TextDecoder().decode(payload));
+        } catch {
+          return null;
+        }
       }
 
       function isStaleTerminalMount(session, mount, mountEpoch) {
@@ -2355,12 +2597,20 @@
 
       function disposeTerminal(id) {
         const host = terminalHosts.get(id);
-        if (host?.socket && host.socket.readyState < WebSocket.CLOSING)
-          host.socket.close(1000, "unmounted");
+        if (host?.live && terminalHubSocket?.readyState === WebSocket.OPEN) {
+          sendTerminalFrame(id, terminalMessageType.unsubscribe);
+        }
         if (host?.dataSub && typeof host.dataSub.dispose === "function") host.dataSub.dispose();
         if (host?.fit && typeof host.fit.dispose === "function") host.fit.dispose();
         if (host?.term && typeof host.term.dispose === "function") host.term.dispose();
         terminalHosts.delete(id);
+        if (![...terminalHosts.values()].some((item) => item.live)) {
+          if (terminalHubReconnectTimer) clearTimeout(terminalHubReconnectTimer);
+          terminalHubReconnectTimer = null;
+          if (terminalHubSocket?.readyState < WebSocket.CLOSING) {
+            terminalHubSocket.close(1000, "no terminals mounted");
+          }
+        }
       }
 
       function renderRunSide(card) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,14 @@ import {
 } from "kysely";
 import { getSandbox, type Sandbox as CloudflareSandbox } from "@cloudflare/sandbox";
 import {
+  TerminalMessageType,
+  decodeTerminalFrame,
+  decodeResizePayload,
+  decodeSubscribePayload,
+  encodeJsonPayload,
+  encodeTerminalFrame,
+} from "./terminal-protocol";
+import {
   APP_HTML,
   GHOSTTY_BROWSER_EXTERNAL_JS,
   GHOSTTY_WEB_JS,
@@ -262,6 +270,25 @@ type InteractiveProvisionResult = {
 type InteractiveTerminalTarget = {
   url: string;
   authorization: string | null;
+};
+
+type TerminalHubSubscription = {
+  session: InteractiveSession;
+  upstream: WebSocket;
+  canView: () => Promise<boolean>;
+  canInput: () => Promise<boolean>;
+  viewCheck: ReturnType<typeof setInterval> | null;
+  cols: number;
+  rows: number;
+};
+
+type PendingTerminalSubscription = {
+  unsubscribeRequested: boolean;
+};
+
+type TerminalUpstream = {
+  socket: WebSocket;
+  markConnected: () => Promise<void>;
 };
 
 type ClawFleetInstancePayload = {
@@ -695,6 +722,10 @@ async function api(request: Request, env: RuntimeEnv): Promise<Response> {
     );
   }
 
+  if (request.method === "GET" && url.pathname === "/api/terminal/ws") {
+    return interactiveTerminalHub(request, env, await optionalUser(request, env));
+  }
+
   const user = await requireUser(request, env);
 
   if (request.method === "GET" && url.pathname === "/api/session") {
@@ -971,6 +1002,23 @@ async function requireUser(request: Request, env: RuntimeEnv): Promise<User> {
     await upsertUser(env, authorized, Date.now());
   }
   return authorized;
+}
+
+async function optionalUser(request: Request, env: RuntimeEnv): Promise<User | null> {
+  try {
+    return await requireUser(request, env);
+  } catch (error) {
+    const status =
+      typeof error === "object" && error && "status" in error ? Number(error.status) : 0;
+    const url = new URL(request.url);
+    if (
+      status === 401 ||
+      (status === 403 && url.pathname === "/api/terminal/ws" && url.searchParams.has("token"))
+    ) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 async function readState(env: RuntimeEnv, user: User): Promise<Record<string, unknown>> {
@@ -1387,6 +1435,492 @@ async function mutateInteractiveSession(
   }
 
   throw badRequest("unknown action");
+}
+
+async function interactiveTerminalHub(
+  request: Request,
+  env: RuntimeEnv,
+  user: User | null,
+): Promise<Response> {
+  if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+    throw badRequest("websocket upgrade required");
+  }
+  if (!user && !(await canOpenAnonymousTerminalHub(request, env))) {
+    throw unauthorized();
+  }
+
+  const pair = new WebSocketPair();
+  const client = pair[0];
+  const server = pair[1];
+  const subscriptions = new Map<string, TerminalHubSubscription>();
+  const pendingSubscriptions = new Map<string, PendingTerminalSubscription>();
+  let queue = Promise.resolve();
+  let hubClosed = false;
+
+  server.accept();
+  sendTerminalJson(server, TerminalMessageType.Welcome, "", {
+    ok: true,
+    version: 1,
+    multiplex: true,
+  });
+
+  const closeSubscription = (id: string, code = 1000, reason = "unsubscribed") => {
+    const subscription = subscriptions.get(id);
+    if (!subscription) return;
+    subscriptions.delete(id);
+    if (subscription.viewCheck !== null) clearInterval(subscription.viewCheck);
+    if (subscription.upstream.readyState < WebSocket.CLOSING) {
+      subscription.upstream.close(code, reason);
+    }
+  };
+
+  const closeAll = (code = 1000, reason = "client closed") => {
+    for (const id of subscriptions.keys()) closeSubscription(id, code, reason);
+  };
+
+  server.addEventListener("message", (event) => {
+    queue = queue
+      .catch(() => undefined)
+      .then(async () => {
+        const data = await webSocketMessageData(event.data);
+        const bytes =
+          typeof data === "string" ? encoder.encode(data) : new Uint8Array(data.slice(0));
+        const frame = decodeTerminalFrame(bytes);
+        if (!frame) {
+          sendTerminalJson(server, TerminalMessageType.Error, "", { error: "invalid frame" });
+          return;
+        }
+        if (frame.type === TerminalMessageType.Hello) {
+          sendTerminalJson(server, TerminalMessageType.Welcome, "", {
+            ok: true,
+            version: 1,
+            multiplex: true,
+          });
+          return;
+        }
+        if (frame.type === TerminalMessageType.Ping) {
+          sendTerminalFrame(server, TerminalMessageType.Pong, frame.sessionId, frame.payload);
+          return;
+        }
+        if (frame.type === TerminalMessageType.Subscribe) {
+          if (frame.sessionId) {
+            const existingPending = pendingSubscriptions.get(frame.sessionId);
+            if (existingPending && !existingPending.unsubscribeRequested) {
+              sendTerminalJson(server, TerminalMessageType.Event, frame.sessionId, {
+                type: "subscribing",
+              });
+              return;
+            }
+          }
+          const pending = { unsubscribeRequested: false };
+          if (frame.sessionId) pendingSubscriptions.set(frame.sessionId, pending);
+          void subscribeTerminalHubSession(
+            request,
+            env,
+            user,
+            server,
+            subscriptions,
+            frame,
+            () => !hubClosed && !pending.unsubscribeRequested,
+          ).finally(() => {
+            if (frame.sessionId && pendingSubscriptions.get(frame.sessionId) === pending) {
+              pendingSubscriptions.delete(frame.sessionId);
+            }
+          });
+          return;
+        }
+        if (frame.type === TerminalMessageType.Unsubscribe) {
+          const pending = pendingSubscriptions.get(frame.sessionId);
+          if (pending) {
+            pending.unsubscribeRequested = true;
+            return;
+          }
+          closeSubscription(frame.sessionId);
+          return;
+        }
+
+        if (pendingSubscriptions.has(frame.sessionId)) {
+          sendTerminalJson(server, TerminalMessageType.Event, frame.sessionId, {
+            type: "subscribing",
+          });
+          return;
+        }
+
+        const subscription = subscriptions.get(frame.sessionId);
+        if (!subscription) {
+          sendTerminalJson(server, TerminalMessageType.Error, frame.sessionId, {
+            error: "session is not subscribed",
+          });
+          return;
+        }
+        if (frame.type === TerminalMessageType.Input || frame.type === TerminalMessageType.Key) {
+          if (!(await subscription.canInput())) {
+            sendTerminalJson(server, TerminalMessageType.ControlRevoked, frame.sessionId, {
+              error: "terminal control has not been granted",
+            });
+            return;
+          }
+          if (subscription.upstream.readyState === WebSocket.OPEN) {
+            subscription.upstream.send(frame.payload);
+          }
+          return;
+        }
+        if (frame.type === TerminalMessageType.Resize) {
+          const size = decodeResizePayload(frame.payload);
+          if (!(await subscription.canInput())) {
+            sendTerminalJson(server, TerminalMessageType.ControlRevoked, frame.sessionId, {
+              error: "terminal control has not been granted",
+            });
+            return;
+          }
+          if (size) {
+            subscription.cols = size.cols;
+            subscription.rows = size.rows;
+            if (subscription.upstream.readyState === WebSocket.OPEN) {
+              subscription.upstream.send(JSON.stringify({ type: "resize", ...size }));
+            }
+          }
+          sendTerminalJson(server, TerminalMessageType.Event, frame.sessionId, {
+            type: "resize",
+            cols: size?.cols ?? null,
+            rows: size?.rows ?? null,
+          });
+          return;
+        }
+        if (frame.type === TerminalMessageType.Stop) {
+          closeSubscription(frame.sessionId, 1000, "stopped by client");
+        }
+      });
+  });
+
+  server.addEventListener("close", () => {
+    hubClosed = true;
+    closeAll();
+  });
+  server.addEventListener("error", () => {
+    hubClosed = true;
+    closeAll(1011, "client error");
+  });
+
+  return new Response(null, { status: 101, webSocket: client });
+}
+
+async function subscribeTerminalHubSession(
+  request: Request,
+  env: RuntimeEnv,
+  user: User | null,
+  client: WebSocket,
+  subscriptions: Map<string, TerminalHubSubscription>,
+  frame: { sessionId: string; payload: Uint8Array },
+  isHubOpen: () => boolean,
+): Promise<void> {
+  const id = frame.sessionId;
+  if (!id) {
+    sendTerminalJson(client, TerminalMessageType.Error, "", { error: "session id required" });
+    return;
+  }
+  const subscription = decodeSubscribePayload(frame.payload);
+  if (!subscription) {
+    sendTerminalJson(client, TerminalMessageType.Error, id, { error: "invalid subscribe payload" });
+    return;
+  }
+  if (subscriptions.has(id)) {
+    sendTerminalJson(client, TerminalMessageType.Event, id, { type: "subscribed" });
+    return;
+  }
+
+  if (!user && !(await canViewSharedTerminalRequest(request, env, id))) {
+    sendTerminalJson(client, TerminalMessageType.Error, id, { error: "unauthorized" });
+    return;
+  }
+
+  const session = await readInteractiveSession(env, id);
+  if (!session) {
+    sendTerminalJson(client, TerminalMessageType.Error, id, {
+      error: "interactive session not found",
+    });
+    return;
+  }
+  if (["expired", "failed", "stopped"].includes(session.status)) {
+    sendTerminalJson(client, TerminalMessageType.Error, id, {
+      error: `session is ${session.status}`,
+    });
+    return;
+  }
+  if (!(await canViewTerminalSession(request, env, user, session))) {
+    sendTerminalJson(client, TerminalMessageType.Error, id, { error: "unauthorized" });
+    return;
+  }
+
+  try {
+    const canInput = terminalInputGrant(env, user, session);
+    const canInputNow = await canInput();
+    const canView = terminalViewGrant(request, env, user, session);
+    const cols = canInputNow ? terminalDimension(subscription.cols, 120) : 120;
+    const rows = canInputNow ? terminalDimension(subscription.rows, 34) : 34;
+    const upstreamConnection = await openInteractiveTerminalUpstream(
+      request,
+      env,
+      user,
+      session,
+      cols,
+      rows,
+    );
+    const upstream = upstreamConnection.socket;
+    if (!isHubOpen() || client.readyState !== WebSocket.OPEN) {
+      if (upstream.readyState < WebSocket.CLOSING) upstream.close(1000, "client closed");
+      return;
+    }
+    let viewGranted = true;
+    let viewCheck: ReturnType<typeof setInterval> | null = null;
+    const revokeView = () => {
+      if (!viewGranted) return;
+      viewGranted = false;
+      subscriptions.delete(id);
+      if (viewCheck !== null) clearInterval(viewCheck);
+      if (upstream.readyState === WebSocket.OPEN) upstream.close(1008, "share revoked");
+      sendTerminalJson(client, TerminalMessageType.Error, id, {
+        error: "terminal share revoked",
+      });
+    };
+    viewCheck = setInterval(() => {
+      void canView()
+        .then((allowed) => {
+          if (!allowed) revokeView();
+        })
+        .catch(() => revokeView());
+    }, 5000);
+    subscriptions.set(id, { session, upstream, canView, canInput, viewCheck, cols, rows });
+    let outputQueue = Promise.resolve();
+    sendTerminalJson(client, TerminalMessageType.Event, id, {
+      type: "subscribed",
+      canInput: canInputNow,
+    });
+    upstream.addEventListener("message", (event) => {
+      const raw = event.data;
+      outputQueue = outputQueue
+        .catch(() => undefined)
+        .then(async () => {
+          const data = await webSocketMessageData(raw);
+          if (client.readyState !== WebSocket.OPEN) return;
+          if (!viewGranted) return;
+          if (typeof data === "string") {
+            const parsed = parseTerminalControlMessage(data);
+            if (parsed) {
+              sendTerminalJson(client, TerminalMessageType.Event, id, parsed);
+              return;
+            }
+            sendTerminalFrame(client, TerminalMessageType.Output, id, encoder.encode(data));
+            return;
+          }
+          sendTerminalFrame(client, TerminalMessageType.Output, id, new Uint8Array(data));
+        });
+    });
+    upstream.addEventListener("close", (event) => {
+      subscriptions.delete(id);
+      if (viewCheck !== null) clearInterval(viewCheck);
+      if (client.readyState === WebSocket.OPEN) {
+        sendTerminalJson(client, TerminalMessageType.Event, id, {
+          type: "closed",
+          code: event.code,
+          reason: event.reason,
+        });
+      }
+    });
+    upstream.addEventListener("error", () => {
+      subscriptions.delete(id);
+      if (viewCheck !== null) clearInterval(viewCheck);
+      sendTerminalJson(client, TerminalMessageType.Error, id, { error: "upstream terminal error" });
+    });
+    void upstreamConnection.markConnected().catch(() => {
+      sendTerminalJson(client, TerminalMessageType.Event, id, {
+        type: "warning",
+        message: "terminal connection state update failed",
+      });
+    });
+  } catch (error) {
+    sendTerminalJson(client, TerminalMessageType.Error, id, {
+      error: error instanceof Error ? clean(error.message, 200) : "terminal connection failed",
+    });
+  }
+}
+
+async function openInteractiveTerminalUpstream(
+  request: Request,
+  env: RuntimeEnv,
+  user: User | null,
+  session: InteractiveSession,
+  cols: number,
+  rows: number,
+): Promise<TerminalUpstream> {
+  const now = Date.now();
+  if (session.leaseId?.startsWith(sandboxLeasePrefix) && env.SANDBOX) {
+    const sandboxId =
+      session.leaseId?.slice(sandboxLeasePrefix.length) || sandboxIdForSession(session.id);
+    const sandbox = getSandbox(env.SANDBOX, sandboxId);
+    const terminalSession = await sandbox.getSession(sandboxTerminalSessionId(session.id));
+    const upstreamResponse = await terminalSession.terminal(request, {
+      cols,
+      rows,
+      shell: sandboxStartupScriptPath(session),
+    });
+    const upstream = upstreamResponse.webSocket;
+    if (!upstream || upstreamResponse.status !== 101) {
+      throw serviceUnavailable(`Cloudflare Sandbox terminal HTTP ${upstreamResponse.status}`);
+    }
+    upstream.accept();
+    return {
+      socket: upstream,
+      markConnected: () =>
+        markInteractiveTerminalConnected(
+          env,
+          user,
+          session.id,
+          now,
+          "Cloudflare Sandbox terminal connected",
+        ),
+    };
+  }
+
+  const target = interactiveTerminalTarget(env, session);
+  if (!target) throw serviceUnavailable("PTY bridge is not configured for this session");
+  const upstreamResponse = await fetch(
+    addQuery(target.url, { cols: String(cols), rows: String(rows) }),
+    {
+      headers: interactiveTerminalHeaders(session, target.authorization),
+    },
+  );
+  const upstream = upstreamResponse.webSocket;
+  if (!upstream || upstreamResponse.status !== 101) {
+    throw serviceUnavailable(`PTY bridge HTTP ${upstreamResponse.status}`);
+  }
+  upstream.accept();
+  return {
+    socket: upstream,
+    markConnected: () =>
+      markInteractiveTerminalConnected(env, user, session.id, now, "PTY terminal connected"),
+  };
+}
+
+async function markInteractiveTerminalConnected(
+  env: RuntimeEnv,
+  user: User | null,
+  id: string,
+  now: number,
+  message: string,
+): Promise<void> {
+  await database(env)
+    .updateTable("interactive_sessions")
+    .set({
+      status: "attached",
+      last_seen_at: now,
+      updated_at: now,
+      last_event: message,
+    })
+    .where("id", "=", id)
+    .where("status", "in", ["ready", "attached", "detached"])
+    .execute();
+  if (user) await appendInteractiveSessionEvent(env, id, user, message, now);
+}
+
+function terminalInputGrant(
+  env: RuntimeEnv,
+  user: User | null,
+  session: InteractiveSession,
+): () => Promise<boolean> {
+  if (!user) return async () => false;
+  if (canManageInteractiveSession(user, session)) return async () => true;
+  return () => canControlInteractiveSessionById(env, user, session.id);
+}
+
+function terminalViewGrant(
+  request: Request,
+  env: RuntimeEnv,
+  user: User | null,
+  session: InteractiveSession,
+): () => Promise<boolean> {
+  return async () =>
+    Boolean(user && (await canControlInteractiveSessionById(env, user, session.id))) ||
+    (await canViewSharedTerminalRequest(request, env, session.id));
+}
+
+async function canViewSharedTerminalRequest(
+  request: Request,
+  env: RuntimeEnv,
+  id: string,
+): Promise<boolean> {
+  const url = new URL(request.url);
+  const shareSession = url.searchParams.get("shareSession") ?? "";
+  const token = url.searchParams.get("token") ?? "";
+  return (!shareSession || shareSession === id) && (await isSharedSessionToken(env, id, token));
+}
+
+async function canOpenAnonymousTerminalHub(request: Request, env: RuntimeEnv): Promise<boolean> {
+  const url = new URL(request.url);
+  const shareSession = url.searchParams.get("shareSession") ?? "";
+  const token = url.searchParams.get("token") ?? "";
+  return Boolean(shareSession && token && (await isSharedSessionToken(env, shareSession, token)));
+}
+
+async function canViewTerminalSession(
+  request: Request,
+  env: RuntimeEnv,
+  user: User | null,
+  session: InteractiveSession,
+): Promise<boolean> {
+  if (user) {
+    requireRole(user, "viewer");
+    if (await canControlInteractiveSessionById(env, user, session.id)) return true;
+  }
+  return canViewSharedTerminalRequest(request, env, session.id);
+}
+
+async function isSharedSessionToken(env: RuntimeEnv, id: string, token: string): Promise<boolean> {
+  if (!token) return false;
+  const row = await database(env)
+    .selectFrom("interactive_sessions")
+    .select(["share_token_hash", "share_mode", "status"])
+    .where("id", "=", id)
+    .where("share_mode", "=", "link_read")
+    .executeTakeFirst();
+  return Boolean(
+    row?.share_token_hash &&
+    !["expired", "failed", "stopped"].includes(row.status) &&
+    (await sha256(token)) === row.share_token_hash,
+  );
+}
+
+function sendTerminalFrame(
+  socket: WebSocket,
+  type: TerminalMessageType,
+  sessionId: string,
+  payload?: Uint8Array,
+): void {
+  if (socket.readyState === WebSocket.OPEN) {
+    socket.send(
+      payload
+        ? encodeTerminalFrame({ type, sessionId, payload })
+        : encodeTerminalFrame({ type, sessionId }),
+    );
+  }
+}
+
+function sendTerminalJson(
+  socket: WebSocket,
+  type: TerminalMessageType,
+  sessionId: string,
+  payload: unknown,
+): void {
+  sendTerminalFrame(socket, type, sessionId, encodeJsonPayload(payload));
+}
+
+function parseTerminalControlMessage(data: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(data) as Record<string, unknown>;
+    return typeof parsed.type === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 async function interactiveSessionPty(
@@ -3850,6 +4384,11 @@ function terminalSize(request: Request, name: "cols" | "rows", fallback: number)
   const value = Number(url.searchParams.get(name));
   if (!Number.isFinite(value)) return fallback;
   return Math.min(300, Math.max(10, Math.trunc(value)));
+}
+
+function terminalDimension(value: number | null, fallback: number): number {
+  if (!Number.isFinite(value ?? Number.NaN)) return fallback;
+  return Math.min(300, Math.max(10, Math.trunc(value as number)));
 }
 
 function shellQuote(value: string): string {

--- a/src/terminal-protocol.ts
+++ b/src/terminal-protocol.ts
@@ -1,0 +1,157 @@
+export const TERMINAL_WS_MAGIC = 0x5943;
+export const TERMINAL_WS_VERSION = 1;
+
+export const TerminalMessageType = {
+  Hello: 1,
+  Welcome: 2,
+  Subscribe: 10,
+  Unsubscribe: 11,
+  Output: 20,
+  Snapshot: 21,
+  Event: 22,
+  Error: 23,
+  Input: 30,
+  Key: 31,
+  Resize: 32,
+  Stop: 33,
+  ControlRequest: 50,
+  ControlDecision: 51,
+  ControlGranted: 52,
+  ControlRevoked: 53,
+  Ping: 60,
+  Pong: 61,
+} as const;
+
+export type TerminalMessageType = (typeof TerminalMessageType)[keyof typeof TerminalMessageType];
+
+export const TerminalSubscribeFlags = {
+  Output: 1 << 0,
+  Snapshot: 1 << 1,
+  Events: 1 << 2,
+} as const;
+
+export type TerminalFrame = {
+  type: TerminalMessageType;
+  sessionId: string;
+  payload: Uint8Array;
+};
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export function encodeTerminalFrame(params: {
+  type: TerminalMessageType;
+  sessionId?: string;
+  payload?: Uint8Array;
+}): Uint8Array {
+  const sessionId = params.sessionId ?? "";
+  const sessionIdBytes = textEncoder.encode(sessionId);
+  const payload = params.payload ?? new Uint8Array();
+  const headerLength = 2 + 1 + 1 + 4 + sessionIdBytes.length + 4;
+  const frame = new Uint8Array(headerLength + payload.length);
+  const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
+  let offset = 0;
+  view.setUint16(offset, TERMINAL_WS_MAGIC, true);
+  offset += 2;
+  view.setUint8(offset, TERMINAL_WS_VERSION);
+  offset += 1;
+  view.setUint8(offset, params.type);
+  offset += 1;
+  view.setUint32(offset, sessionIdBytes.length, true);
+  offset += 4;
+  frame.set(sessionIdBytes, offset);
+  offset += sessionIdBytes.length;
+  view.setUint32(offset, payload.length, true);
+  offset += 4;
+  frame.set(payload, offset);
+  return frame;
+}
+
+export function decodeTerminalFrame(data: Uint8Array): TerminalFrame | null {
+  if (data.byteLength < 12) return null;
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  let offset = 0;
+  if (view.getUint16(offset, true) !== TERMINAL_WS_MAGIC) return null;
+  offset += 2;
+  if (view.getUint8(offset) !== TERMINAL_WS_VERSION) return null;
+  offset += 1;
+  const type = view.getUint8(offset) as TerminalMessageType;
+  offset += 1;
+  const sessionIdLength = view.getUint32(offset, true);
+  offset += 4;
+  if (offset + sessionIdLength + 4 > data.byteLength) return null;
+  const sessionId = textDecoder.decode(data.subarray(offset, offset + sessionIdLength));
+  offset += sessionIdLength;
+  const payloadLength = view.getUint32(offset, true);
+  offset += 4;
+  if (offset + payloadLength > data.byteLength) return null;
+  return {
+    type,
+    sessionId,
+    payload: data.subarray(offset, offset + payloadLength),
+  };
+}
+
+export function encodeSubscribePayload(params: {
+  flags: number;
+  snapshotMinIntervalMs?: number;
+  snapshotMaxIntervalMs?: number;
+  cols?: number;
+  rows?: number;
+}): Uint8Array {
+  const hasSize = params.cols !== undefined && params.rows !== undefined;
+  const payload = new Uint8Array(hasSize ? 20 : 12);
+  const view = new DataView(payload.buffer);
+  view.setUint32(0, params.flags >>> 0, true);
+  view.setUint32(4, (params.snapshotMinIntervalMs ?? 0) >>> 0, true);
+  view.setUint32(8, (params.snapshotMaxIntervalMs ?? 0) >>> 0, true);
+  if (hasSize) {
+    view.setUint32(12, params.cols ?? 0, true);
+    view.setUint32(16, params.rows ?? 0, true);
+  }
+  return payload;
+}
+
+export function decodeSubscribePayload(payload: Uint8Array): {
+  flags: number;
+  snapshotMinIntervalMs: number;
+  snapshotMaxIntervalMs: number;
+  cols: number | null;
+  rows: number | null;
+} | null {
+  if (payload.byteLength < 12) return null;
+  const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+  return {
+    flags: view.getUint32(0, true),
+    snapshotMinIntervalMs: view.getUint32(4, true),
+    snapshotMaxIntervalMs: view.getUint32(8, true),
+    cols: payload.byteLength >= 20 ? view.getUint32(12, true) : null,
+    rows: payload.byteLength >= 20 ? view.getUint32(16, true) : null,
+  };
+}
+
+export function encodeResizePayload(cols: number, rows: number): Uint8Array {
+  const payload = new Uint8Array(8);
+  const view = new DataView(payload.buffer);
+  view.setUint32(0, cols >>> 0, true);
+  view.setUint32(4, rows >>> 0, true);
+  return payload;
+}
+
+export function decodeResizePayload(payload: Uint8Array): { cols: number; rows: number } | null {
+  if (payload.byteLength < 8) return null;
+  const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+  return { cols: view.getUint32(0, true), rows: view.getUint32(4, true) };
+}
+
+export function encodeJsonPayload(value: unknown): Uint8Array {
+  return textEncoder.encode(JSON.stringify(value));
+}
+
+export function decodeJsonPayload<T>(payload: Uint8Array): T | null {
+  try {
+    return JSON.parse(textDecoder.decode(payload)) as T;
+  } catch {
+    return null;
+  }
+}

--- a/tests/terminal-protocol.test.ts
+++ b/tests/terminal-protocol.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  TerminalMessageType,
+  TerminalSubscribeFlags,
+  decodeResizePayload,
+  decodeSubscribePayload,
+  decodeTerminalFrame,
+  encodeJsonPayload,
+  encodeResizePayload,
+  encodeSubscribePayload,
+  encodeTerminalFrame,
+} from "../src/terminal-protocol.ts";
+
+test("terminal frames round-trip binary payloads and session ids", () => {
+  const payload = new Uint8Array([0, 1, 2, 255]);
+  const encoded = encodeTerminalFrame({
+    type: TerminalMessageType.Output,
+    sessionId: "IS-123",
+    payload,
+  });
+
+  const decoded = decodeTerminalFrame(encoded);
+  assert.deepEqual(decoded, {
+    type: TerminalMessageType.Output,
+    sessionId: "IS-123",
+    payload,
+  });
+});
+
+test("terminal decoder rejects truncated and wrong-version frames", () => {
+  assert.equal(decodeTerminalFrame(new Uint8Array([0x43, 0x59])), null);
+  const encoded = encodeTerminalFrame({ type: TerminalMessageType.Ping });
+  encoded[2] = 99;
+  assert.equal(decodeTerminalFrame(encoded), null);
+});
+
+test("terminal subscribe and resize payloads use stable little-endian fields", () => {
+  const subscribe = decodeSubscribePayload(
+    encodeSubscribePayload({
+      flags: TerminalSubscribeFlags.Output | TerminalSubscribeFlags.Events,
+      snapshotMinIntervalMs: 100,
+      snapshotMaxIntervalMs: 500,
+    }),
+  );
+  assert.deepEqual(subscribe, {
+    flags: TerminalSubscribeFlags.Output | TerminalSubscribeFlags.Events,
+    snapshotMinIntervalMs: 100,
+    snapshotMaxIntervalMs: 500,
+    cols: null,
+    rows: null,
+  });
+
+  assert.deepEqual(decodeResizePayload(encodeResizePayload(132, 43)), { cols: 132, rows: 43 });
+});
+
+test("terminal subscribe payloads can carry initial PTY size", () => {
+  assert.deepEqual(
+    decodeSubscribePayload(
+      encodeSubscribePayload({
+        flags: TerminalSubscribeFlags.Output,
+        cols: 144,
+        rows: 41,
+      }),
+    ),
+    {
+      flags: TerminalSubscribeFlags.Output,
+      snapshotMinIntervalMs: 0,
+      snapshotMaxIntervalMs: 0,
+      cols: 144,
+      rows: 41,
+    },
+  );
+});
+
+test("json payloads fit inside regular terminal frames", () => {
+  const payload = encodeJsonPayload({ ok: true, version: 1 });
+  const decoded = decodeTerminalFrame(
+    encodeTerminalFrame({ type: TerminalMessageType.Welcome, payload }),
+  );
+  assert.equal(new TextDecoder().decode(decoded?.payload), '{"ok":true,"version":1}');
+});


### PR DESCRIPTION
## Summary
- Add a multiplexed binary terminal WebSocket protocol for Codex session grids.
- Move Ghostty terminals onto one shared hub socket with reconnects, snapshots, shared read-only viewing, and controlled input.
- Add protocol tests and changelog coverage.

## Proof
- pnpm test
- pnpm check
- pnpm build
- codex-review helper clean after fixes
