### PR TITLE
feat: add editable Codex session grid layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add an editable, persisted Codex session grid with column density, compact mode, drag reorder, and per-tile sizing.
 - Add browser clipboard copy/paste controls for live Codex terminals, including image/file paste into Cloudflare Sandbox workspaces.
 - Add a multiplexed binary terminal WebSocket protocol for Codex session grids and shared viewers.
 - Add read-only Codex session share links with owner-approved terminal control requests.

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -86,6 +86,7 @@ Attach opens a fullscreen Ghostty WASM grid. Current behavior:
 - Replays D1 event logs into the terminal surface while a live PTY is unavailable.
 - Falls back to a text terminal if Ghostty cannot initialize.
 - Copies terminal selection, pastes clipboard text when the viewer has writable control, and uploads clipboard images/files for Cloudflare Sandbox sessions.
+- Persists local grid layout preferences: auto or 1-10 columns, compact mode, drag reorder, and per-tile width/height sizing.
 - Supports focused fullscreen card view.
 - Supports focused share URLs with public read-only event scrollback and owner-approved writable control requests for signed-in viewers.
 

--- a/src/app.html
+++ b/src/app.html
@@ -828,22 +828,67 @@
         flex-wrap: wrap;
         justify-content: flex-end;
       }
+      .session-tools select {
+        width: auto;
+        min-width: 82px;
+        min-height: 34px;
+        padding: 0 28px 0 10px;
+        font-size: 12px;
+        font-weight: 700;
+      }
+      .session-tools label {
+        min-height: 34px;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+        padding: 0 10px;
+        color: var(--ink);
+        font-size: 12px;
+        font-weight: 700;
+        box-shadow: var(--shadow);
+      }
+      .session-tools input[type="checkbox"] {
+        width: 14px;
+        height: 14px;
+        min-height: 0;
+        padding: 0;
+        box-shadow: none;
+      }
       .session-panel .panel-body {
         display: grid;
         min-height: 0;
         padding: 14px;
       }
       .session-grid {
+        --session-gap: 12px;
+        --session-row-height: 180px;
+        --session-cell-min: 360px;
         min-height: 0;
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
-        gap: 12px;
+        grid-template-columns: repeat(auto-fit, minmax(min(380px, 100%), 1fr));
+        grid-auto-flow: row;
+        grid-auto-rows: minmax(var(--session-row-height), auto);
+        gap: var(--session-gap);
+      }
+      .session-grid.fixed-columns {
+        grid-template-columns: repeat(var(--session-columns), minmax(0, 1fr));
+      }
+      .session-grid.layout-editing {
+        user-select: none;
+      }
+      .session-grid.compact-layout {
+        --session-gap: 8px;
+        --session-row-height: 145px;
+        --session-cell-min: 280px;
       }
       .session-grid.focus-mode {
         grid-template-columns: 1fr;
       }
       .session-cell {
-        min-height: 360px;
+        min-height: var(--session-cell-min);
         min-width: 0;
         display: grid;
         grid-template-rows: auto 1fr auto;
@@ -851,9 +896,30 @@
         border-radius: 8px;
         overflow: hidden;
         background: var(--panel-2);
+        transition:
+          border-color 0.12s ease,
+          box-shadow 0.12s ease,
+          opacity 0.12s ease;
       }
       .session-grid.focus-mode .session-cell {
         min-height: calc(100vh - 158px);
+      }
+      .session-cell.dragging {
+        opacity: 0.48;
+      }
+      .session-cell.drop-target {
+        border-color: var(--primary);
+        box-shadow: 0 0 0 2px rgb(124 138 219 / 0.24);
+      }
+      .session-grid.compact-layout .session-cell-head {
+        padding: 8px 10px;
+      }
+      .session-grid.compact-layout .session-meta {
+        display: none;
+      }
+      .session-grid.compact-layout .session-cell-foot {
+        min-height: 28px;
+        padding: 5px 10px;
       }
       .session-cell-head {
         display: grid;
@@ -891,6 +957,13 @@
         padding: 0 9px;
         font-size: 12px;
         font-weight: 700;
+      }
+      .session-controls button.session-drag {
+        cursor: grab;
+      }
+      .session-controls button.layout-control {
+        min-width: 30px;
+        padding: 0 7px;
       }
       .session-controls button.danger {
         color: #fca5a5;
@@ -1371,6 +1444,25 @@
             <p>Attach, watch, or take over live Codex CLI terminals.</p>
           </div>
           <div class="session-tools">
+            <label>
+              Columns
+              <select id="session-columns">
+                <option value="auto">Auto</option>
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
+                <option value="6">6</option>
+                <option value="7">7</option>
+                <option value="8">8</option>
+                <option value="9">9</option>
+                <option value="10">10</option>
+              </select>
+            </label>
+            <label><input id="session-compact" type="checkbox" /> Compact</label>
+            <button id="session-edit-layout">Edit layout</button>
+            <button id="session-reset-layout">Reset</button>
             <button id="show-all-sessions">Grid</button>
             <button class="icon" data-close="sessions-drawer" aria-label="Close sessions">
               <i data-lucide="x"></i>
@@ -1488,6 +1580,9 @@
       const terminalHosts = new Map();
       let terminalHubSocket = null;
       let terminalHubReconnectTimer = null;
+      const sessionLayoutStorageKey = "crabyard-session-layout-v1";
+      let sessionLayout = loadSessionLayout();
+      let draggedSessionId = null;
       const terminalMessageType = {
         hello: 1,
         welcome: 2,
@@ -1805,6 +1900,78 @@
         renderThemeToggle();
       }
 
+      function loadSessionLayout() {
+        const fallback = {
+          columns: "auto",
+          compact: false,
+          edit: false,
+          manualOrder: false,
+          order: [],
+          sizes: {},
+        };
+        try {
+          const saved = JSON.parse(localStorage.getItem(sessionLayoutStorageKey) || "null");
+          return normalizeSessionLayout(saved || fallback);
+        } catch {
+          return fallback;
+        }
+      }
+
+      function normalizeSessionLayout(value) {
+        const columns = ["auto", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"].includes(
+          String(value?.columns),
+        )
+          ? String(value.columns)
+          : "auto";
+        return {
+          columns,
+          compact: Boolean(value?.compact),
+          edit: false,
+          manualOrder: Boolean(value?.manualOrder),
+          order: Array.isArray(value?.order) ? value.order.map(String).slice(0, 200) : [],
+          sizes: typeof value?.sizes === "object" && value.sizes ? value.sizes : {},
+        };
+      }
+
+      function saveSessionLayout() {
+        try {
+          localStorage.setItem(
+            sessionLayoutStorageKey,
+            JSON.stringify({
+              columns: sessionLayout.columns,
+              compact: sessionLayout.compact,
+              manualOrder: sessionLayout.manualOrder,
+              order: sessionLayout.order,
+              sizes: sessionLayout.sizes,
+            }),
+          );
+        } catch {}
+      }
+
+      function resetSessionLayout() {
+        sessionLayout = {
+          columns: "auto",
+          compact: false,
+          edit: true,
+          manualOrder: false,
+          order: [],
+          sizes: {},
+        };
+        saveSessionLayout();
+        renderSessionGrid();
+      }
+
+      function moveSessionLayoutItem(sourceId, targetId) {
+        const ids = orderedSessionItems(sessionItems()).map((item) => item.id);
+        const sourceIndex = ids.indexOf(sourceId);
+        const targetIndex = ids.indexOf(targetId);
+        if (sourceIndex === -1 || targetIndex === -1) return;
+        ids.splice(sourceIndex, 1);
+        ids.splice(targetIndex, 0, sourceId);
+        sessionLayout.manualOrder = true;
+        sessionLayout.order = ids;
+      }
+
       function canMaintain() {
         return roleRank(state.user?.role) >= roleRank("maintainer");
       }
@@ -1922,6 +2089,7 @@
         const urlSessionId = findInteractiveSession(focusedSessionId) ? focusedSessionId : null;
         if (urlSessionId || !sharedToken) setSessionUrl(urlSessionId);
         openDrawer("sessions-drawer");
+        warmGhosttyModule();
         renderSessionGrid();
       }
 
