### PR TITLE
[codex] Add terminal clipboard upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add browser clipboard copy/paste controls for live Codex terminals, including image/file paste into Cloudflare Sandbox workspaces.
 - Add a multiplexed binary terminal WebSocket protocol for Codex session grids and shared viewers.
 - Add read-only Codex session share links with owner-approved terminal control requests.
 - Install bubblewrap and default interactive Codex sessions to yolo mode with a clean PTY buffer.

--- a/docs/api.md
+++ b/docs/api.md
@@ -277,6 +277,10 @@ Supported browser actions:
 
 Server messages include `Welcome`, `Output`, `Event`, `Error`, `ControlRevoked`, and `Pong`. Shared-link viewers can subscribe and scroll output, but input frames are rejected unless an owner/maintainer grants writable control.
 
+### POST /api/interactive-sessions/:id/clipboard
+
+Viewer+ with writable terminal control. Uploads a browser clipboard image/file body into the controlled Cloudflare Sandbox workspace and returns `{ path, name, mediaType, byteCount }`. The browser then pastes the returned path into the PTY. Max body size: 10 MiB. Non-Sandbox PTY backends do not expose file paste.
+
 ### GET /api/interactive-sessions/:id/pty
 
 Viewer+. Legacy single-session WebSocket endpoint. Crabyard authenticates the browser session, verifies the interactive session is still attachable, verifies terminal control, then proxies PTY bytes to the configured runner. Owners and maintainers have control by default; other viewers require an approved control request.

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -85,6 +85,7 @@ Attach opens a fullscreen Ghostty WASM grid. Current behavior:
 - Streams live PTY bytes through the multiplex `/api/terminal/ws` hub when a sandbox or bridge is configured.
 - Replays D1 event logs into the terminal surface while a live PTY is unavailable.
 - Falls back to a text terminal if Ghostty cannot initialize.
+- Copies terminal selection, pastes clipboard text when the viewer has writable control, and uploads clipboard images/files for Cloudflare Sandbox sessions.
 - Supports focused fullscreen card view.
 - Supports focused share URLs with public read-only event scrollback and owner-approved writable control requests for signed-in viewers.
 

--- a/src/app.html
+++ b/src/app.html
@@ -2053,7 +2053,15 @@
           stopped || !canControlSession
             ? ""
             : `<button data-interactive-attach="${session.id}">Attach</button>`;
-        return `${shareButton}${unshareButton}${requestButton}${reviewButtons}${revokeButton}${attachButton}${stopButton}`;
+        const canPasteFiles =
+          canControlSession &&
+          typeof session.leaseId === "string" &&
+          session.leaseId.startsWith("sandbox:");
+        const clipboardButtons =
+          stopped || !canControlSession
+            ? `<button data-terminal-copy="${session.id}">Copy</button>`
+            : `<button data-terminal-copy="${session.id}">Copy</button><button data-terminal-paste-text="${session.id}">Paste</button>${canPasteFiles ? `<button data-terminal-paste-file="${session.id}">Paste file</button>` : ""}`;
+        return `${clipboardButtons}${shareButton}${unshareButton}${requestButton}${reviewButtons}${revokeButton}${attachButton}${stopButton}`;
       }
 
       function isOptimisticInteractiveSession(session) {
@@ -2208,6 +2216,8 @@
             fit.fit();
             if (typeof fit.observeResize === "function") fit.observeResize();
           }
+          const pasteHandler = (event) => handleTerminalPasteEvent(session.id, event);
+          mount.addEventListener("paste", pasteHandler, { capture: true });
           if (!live) term.write(text);
           const host = {
             mount,
@@ -2219,6 +2229,7 @@
             sessionId: session.id,
             subscribed: false,
             dataSub: null,
+            pasteHandler,
           };
           if (canInput && typeof term.onData === "function") {
             host.dataSub = term.onData((data) => sendTerminalInput(host, data));
@@ -2412,6 +2423,172 @@
         }
       }
 
