### PR TITLE
docs: update terminal hub docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -7,7 +7,7 @@ description: "REST API reference for Crabyard."
 
 # API Reference
 
-Crabyard exposes a same-origin REST API from the Worker. There are no live WebSocket APIs in the deployed MVP yet.
+Crabyard exposes same-origin REST APIs and terminal WebSocket APIs from the Worker. Browser clients keep app state in D1-backed REST calls and attach to live Codex terminals through the multiplex terminal hub.
 
 ## Auth
 
@@ -250,9 +250,36 @@ Backends:
 - ClawFleet handles `crabbox` sessions only; use `CRABYARD_RUNTIME_PROVISION_URL` or `CRABYARD_CLOUDFLARE_RUNNER_URL` for `container` sessions.
 - If neither backend is configured, returns `pending_adapter` with a message that the route is live.
 
+### GET /api/terminal/ws
+
+Viewer+, or public shared-link token for read-only sessions. Same-origin multiplex WebSocket endpoint used by the Ghostty WASM session grid. One browser socket can subscribe to multiple interactive sessions, receive PTY output frames, resize terminals, and send input only when the current user has control.
+
+The wire format is a compact binary frame:
+
+```text
+u16 magic 0x5943
+u8 version 1
+u8 message_type
+u32 session_id_length
+utf8 session_id
+u32 payload_length
+payload bytes
+```
+
+Supported browser actions:
+
+- `Subscribe`: attach to a session with output/snapshot/event flags and optional initial cols/rows.
+- `Unsubscribe`: detach one session without closing the hub.
+- `Input` / `Key`: send terminal bytes when control is granted.
+- `Resize`: forward terminal dimensions to the upstream PTY.
+- `Stop`: close the upstream subscription.
+- `Ping`: keepalive, answered with `Pong`.
+
+Server messages include `Welcome`, `Output`, `Event`, `Error`, `ControlRevoked`, and `Pong`. Shared-link viewers can subscribe and scroll output, but input frames are rejected unless an owner/maintainer grants writable control.
+
 ### GET /api/interactive-sessions/:id/pty
 
-Viewer+. Same-origin WebSocket endpoint used by the Ghostty WASM terminal. Crabyard authenticates the browser session, verifies the interactive session is still attachable, verifies terminal control, then proxies PTY bytes to the configured runner. Owners and maintainers have control by default; other viewers require an approved control request.
+Viewer+. Legacy single-session WebSocket endpoint. Crabyard authenticates the browser session, verifies the interactive session is still attachable, verifies terminal control, then proxies PTY bytes to the configured runner. Owners and maintainers have control by default; other viewers require an approved control request.
 
 Target resolution:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Crabyard is an OpenClaw control plane for Codex work: prompt cards, repo gates, 
 - Cards from prompts or `#number` issue/PR previews across enabled repos.
 - Optional title generation from prompt.
 - Durable run attempts with heartbeat, stall handling, operator, runtime reason, and capabilities.
-- Ghostty WASM fullscreen session grid with D1 event replay and text fallback.
+- Ghostty WASM fullscreen session grid with D1 event replay, live multiplex PTY attach, and text fallback.
 - Card diff metadata and compact patch view.
 - Owner workflow evaluation for repo `CRABYARD.md`.
 - Worker-served docs at `/docs/` and GitHub Pages docs at `docs.crabyard.ai`.
@@ -25,7 +25,6 @@ Crabyard is an OpenClaw control plane for Codex work: prompt cards, repo gates, 
 ## Not Wired Yet
 
 - Real Container/Crabbox lease creation.
-- Live PTY/app-server stdin/stdout transport.
 - R2 artifact/terminal archival.
 - Durable Object WebSocket fanout.
 - Direct merge execution and ClawSweeper handoff.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -105,7 +105,7 @@ The Worker will:
 - Store a run attempt with selection reason and capabilities.
 - Move the card to Running and append events.
 