@@ -1930,7 +2098,8 @@
         if (!grid) return;
         if (!document.getElementById("sessions-drawer").classList.contains("open")) return;
         const focusedSession = focusedSessionId ? findSessionItem(focusedSessionId) : null;
-        const sessions = focusedSession ? [focusedSession] : sessionItems();
+        const sessions = focusedSession ? [focusedSession] : orderedSessionItems(sessionItems());
+        applySessionLayoutControls(grid, Boolean(focusedSession));
         grid.classList.toggle("focus-mode", Boolean(focusedSession));
         document.getElementById("show-all-sessions").hidden = !focusedSession;
         if (!sessions.length) {
@@ -1941,17 +2110,22 @@
           return;
         }
         const ids = new Set(sessions.map((session) => session.id));
-        const sessionKey = `${focusedSession ? "focus" : "grid"}:${sessions
-          .map(sessionRenderKey)
-          .join("|")}`;
         disposeMissingTerminals(ids);
-        if (grid.dataset.sessionKey !== sessionKey) {
-          terminalEpoch += 1;
-          grid.innerHTML = sessions.map(renderSessionCell).join("");
-          grid.dataset.sessionKey = sessionKey;
-        } else {
-          for (const session of sessions) refreshSessionCell(session);
+        grid.querySelector(".session-empty")?.remove();
+        for (const session of sessions) {
+          let cell = grid.querySelector(`[data-session-cell="${CSS.escape(session.id)}"]`);
+          if (!cell) {
+            const template = document.createElement("template");
+            template.innerHTML = renderSessionCell(session);
+            cell = template.content.firstElementChild;
+          }
+          grid.appendChild(cell);
+          refreshSessionCell(session);
         }
+        for (const cell of [...grid.querySelectorAll(".session-cell")]) {
+          if (!ids.has(cell.dataset.sessionCell)) cell.remove();
+        }
+        grid.dataset.sessionKey = focusedSession ? `focus:${focusedSession.id}` : "grid";
         requestAnimationFrame(hydrateSessionTerminals);
       }
 