+      function handleTerminalPasteEvent(id, event) {
+        const file = firstClipboardFile(event.clipboardData);
+        if (!file) return;
+        event.preventDefault();
+        event.stopPropagation();
+        void uploadTerminalClipboardBlob(id, file, file.name || clipboardName(file.type));
+      }
+
+      function firstClipboardFile(data) {
+        if (!data) return null;
+        for (const file of Array.from(data.files || [])) {
+          if (file && file.size > 0) return file;
+        }
+        for (const item of Array.from(data.items || [])) {
+          if (item.kind !== "file") continue;
+          const file = item.getAsFile();
+          if (file && file.size > 0) return file;
+        }
+        return null;
+      }
+
+      async function pasteClipboardText(id) {
+        const host = terminalHosts.get(id);
+        if (!host?.canInput) {
+          setTerminalStatus(id, "Read-only PTY");
+          return;
+        }
+        try {
+          const text = await navigator.clipboard?.readText?.();
+          if (!text) {
+            setTerminalStatus(id, "Clipboard empty");
+            return;
+          }
+          pasteTerminalText(host, text);
+        } catch {
+          setTerminalStatus(id, "Clipboard read blocked");
+        }
+      }
+
+      async function pasteClipboardFile(id) {
+        const host = terminalHosts.get(id);
+        if (!host?.canInput) {
+          setTerminalStatus(id, "Read-only PTY");
+          return;
+        }
+        if (!navigator.clipboard?.read) {
+          setTerminalStatus(id, "Clipboard files unavailable");
+          return;
+        }
+        try {
+          const items = await navigator.clipboard.read();
+          for (const item of items) {
+            const type =
+              item.types.find((candidate) => candidate.startsWith("image/")) ||
+              item.types.find((candidate) => candidate !== "text/plain");
+            if (!type) continue;
+            const blob = await item.getType(type);
+            await uploadTerminalClipboardBlob(id, blob, clipboardName(type), type);
+            return;
+          }
+          const text = await navigator.clipboard.readText();
+          if (text) pasteTerminalText(host, text);
+          else setTerminalStatus(id, "Clipboard empty");
+        } catch {
+          setTerminalStatus(id, "Clipboard read blocked");
+        }
+      }
+
+      async function copyTerminalSelection(id) {
+        const host = terminalHosts.get(id);
+        const selection = host?.term?.getSelection?.() || "";
+        if (!selection) {
+          setTerminalStatus(id, "No selection");
+          return;
+        }
+        try {
+          await navigator.clipboard.writeText(selection);
+          setTerminalStatus(id, "Copied");
+        } catch {
+          setTerminalStatus(id, "Clipboard write blocked");
+        }
+      }
+
+      async function uploadTerminalClipboardBlob(id, blob, name, mediaType = blob?.type || "") {
+        const host = terminalHosts.get(id);
+        if (!host?.canInput || terminalHubSocket?.readyState !== WebSocket.OPEN) {
+          setTerminalStatus(id, "Live control required");
+          return;
+        }
+        if (!canUploadTerminalClipboardFile(id)) {
+          setTerminalStatus(id, "File paste requires Sandbox");
+          return;
+        }
+        if (!blob || blob.size <= 0) {
+          setTerminalStatus(id, "Clipboard empty");
+          return;
+        }
+        if (blob.size > 10 * 1024 * 1024) {
+          setTerminalStatus(id, "Clipboard file too large");
+          return;
+        }
+        setTerminalStatus(id, `Uploading ${name || "clipboard"}`);
+        const response = await fetch(
+          `/api/interactive-sessions/${encodeURIComponent(id)}/clipboard`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": mediaType || blob.type || "application/octet-stream",
+              "x-clipboard-name": encodeURIComponent(name || clipboardName(mediaType)),
+            },
+            body: blob,
+          },
+        );
+        if (!response.ok) {
+          setTerminalStatus(id, `Paste failed (${response.status})`);
+          return;
+        }
+        const result = await response.json();
+        const path = String(result.path || "");
+        setTerminalStatus(id, path ? `Pasted ${result.name || "file"}` : "Paste done");
+        if (path) pasteTerminalText(host, path);
+      }
+
+      function canUploadTerminalClipboardFile(id) {
+        const session = sessionItems().find(
+          (item) => item.kind === "interactive" && item.id === id,
+        );
+        return (
+          session?.canControl === true &&
+          typeof session.leaseId === "string" &&
+          session.leaseId.startsWith("sandbox:")
+        );
+      }
+
+      function pasteTerminalText(host, text) {
+        if (!host?.canInput) return;
+        if (typeof host.term?.paste === "function") {
+          host.term.paste(text);
+          return;
+        }
+        sendTerminalInput(host, text);
+      }
+
+      function clipboardName(mediaType) {
+        return `clipboard-${Date.now()}${clipboardExtension(mediaType)}`;
+      }
+
+      function clipboardExtension(mediaType) {
+        return (
+          {
+            "image/png": ".png",
+            "image/jpeg": ".jpg",
+            "image/gif": ".gif",
+            "image/webp": ".webp",
+            "text/plain": ".txt",
+            "text/markdown": ".md",
+            "application/json": ".json",
+            "application/pdf": ".pdf",
+          }[
+            String(mediaType || "")
+              .toLowerCase()
+              .split(";")[0]
+          ] || ".bin"
+        );
+      }
+
       function scheduleTerminalResubscribe(id) {
         setTimeout(() => {
           const host = terminalHosts.get(id);
@@ -2602,6 +2779,9 @@
         }
         if (host?.dataSub && typeof host.dataSub.dispose === "function") host.dataSub.dispose();
         if (host?.fit && typeof host.fit.dispose === "function") host.fit.dispose();
+        if (host?.pasteHandler) {
+          host.mount?.removeEventListener?.("paste", host.pasteHandler, { capture: true });
+        }
         if (host?.term && typeof host.term.dispose === "function") host.term.dispose();
         terminalHosts.delete(id);
         if (![...terminalHosts.values()].some((item) => item.live)) {
@@ -2807,6 +2987,9 @@
           interactiveSessionAction(target.dataset.interactiveDenyControl, "deny_control");
         if (target.dataset.interactiveRevokeControl)
           interactiveSessionAction(target.dataset.interactiveRevokeControl, "revoke_control");
+        if (target.dataset.terminalCopy) copyTerminalSelection(target.dataset.terminalCopy);
+        if (target.dataset.terminalPasteText) pasteClipboardText(target.dataset.terminalPasteText);
+        if (target.dataset.terminalPasteFile) pasteClipboardFile(target.dataset.terminalPasteFile);
         if (target.dataset.createRef) createRefCard(Number(target.dataset.createRef));
         if (target.dataset.remove === "allow") removeAllow(target.dataset.value);
         if (target.dataset.remove === "repo") removeRepo(target.dataset.value);

--- a/src/index.ts
+++ b/src/index.ts
@@ -489,6 +489,7 @@ const sessionCookie = "crabyard_session";
 const oauthStateCookie = "crabyard_oauth_state";
 const bootstrapSessionSeconds = 60 * 60;
 const githubSessionSeconds = 60 * 15;
+const terminalClipboardMaxBytes = 10 * 1024 * 1024;
 const lanes = ["Todo", "Running", "Human Review", "Done"];
 const preferredRepo = "openclaw/openclaw";
 const sandboxLeasePrefix = "sandbox:";
@@ -783,6 +784,22 @@ async function api(request: Request, env: RuntimeEnv): Promise<Response> {
       env,
       user,
       decodeURIComponent(interactivePtyMatch[1] ?? ""),
+    );
+  }
+
+  const interactiveClipboardMatch = url.pathname.match(
+    /^\/api\/interactive-sessions\/([^/]+)\/clipboard$/,
+  );
+  if (request.method === "POST" && interactiveClipboardMatch) {
+    requireRole(user, "viewer");
+    return json(
+      await uploadInteractiveSessionClipboard(
+        request,
+        env,
+        user,
+        decodeURIComponent(interactiveClipboardMatch[1] ?? ""),
+      ),
+      { status: 201 },
     );
   }
 
@@ -1605,6 +1622,41 @@ async function interactiveTerminalHub(
   return new Response(null, { status: 101, webSocket: client });
 }
 
+async function writeTerminalClipboardFile(
+  env: RuntimeEnv,
+  user: User,
+  session: InteractiveSession,
+  bytes: Uint8Array,
+  rawName: unknown,
+  rawMediaType: unknown,
+): Promise<{ path: string; name: string; mediaType: string; byteCount: number }> {
+  if (!session.leaseId?.startsWith(sandboxLeasePrefix) || !env.SANDBOX) {
+    throw serviceUnavailable("clipboard file paste requires a Cloudflare Sandbox session");
+  }
+  if (!bytes.byteLength || bytes.byteLength > terminalClipboardMaxBytes) {
+    throw badRequest(
+      `clipboard file exceeds ${Math.floor(terminalClipboardMaxBytes / 1024 / 1024)} MiB`,
+    );
+  }
+  const mediaType = clean(rawMediaType || "application/octet-stream", 120);
+  const name = safeClipboardFilename(rawName, mediaType);
+  const sandboxId =
+    session.leaseId.slice(sandboxLeasePrefix.length) || sandboxIdForSession(session.id);
+  const sandbox = getSandbox(env.SANDBOX, sandboxId);
+  const directory = `${sandboxWorkdir(session.id)}/.crabyard/clipboard`;
+  const path = `${directory}/${Date.now()}-${crypto.randomUUID().slice(0, 8)}-${name}`;
+  await sandbox.mkdir(directory, { recursive: true });
+  await sandbox.writeFile(path, base64FromBytes(bytes), { encoding: "base64" });
+  await appendInteractiveSessionEvent(
+    env,
+    session.id,
+    user,
+    `Clipboard file pasted: ${path}`,
+    Date.now(),
+  );
+  return { path, name, mediaType, byteCount: bytes.byteLength };
+}
+
 async function subscribeTerminalHubSession(
   request: Request,
   env: RuntimeEnv,
@@ -1821,6 +1873,48 @@ async function markInteractiveTerminalConnected(
     .where("status", "in", ["ready", "attached", "detached"])
     .execute();
   if (user) await appendInteractiveSessionEvent(env, id, user, message, now);
+}
+
+async function uploadInteractiveSessionClipboard(
+  request: Request,
+  env: RuntimeEnv,
+  user: User,
+  id: string,
+): Promise<{ path: string; name: string; mediaType: string; byteCount: number }> {
+  if (!(await canControlInteractiveSessionById(env, user, id))) {
+    throw forbidden("terminal control has not been granted");
+  }
+  const session = await readInteractiveSession(env, id);
+  if (!session) throw notFound("interactive session not found");
+  if (["expired", "failed", "stopped"].includes(session.status)) {
+    throw badRequest(`session is ${session.status}`);
+  }
+  const bytes = await readClipboardUploadBytes(request);
+  return writeTerminalClipboardFile(
+    env,
+    user,
+    session,
+    bytes,
+    decodeHeaderValue(request.headers.get("x-clipboard-name")),
+    request.headers.get("content-type") || "application/octet-stream",
+  );
+}
+
+async function readClipboardUploadBytes(request: Request): Promise<Uint8Array> {
+  const contentLength = Number(request.headers.get("content-length") || "0");
+  if (Number.isFinite(contentLength) && contentLength > terminalClipboardMaxBytes) {
+    throw badRequest(
+      `clipboard file exceeds ${Math.floor(terminalClipboardMaxBytes / 1024 / 1024)} MiB`,
+    );
+  }
+  const bytes = new Uint8Array(await request.arrayBuffer());
+  if (!bytes.byteLength) throw badRequest("clipboard file is empty");
+  if (bytes.byteLength > terminalClipboardMaxBytes) {
+    throw badRequest(
+      `clipboard file exceeds ${Math.floor(terminalClipboardMaxBytes / 1024 / 1024)} MiB`,
+    );
+  }
+  return bytes;
 }
 
 function terminalInputGrant(
@@ -4324,6 +4418,54 @@ function clean(value: unknown, max: number): string {
   return String(value ?? "")
     .trim()
     .slice(0, max);
+}
+
+function decodeHeaderValue(value: string | null): string {
+  if (!value) return "";
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function base64FromBytes(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function safeClipboardFilename(value: unknown, mediaType: string): string {
+  const raw =
+    String(value ?? "")
+      .split(/[\\/]/)
+      .pop() || "";
+  const base = clean(raw || `clipboard${clipboardExtension(mediaType)}`, 90)
+    .replace(/[^A-Za-z0-9._-]/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+/g, "-");
+  const fallback = `clipboard${clipboardExtension(mediaType)}`;
+  const name = base || fallback;
+  return name.includes(".") ? name : `${name}${clipboardExtension(mediaType)}`;
+}
+
+function clipboardExtension(mediaType: string): string {
+  const normalized = (mediaType.toLowerCase().split(";")[0] ?? "").trim();
+  return (
+    {
+      "image/png": ".png",
+      "image/jpeg": ".jpg",
+      "image/gif": ".gif",
+      "image/webp": ".webp",
+      "text/plain": ".txt",
+      "text/markdown": ".md",
+      "application/json": ".json",
+      "application/pdf": ".pdf",
+    }[normalized] || ".bin"
+  );
 }
 
 function joinUrl(base: string, path: string): string {


### PR DESCRIPTION
## Summary
- add terminal copy/paste controls for live Codex sessions
- add authenticated clipboard upload endpoint for Cloudflare Sandbox sessions
- document clipboard upload behavior and Sandbox-only file paste

## Validation
- pnpm test
- pnpm check
- pnpm build
- codex-review clean after fixing upload transport and backend gating findings