-Click Attach to open the Ghostty WASM session grid. The current grid replays D1 events. Live PTY/app-server transport is planned.
+Click Attach to open the Ghostty WASM session grid. The grid immediately shows D1 event replay and switches to live PTY output through the terminal hub when the session has a sandbox or bridge.
 
 ## Troubleshooting
 

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -7,7 +7,7 @@ description: "Runtime execution, logs, attach/takeover, and debugging for Codex 
 
 # Runs
 
-A run is a durable attempt to execute a card. Today Crabyard records attempts, heartbeats, runtime selection evidence, operator intent, and event logs in D1. External Container/Crabbox execution and live PTY transport are the next adapter binding step.
+A run is a durable attempt to execute a card. Today Crabyard records attempts, heartbeats, runtime selection evidence, operator intent, and event logs in D1. Interactive sessions can attach to live PTYs through the Worker terminal hub when a Cloudflare Sandbox or runner bridge is available.
 
 ## Run Lifecycle
 
@@ -82,7 +82,7 @@ Attach opens a fullscreen Ghostty WASM grid. Current behavior:
 - Shows one or more Codex session tiles.
 - Includes standalone interactive Codex CLI sessions created from New session.
 - Uses the local `ghostty-web` bundle served by the Worker.
-- Streams live PTY bytes through `/api/interactive-sessions/:id/pty` when a bridge is configured.
+- Streams live PTY bytes through the multiplex `/api/terminal/ws` hub when a sandbox or bridge is configured.
 - Replays D1 event logs into the terminal surface while a live PTY is unavailable.
 - Falls back to a text terminal if Ghostty cannot initialize.
 - Supports focused fullscreen card view.
@@ -111,10 +111,10 @@ Cloudflare runner configuration:
 
 Runner PTY contract:
 
-- Crabyard accepts the browser WebSocket on `/api/interactive-sessions/:id/pty`.
+- Crabyard accepts the browser WebSocket on `/api/terminal/ws` and multiplexes one or more subscribed sessions.
 - Crabyard connects upstream to the configured bridge with `Upgrade: websocket`.
-- Browser-to-runner messages are terminal input bytes.
-- Runner-to-browser messages are terminal output bytes.
+- Browser-to-Crabyard messages use binary terminal frames for subscribe, input, resize, and stop.
+- Runner-to-browser output is wrapped in terminal output frames with session IDs.
 - The bridge receives `x-crabyard-session`, `x-crabyard-repo`, and `x-crabyard-runtime` headers plus session query parameters.
 
 Session sharing:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -48,7 +48,7 @@ Implemented now:
 - Optional titles derived from prompt.
 - D1 `run_attempts` with heartbeat, stall reconciliation, runtime selection reason, lease fields, operator intent, and runtime capabilities.
 - Runtime adapter descriptor for Container and Crabbox policy.
-- Ghostty WASM fullscreen session grid with D1 event replay and text fallback.
+- Ghostty WASM fullscreen session grid with D1 event replay, live multiplex PTY attach, and text fallback.
 - Focused Codex session URLs with public read-only share links and owner-approved control requests.
 - `CRABYARD.md` fetch/parse/evaluate admin surface.
 - Card diff metadata and compact patch preview.
@@ -58,7 +58,7 @@ Implemented now:
 Not wired yet:
 
 - Crabbox/ClawFleet lease creation.
-- Runner-side PTY process hosting and app-server transport.
+- External Crabbox/runner-side app-server transport.
 - R2 terminal/artifact archival.
 - Durable Object WebSocket fanout.
 - Direct merge execution or ClawSweeper handoff.
@@ -648,7 +648,7 @@ WebSockets:
 
 - `/ws/board/:board_id`
 - `/ws/run/:run_id`
-- `/ws/terminal/:run_id`
+- `/api/terminal/ws`
 
 Service bindings:
 


### PR DESCRIPTION
## Summary
- Update docs to describe the deployed multiplex terminal hub.
- Replace stale planned/live PTY language in API, runs, quickstart, index, and spec docs.

## Proof
- pnpm build:static
- pnpm check
- git diff --check