@@ -1976,10 +2150,93 @@
         });
       }
 
-      function sessionRenderKey(session) {
-        return session.kind === "interactive"
-          ? `${session.id}:${session.status}:${session.leaseId || ""}:${session.attachUrl || ""}:${session.shareMode || ""}:${session.canControl ? "control" : "view"}:${session.controlRequestedBy || ""}:${session.controller || ""}`
-          : `${session.id}:${session.lane}:${session.run?.status || ""}`;
+      function orderedSessionItems(items) {
+        const currentIds = new Set(items.map((item) => item.id));
+        for (const id of Object.keys(sessionLayout.sizes)) {
+          if (!currentIds.has(id)) delete sessionLayout.sizes[id];
+        }
+        if (!sessionLayout.manualOrder) {
+          sessionLayout.order = [];
+          return items;
+        }
+        sessionLayout.order = [
+          ...sessionLayout.order.filter((id) => currentIds.has(id)),
+          ...items.map((item) => item.id).filter((id) => !sessionLayout.order.includes(id)),
+        ];
+        const rank = new Map(sessionLayout.order.map((id, index) => [id, index]));
+        return [...items].sort(
+          (left, right) =>
+            (rank.get(left.id) ?? Number.MAX_SAFE_INTEGER) -
+            (rank.get(right.id) ?? Number.MAX_SAFE_INTEGER),
+        );
+      }
+
+      function applySessionLayoutControls(grid, focused) {
+        const columns = document.getElementById("session-columns");
+        const compact = document.getElementById("session-compact");
+        const edit = document.getElementById("session-edit-layout");
+        const reset = document.getElementById("session-reset-layout");
+        if (columns) {
+          columns.value = focused ? "1" : sessionLayout.columns;
+          columns.disabled = focused;
+        }
+        if (compact) {
+          compact.checked = sessionLayout.compact;
+          compact.disabled = focused;
+        }
+        if (edit) {
+          edit.textContent = sessionLayout.edit && !focused ? "Done editing" : "Edit layout";
+          edit.classList.toggle("primary", sessionLayout.edit && !focused);
+          edit.disabled = focused;
+        }
+        if (reset) reset.disabled = focused;
+        const fixedColumns = !focused && sessionLayout.columns !== "auto";
+        grid.classList.toggle("fixed-columns", fixedColumns);
+        grid.classList.toggle("compact-layout", sessionLayout.compact && !focused);
+        grid.classList.toggle("layout-editing", sessionLayout.edit && !focused);
+        grid.style.setProperty("--session-columns", fixedColumns ? sessionLayout.columns : "1");
+      }
+
+      function renderSessionLayoutControls(session) {
+        if (focusedSessionId || !sessionLayout.edit) return "";
+        const size = sessionTileSize(session.id);
+        const id = escapeHtml(session.id);
+        return `<button class="session-drag layout-control" draggable="true" data-session-drag="${id}" title="Drag to rearrange">Move</button><button class="layout-control" data-session-grow="${id}" title="Cycle tile width">W${size.w}</button><button class="layout-control" data-session-tall="${id}" title="Cycle tile height">H${size.h}</button>`;
+      }
+
+      function sessionTileSize(id) {
+        const size = sessionLayout.sizes[id] || {};
+        return {
+          w: Math.min(4, Math.max(1, Number(size.w) || 1)),
+          h: Math.min(3, Math.max(1, Number(size.h) || 1)),
+        };
+      }
+
+      function applySessionCellLayout(cell, id) {
+        const size = sessionTileSize(id);
+        cell.draggable = sessionLayout.edit && !focusedSessionId;
+        cell.classList.toggle("layout-editing", cell.draggable);
+        if (focusedSessionId) {
+          cell.style.gridColumn = "";
+          cell.style.gridRow = "";
+          cell.style.minHeight = "";
+          return;
+        }
+        cell.style.gridColumn = `span ${Math.min(size.w, sessionColumnLimit(cell))}`;
+        cell.style.gridRow = `span ${size.h}`;
+        cell.style.minHeight = `calc(var(--session-cell-min) * ${size.h} + var(--session-gap) * ${size.h - 1})`;
+      }
+
+      function sessionColumnLimit(cell) {
+        const fixed = Number(sessionLayout.columns);
+        if (Number.isFinite(fixed) && fixed > 0) return fixed;
+        const grid = cell.parentElement;
+        const style = grid ? getComputedStyle(grid) : null;
+        const gap = Number.parseFloat(style?.columnGap || "0") || 0;
+        const min =
+          Number.parseFloat(style?.getPropertyValue("--session-cell-min") || "380") || 380;
+        const width = grid?.clientWidth || min;
+        return Math.max(1, Math.floor((width + gap) / (min + gap)));
       }
 
       function renderSessionCell(session) {
@@ -1989,14 +2246,16 @@
             : renderCardSessionControls(session);
         const focusButton = focusedSessionId
           ? `<button data-session-unfocus>Grid</button>`
-          : `<button data-session-focus="${session.id}">Full</button>`;
-        return `<article class="session-cell">
+          : `<button data-session-focus="${escapeHtml(session.id)}">Full</button>`;
+        const layoutControls = renderSessionLayoutControls(session);
+        return `<article class="session-cell" data-session-cell="${escapeHtml(session.id)}">
           <header class="session-cell-head">
             <div class="session-cell-title">
               <strong data-session-title="${escapeHtml(session.id)}" title="${escapeHtml(session.title)}">${escapeHtml(session.title)}</strong>
               <div class="session-meta" data-session-meta="${escapeHtml(session.id)}">${sessionMetaHtml(session)}</div>
             </div>
             <div class="session-controls">
+              ${layoutControls}
               ${focusButton}
               ${controls}
             </div>
@@ -2144,15 +2403,28 @@
 
       function refreshSessionCell(session) {
         const id = CSS.escape(session.id);
+        const cell = document.querySelector(`[data-session-cell="${id}"]`);
         const title = document.querySelector(`[data-session-title="${id}"]`);
         const meta = document.querySelector(`[data-session-meta="${id}"]`);
         const runtime = document.querySelector(`[data-session-runtime-label="${id}"]`);
+        const controls = cell?.querySelector(".session-controls");
+        if (cell) applySessionCellLayout(cell, session.id);
         if (title) {
           title.textContent = session.title;
           title.title = session.title;
         }
         if (meta) meta.innerHTML = sessionMetaHtml(session);
         if (runtime) runtime.textContent = runtimeCapabilityLabel(session);
+        if (controls) {
+          const focusButton = focusedSessionId
+            ? `<button data-session-unfocus>Grid</button>`
+            : `<button data-session-focus="${escapeHtml(session.id)}">Full</button>`;
+          const sessionControls =
+            session.kind === "interactive"
+              ? renderInteractiveSessionControls(session)
+              : renderCardSessionControls(session);
+          controls.innerHTML = `${renderSessionLayoutControls(session)}${focusButton}${sessionControls}`;
+        }
       }
 
       async function hydrateSessionTerminals() {
@@ -2166,7 +2438,9 @@
       async function mountGhosttyTerminal(session, mount) {
         const existing = terminalHosts.get(session.id);
         const text = terminalText(session);
-        if (existing?.mount === mount) {
+        const live = shouldConnectLiveTerminal(session);
+        const canInput = canSendTerminalInput(session);
+        if (existing?.mount === mount && existing.live === live) {
           if (existing.live) {
             syncTerminalInputState(session, existing, existing.term);
             if (existing.terminalExited) {
@@ -2202,8 +2476,6 @@
           if (isStaleTerminalMount(session, mount, mountEpoch)) return;
           if (!mod?.Terminal) throw new Error("Ghostty module missing Terminal");
           mount.innerHTML = "";
-          const live = shouldConnectLiveTerminal(session);
-          const canInput = canSendTerminalInput(session);
           const term = new mod.Terminal({
             disableStdin: !canInput,
             fontSize: focusedSessionId === session.id ? 14 : 13,
@@ -2723,6 +2995,12 @@
         return ghosttyModulePromise;
       }
 
+      function warmGhosttyModule() {
+        void loadGhosttyModule().catch((error) => {
+          console.warn("Ghostty preload failed", error);
+        });
+      }
+
       function terminalText(session) {
         if (session.kind === "interactive") {
           const header = [
@@ -2969,6 +3247,26 @@
           if (!sharedToken) setSessionUrl(null);
           renderSessionGrid();
         }
+        if (target.id === "session-edit-layout") {
+          sessionLayout.edit = !sessionLayout.edit;
+          saveSessionLayout();
+          renderSessionGrid();
+        }
+        if (target.id === "session-reset-layout") resetSessionLayout();
+        if (target.dataset.sessionGrow) {
+          const id = target.dataset.sessionGrow;
+          const size = sessionTileSize(id);
+          sessionLayout.sizes[id] = { ...size, w: size.w >= 4 ? 1 : size.w + 1 };
+          saveSessionLayout();
+          renderSessionGrid();
+        }
+        if (target.dataset.sessionTall) {
+          const id = target.dataset.sessionTall;
+          const size = sessionTileSize(id);
+          sessionLayout.sizes[id] = { ...size, h: size.h >= 3 ? 1 : size.h + 1 };
+          saveSessionLayout();
+          renderSessionGrid();
+        }
         if (target.dataset.sessionDetails) openRunDetails(target.dataset.sessionDetails);
         if (target.dataset.sessionWatch) cardAction(target.dataset.sessionWatch, "watch");
         if (target.dataset.sessionTakeover) cardAction(target.dataset.sessionTakeover, "takeover");
@@ -3024,6 +3322,59 @@
           if (signedIn) logout();
           else void beginLogin();
         }
+      });
+
+      document.addEventListener("change", (event) => {
+        const target = event.target;
+        if (target?.id === "session-columns") {
+          sessionLayout.columns = target.value;
+          saveSessionLayout();
+          renderSessionGrid();
+        }
+        if (target?.id === "session-compact") {
+          sessionLayout.compact = target.checked;
+          saveSessionLayout();
+          renderSessionGrid();
+        }
+      });
+
+      document.addEventListener("dragstart", (event) => {
+        const cell = event.target?.closest?.(".session-cell");
+        if (!cell || !sessionLayout.edit || focusedSessionId) return;
+        draggedSessionId = cell.dataset.sessionCell;
+        cell.classList.add("dragging");
+        event.dataTransfer.effectAllowed = "move";
+        event.dataTransfer.setData("text/plain", draggedSessionId);
+      });
+
+      document.addEventListener("dragover", (event) => {
+        if (!draggedSessionId || !sessionLayout.edit) return;
+        const cell = event.target?.closest?.(".session-cell");
+        if (!cell || cell.dataset.sessionCell === draggedSessionId) return;
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "move";
+        document
+          .querySelectorAll(".session-cell.drop-target")
+          .forEach((item) => item.classList.remove("drop-target"));
+        cell.classList.add("drop-target");
+      });
+
+      document.addEventListener("drop", (event) => {
+        const targetCell = event.target?.closest?.(".session-cell");
+        if (!draggedSessionId || !targetCell || targetCell.dataset.sessionCell === draggedSessionId)
+          return;
+        event.preventDefault();
+        moveSessionLayoutItem(draggedSessionId, targetCell.dataset.sessionCell);
+        draggedSessionId = null;
+        saveSessionLayout();
+        renderSessionGrid();
+      });
+
+      document.addEventListener("dragend", () => {
+        draggedSessionId = null;
+        document
+          .querySelectorAll(".session-cell.dragging, .session-cell.drop-target")
+          .forEach((item) => item.classList.remove("dragging", "drop-target"));
       });
 
       document.addEventListener("keydown", (event) => {


### PR DESCRIPTION
## Summary
- add editable Codex session grid controls for columns, compact mode, drag reorder, and tile sizing
- preserve terminal mounts across grid rerenders while still remounting when a session becomes live
- document the new persisted grid preferences

## Proof
- pnpm test
- pnpm check
- pnpm build
- git diff --check
- browser automation: default sort updates until manual reorder, edit mode does not persist, narrow auto layout does not overflow
- codex-review clean: no accepted/actionable findings
