### PR TITLE
Add opt-in multiplayer mode for Codex sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Persist per-session GitHub OAuth credentials inside Cloudflare Sandbox terminals so `gh` and `git push` keep working after Codex starts.
+- Add opt-in multiplayer mode for interactive Codex sessions so submitted prompts are prefixed with the current actor.
 - Expand the Codex sessions grid to full available height when only one session is visible.
 - Pre-bake Cloudflare Sandbox images with Codex, pnpm, GitHub CLI, Crabbox, and common build/debug tools, plus a session diagnostics endpoint.
 - Trust the Cloudflare Sandbox workspace root as well as the checked-out repo so provisioned Codex sessions skip the directory trust prompt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Treat missing Cloudflare Sandbox terminal sessions as already removed before recreation so fresh Codex session provisioning can recover instead of failing with `Session 'terminal-...' not found`.
 - Persist per-session GitHub OAuth credentials inside Cloudflare Sandbox terminals so `gh` and `git push` keep working after Codex starts.
 - Add opt-in multiplayer mode for interactive Codex sessions so submitted prompts are prefixed with the current actor.
 - Expand the Codex sessions grid to full available height when only one session is visible.

--- a/docs/api.md
+++ b/docs/api.md
@@ -328,8 +328,8 @@ Actions:
 - `approve_control`: owner/maintainer, grant pending requester 30 minutes of writable terminal control.
 - `deny_control`: owner/maintainer, clear a pending control request.
 - `revoke_control`: owner/maintainer, revoke active delegated control.
-- `enable_multiplayer`: owner/maintainer, prefix submitted terminal prompts with the actor.
-- `disable_multiplayer`: owner/maintainer, stop prefixing submitted terminal prompts with the actor.
+- `enable_multiplayer`: session creator, prefix submitted terminal prompts with the actor.
+- `disable_multiplayer`: session creator, stop prefixing submitted terminal prompts with the actor.
 - `stop`: owner/maintainer, mark stopped.
 
 Response:

--- a/docs/api.md
+++ b/docs/api.md
@@ -328,6 +328,8 @@ Actions:
 - `approve_control`: owner/maintainer, grant pending requester 30 minutes of writable terminal control.
 - `deny_control`: owner/maintainer, clear a pending control request.
 - `revoke_control`: owner/maintainer, revoke active delegated control.
+- `enable_multiplayer`: owner/maintainer, prefix submitted terminal prompts with the actor.
+- `disable_multiplayer`: owner/maintainer, stop prefixing submitted terminal prompts with the actor.
 - `stop`: owner/maintainer, mark stopped.
 
 Response:

--- a/migrations/0013_interactive_session_multiplayer_mode.sql
+++ b/migrations/0013_interactive_session_multiplayer_mode.sql
@@ -1,0 +1,1 @@
+ALTER TABLE interactive_sessions ADD COLUMN multiplayer_mode INTEGER NOT NULL DEFAULT 0;

--- a/src/app.html
+++ b/src/app.html
@@ -282,6 +282,45 @@
         min-height: 44px;
         font-size: 15px;
       }
+      .dev-identity-panel {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+        box-shadow: var(--shadow);
+        display: grid;
+        grid-template-columns:
+          auto auto minmax(140px, 1fr) minmax(160px, 1fr) minmax(130px, auto)
+          auto;
+        gap: 10px;
+        align-items: end;
+        margin-bottom: 18px;
+        padding: 12px;
+      }
+      .dev-identity-panel[hidden] {
+        display: none;
+      }
+      .login-panel .dev-identity-panel {
+        grid-template-columns: 1fr;
+        margin-bottom: 0;
+      }
+      .dev-identity-title {
+        align-self: center;
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+      .dev-identity-presets {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+      .dev-identity-presets button {
+        min-height: 30px;
+        padding: 0 10px;
+        font-size: 12px;
+      }
       .login-footer {
         text-align: center;
         padding-top: 8px;
@@ -1395,6 +1434,7 @@
         }
         .toolbar,
         .status-strip,
+        .dev-identity-panel,
         .board,
         .run-layout,
         .form-grid,

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -1683,6 +1683,8 @@ function InteractiveSessionActions(props) {
   const canManage = session.canManage || canMaintain(props.state.user);
   const shareAction = session.shareMode === "link_read" ? "disable_share" : "share_link";
   const shareLabel = session.shareMode === "link_read" ? "Unshare" : "Share";
+  const multiplayerAction = session.multiplayerMode ? "disable_multiplayer" : "enable_multiplayer";
+  const multiplayerLabel = session.multiplayerMode ? "Solo input" : "Multiplayer";
   const handleShare = () => {
     if (shareAction === "disable_share")
       return props.interactiveSessionAction(session.id, shareAction);
@@ -1692,6 +1694,11 @@ function InteractiveSessionActions(props) {
     return (
       <>
         {canManage ? <button onClick={handleShare}>{shareLabel}</button> : null}
+        {canManage ? (
+          <button onClick={() => props.interactiveSessionAction(session.id, multiplayerAction)}>
+            {multiplayerLabel}
+          </button>
+        ) : null}
         {canManage ? (
           <button
             class="danger"
@@ -1710,6 +1717,11 @@ function InteractiveSessionActions(props) {
   return (
     <>
       {canManage ? <button onClick={handleShare}>{shareLabel}</button> : null}
+      {canManage ? (
+        <button onClick={() => props.interactiveSessionAction(session.id, multiplayerAction)}>
+          {multiplayerLabel}
+        </button>
+      ) : null}
       {session.canRequestControl && !session.sharedReadOnly && !stopped ? (
         <button onClick={() => props.interactiveSessionAction(session.id, "request_control")}>
           {session.controlRequestedBy ? "Control requested" : "Request control"}
@@ -1788,6 +1800,9 @@ function sessionStatus(session) {
     if (session.shareMode === "link_read" || session.sharedReadOnly) {
       return { label: "Shared", tone: "shared" };
     }
+    if (session.multiplayerMode) {
+      return { label: "Multiplayer", tone: "shared" };
+    }
     if (["ready", "attached", "detached"].includes(session.status)) {
       return { label: "Live", tone: "live" };
     }
@@ -1808,6 +1823,7 @@ function sessionFooterSummary(session) {
     if (seen) parts.push(`seen ${elapsed(seen)}`);
     if (session.status) parts.push(humanStatus(session.status));
     if (session.shareMode === "link_read" || session.sharedReadOnly) parts.push("shared");
+    if (session.multiplayerMode) parts.push("multiplayer");
     if (session.controller) parts.push(`control ${session.controller}`);
     if (session.controlRequestedBy) parts.push(`request ${session.controlRequestedBy}`);
     return parts.join(" · ");

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -1789,8 +1789,8 @@ function InteractiveSessionActions(props) {
   const multiplayerAction = session.multiplayerMode ? "disable_multiplayer" : "enable_multiplayer";
   const multiplayerLabel = session.multiplayerMode ? "Solo input" : "Multiplayer";
   const multiplayerTooltip = session.multiplayerMode
-    ? 'Multiplayer attribution is on. Submitted prompts are prepended with an <s n=""/> tag for the model.'
-    : 'Turn on multiplayer attribution. Submitted prompts will be prepended with an <s n=""/> tag for the model.';
+    ? 'Multiplayer attribution is on. Submitted prompts are prepended with a <sender name=""/> tag for the model.'
+    : 'Turn on multiplayer attribution. Submitted prompts will be prepended with a <sender name=""/> tag for the model.';
   const handleShare = () => {
     if (shareAction === "disable_share")
       return props.interactiveSessionAction(session.id, shareAction);

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -1789,8 +1789,8 @@ function InteractiveSessionActions(props) {
   const multiplayerAction = session.multiplayerMode ? "disable_multiplayer" : "enable_multiplayer";
   const multiplayerLabel = session.multiplayerMode ? "Solo input" : "Multiplayer";
   const multiplayerTooltip = session.multiplayerMode
-    ? 'Multiplayer attribution is on. Submitted prompts are prepended with a <sender name=""/> tag for the model.'
-    : 'Turn on multiplayer attribution. Submitted prompts will be prepended with a <sender name=""/> tag for the model.';
+    ? 'Multiplayer attribution is on. Submitted prompts are prepended with an <s n=""/> tag for the model.'
+    : 'Turn on multiplayer attribution. Submitted prompts will be prepended with an <s n=""/> tag for the model.';
   const handleShare = () => {
     if (shareAction === "disable_share")
       return props.interactiveSessionAction(session.id, shareAction);

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -1789,8 +1789,8 @@ function InteractiveSessionActions(props) {
   const multiplayerAction = session.multiplayerMode ? "disable_multiplayer" : "enable_multiplayer";
   const multiplayerLabel = session.multiplayerMode ? "Solo input" : "Multiplayer";
   const multiplayerTooltip = session.multiplayerMode
-    ? 'Multiplayer attribution is on. Submitted prompts are prepended with a <sender id="" name=""/> tag for the model.'
-    : 'Turn on multiplayer attribution. Submitted prompts will be prepended with a <sender id="" name=""/> tag for the model.';
+    ? 'Multiplayer attribution is on. Submitted prompts are prepended with a <sender name=""/> tag for the model.'
+    : 'Turn on multiplayer attribution. Submitted prompts will be prepended with a <sender name=""/> tag for the model.';
   const handleShare = () => {
     if (shareAction === "disable_share")
       return props.interactiveSessionAction(session.id, shareAction);

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -64,7 +64,11 @@ function App() {
   }, []);
   const [state, setState] = useState(() => initialState(initialSessionLink));
   const [signedIn, setSignedIn] = useState(false);
-  const [authMethods, setAuthMethods] = useState({ github: false, token: false });
+  const [authMethods, setAuthMethods] = useState({
+    github: false,
+    token: false,
+    devIdentity: false,
+  });
   const [loginMessage, setLoginMessage] = useState("");
   const [filter, setFilter] = useState("all");
   const [search, setSearch] = useState("");
@@ -279,7 +283,7 @@ function App() {
       setAuthMethods(methods);
       return methods;
     } catch {
-      const methods = { github: false, token: true };
+      const methods = { github: false, token: true, devIdentity: false };
       setAuthMethods(methods);
       return methods;
     }
@@ -469,6 +473,19 @@ function App() {
     }
   }
 
+  async function devIdentityLogin(identity) {
+    try {
+      await api("/api/login/dev", {
+        method: "POST",
+        body: identity,
+        authOptional: true,
+      });
+      await loadState();
+    } catch (error) {
+      setLoginMessage(String(error.message || error));
+    }
+  }
+
   async function logout() {
     try {
       sessionStorage.setItem(skipAutoGithubLoginKey, "1");
@@ -480,6 +497,7 @@ function App() {
 
   async function maybeAutoGithubLogin(methods = authMethodsRef.current) {
     if (signedInRef.current || autoLoginStarted.current || !methods?.github) return false;
+    if (methods.devIdentity) return false;
     if (methods.token && wantsTokenLoginBypass()) return false;
     const shared = sharedRef.current;
     if (shared.id && shared.token) return false;
@@ -777,6 +795,7 @@ function App() {
     openSessionGrid,
     beginLogin,
     tokenLogin,
+    devIdentityLogin,
     logout,
     setTheme,
     cardAction,
@@ -823,6 +842,7 @@ function CrabyardApp(props) {
         message={props.loginMessage}
         onGithub={props.beginLogin}
         onToken={props.tokenLogin}
+        onDevIdentity={props.devIdentityLogin}
       />
       <AppShell {...props} />
       <CardDrawer {...props} />
@@ -834,7 +854,14 @@ function CrabyardApp(props) {
   );
 }
 
-function LoginScreen({ hidden, authMethods, message, onGithub, onToken }) {
+const devIdentityPresets = [
+  { id: "admin-1", name: "Admin 1", role: "owner" },
+  { id: "admin-2", name: "Admin 2", role: "owner" },
+  { id: "user-1", name: "User 1", role: "maintainer" },
+  { id: "user-2", name: "User 2", role: "viewer" },
+];
+
+function LoginScreen({ hidden, authMethods, message, onGithub, onToken, onDevIdentity }) {
   const [token, setToken] = useState("");
   return (
     <section class="login-screen" hidden={hidden}>
@@ -875,6 +902,11 @@ function LoginScreen({ hidden, authMethods, message, onGithub, onToken }) {
             Use token
           </button>
         </div>
+        <DevIdentityPanel
+          hidden={!authMethods.devIdentity}
+          user={null}
+          onDevIdentity={onDevIdentity}
+        />
         <div class={`banner ${message ? "show" : ""}`}>{message}</div>
         <div class="login-footer">
           <a href="/docs/">Documentation</a>
@@ -992,8 +1024,78 @@ function AppShell(props) {
             {userLabel}
           </button>
         </section>
+        <DevIdentityPanel
+          hidden={!props.authMethods.devIdentity || !props.signedIn}
+          user={user}
+          onDevIdentity={props.devIdentityLogin}
+        />
         <Board {...props} />
       </main>
+    </div>
+  );
+}
+
+function DevIdentityPanel({ hidden, user, onDevIdentity }) {
+  const currentId = user?.subject?.startsWith("dev:")
+    ? user.subject.slice("dev:".length)
+    : user?.login || "admin-1";
+  const currentName = user?.name || user?.login || "Admin 1";
+  const currentRole = user?.role || "owner";
+  const [id, setId] = useState(currentId);
+  const [name, setName] = useState(currentName);
+  const [role, setRole] = useState(currentRole);
+
+  useEffect(() => {
+    if (hidden) return;
+    setId(currentId);
+    setName(currentName);
+    setRole(currentRole);
+  }, [hidden, currentId, currentName, currentRole]);
+
+  async function submit(identity) {
+    setId(identity.id);
+    setName(identity.name);
+    setRole(identity.role);
+    await onDevIdentity(identity);
+  }
+
+  return (
+    <div
+      class="dev-identity-panel"
+      hidden={hidden}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter") return;
+        event.preventDefault();
+        void submit({ id, name, role });
+      }}
+    >
+      <div class="dev-identity-title">Dev identity</div>
+      <div class="dev-identity-presets">
+        {devIdentityPresets.map((preset) => (
+          <button type="button" onClick={() => void submit(preset)}>
+            {preset.name}
+          </button>
+        ))}
+      </div>
+      <label>
+        ID
+        <input value={id} onInput={(event) => setId(event.currentTarget.value)} />
+      </label>
+      <label>
+        Name
+        <input value={name} onInput={(event) => setName(event.currentTarget.value)} />
+      </label>
+      <label>
+        Role
+        <select value={role} onInput={(event) => setRole(event.currentTarget.value)}>
+          <option value="owner">Owner</option>
+          <option value="maintainer">Maintainer</option>
+          <option value="viewer">Viewer</option>
+        </select>
+      </label>
+      <button class="primary" type="button" onClick={() => void submit({ id, name, role })}>
+        Apply
+      </button>
     </div>
   );
 }

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -1685,6 +1685,9 @@ function InteractiveSessionActions(props) {
   const shareLabel = session.shareMode === "link_read" ? "Unshare" : "Share";
   const multiplayerAction = session.multiplayerMode ? "disable_multiplayer" : "enable_multiplayer";
   const multiplayerLabel = session.multiplayerMode ? "Solo input" : "Multiplayer";
+  const multiplayerTooltip = session.multiplayerMode
+    ? 'Multiplayer attribution is on. Submitted prompts are prepended with a <sender id="" name=""/> tag for the model.'
+    : 'Turn on multiplayer attribution. Submitted prompts will be prepended with a <sender id="" name=""/> tag for the model.';
   const handleShare = () => {
     if (shareAction === "disable_share")
       return props.interactiveSessionAction(session.id, shareAction);
@@ -1695,7 +1698,11 @@ function InteractiveSessionActions(props) {
       <>
         {canManage ? <button onClick={handleShare}>{shareLabel}</button> : null}
         {canManage ? (
-          <button onClick={() => props.interactiveSessionAction(session.id, multiplayerAction)}>
+          <button
+            aria-pressed={session.multiplayerMode}
+            title={multiplayerTooltip}
+            onClick={() => props.interactiveSessionAction(session.id, multiplayerAction)}
+          >
             {multiplayerLabel}
           </button>
         ) : null}
@@ -1718,7 +1725,11 @@ function InteractiveSessionActions(props) {
     <>
       {canManage ? <button onClick={handleShare}>{shareLabel}</button> : null}
       {canManage ? (
-        <button onClick={() => props.interactiveSessionAction(session.id, multiplayerAction)}>
+        <button
+          aria-pressed={session.multiplayerMode}
+          title={multiplayerTooltip}
+          onClick={() => props.interactiveSessionAction(session.id, multiplayerAction)}
+        >
           {multiplayerLabel}
         </button>
       ) : null}

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -1783,6 +1783,7 @@ function InteractiveSessionActions(props) {
   if (String(session.id).startsWith("LOCAL-")) return null;
   const stopped = isDeadInteractiveSession(session);
   const canManage = session.canManage || canMaintain(props.state.user);
+  const canChangeMultiplayer = Boolean(session.canChangeMultiplayer);
   const shareAction = session.shareMode === "link_read" ? "disable_share" : "share_link";
   const shareLabel = session.shareMode === "link_read" ? "Unshare" : "Share";
   const multiplayerAction = session.multiplayerMode ? "disable_multiplayer" : "enable_multiplayer";
@@ -1799,7 +1800,7 @@ function InteractiveSessionActions(props) {
     return (
       <>
         {canManage ? <button onClick={handleShare}>{shareLabel}</button> : null}
-        {canManage ? (
+        {canChangeMultiplayer ? (
           <button
             aria-pressed={session.multiplayerMode}
             title={multiplayerTooltip}
@@ -1826,7 +1827,7 @@ function InteractiveSessionActions(props) {
   return (
     <>
       {canManage ? <button onClick={handleShare}>{shareLabel}</button> : null}
-      {canManage ? (
+      {canChangeMultiplayer ? (
         <button
           aria-pressed={session.multiplayerMode}
           title={multiplayerTooltip}

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -169,6 +169,7 @@ export function terminalText(session) {
     if (session.shareMode === "link_read" && !session.sharedReadOnly) {
       header.push(`share read-only link ${session.shareTokenPreview || "enabled"}`);
     }
+    if (session.multiplayerMode) header.push("multiplayer mode");
     if (session.controlRequestedBy)
       header.push(`control requested by ${session.controlRequestedBy}`);
     if (session.controller) header.push(`controller ${session.controller}`);
@@ -248,6 +249,7 @@ export function optimisticInteractiveSession(data, owner) {
     controller: null,
     controlGrantedAt: null,
     controlExpiresAt: null,
+    multiplayerMode: false,
     canControl: true,
     canManage: true,
     canRequestControl: false,
@@ -293,6 +295,7 @@ export function linkedInteractiveSessionPlaceholder(id, options = {}) {
     controller: null,
     controlGrantedAt: null,
     controlExpiresAt: null,
+    multiplayerMode: false,
     canControl: false,
     canManage: false,
     canRequestControl: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,12 @@ import {
   encodeTerminalFrame,
 } from "./terminal-protocol";
 import {
+  attributedTerminalInputPayloads,
+  newTerminalInputState,
+  terminalSubmittedLine,
+  type TerminalInputState,
+} from "./terminal-multiplayer";
+import {
   APP_HTML,
   GHOSTTY_BROWSER_EXTERNAL_JS,
   GHOSTTY_WEB_JS,
@@ -291,8 +297,6 @@ type TerminalHubSubscription = {
   canInput: () => Promise<boolean>;
   markClosing: (reason: string) => void;
   viewCheck: ReturnType<typeof setInterval> | null;
-  inputLine: string;
-  inputControlSequence: "escape" | "csi" | "osc" | "oscEscape" | null;
   cols: number;
   rows: number;
 };
@@ -506,6 +510,7 @@ type CompilableQuery = {
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+const terminalInputStates = new Map<string, TerminalInputState>();
 const sessionCookie = "crabyard_session";
 const oauthStateCookie = "crabyard_oauth_state";
 const bootstrapSessionSeconds = 60 * 60;
@@ -1951,8 +1956,6 @@ async function subscribeTerminalHubSession(
       canInput,
       markClosing,
       viewCheck,
-      inputLine: "",
-      inputControlSequence: null,
       cols,
       rows,
     });
@@ -2665,7 +2668,7 @@ async function multiplayerTerminalInputPayloads(
   user: User | null,
   payload: Uint8Array,
 ): Promise<Uint8Array[]> {
-  const submitted = terminalSubmittedLine(subscription, payload);
+  const submitted = terminalSubmittedLine(terminalInputState(subscription.session.id), payload);
   if (!user || !submitted || !submitted.text.trim()) {
     return [payload];
   }
@@ -2678,10 +2681,16 @@ async function multiplayerTerminalInputPayloads(
     return [payload];
   }
 
-  const sender = terminalSenderTag(user);
-  const attributed = `${sender} ${terminalSingleLineInput(submitted.text)}${submitted.eol}`;
-  const chunks = submitted.replaceCurrentLine ? ["\x15", ...attributed] : [...attributed];
-  return chunks.map((chunk) => encoder.encode(chunk));
+  return attributedTerminalInputPayloads(user, submitted);
+}
+
+function terminalInputState(sessionId: string): TerminalInputState {
+  let state = terminalInputStates.get(sessionId);
+  if (!state) {
+    state = newTerminalInputState();
+    terminalInputStates.set(sessionId, state);
+  }
+  return state;
 }
 
 async function readInteractiveSessionMultiplayerMode(
@@ -2699,109 +2708,6 @@ async function readInteractiveSessionMultiplayerMode(
   } catch {
     return fallback;
   }
-}
-
-function terminalSubmittedLine(
-  subscription: TerminalHubSubscription,
-  payload: Uint8Array,
-): { text: string; eol: string; replaceCurrentLine: boolean } | null {
-  const text = decoder.decode(payload);
-  if (text === "\r" || text === "\n") {
-    const line = subscription.inputLine;
-    subscription.inputLine = "";
-    return { text: line, eol: text, replaceCurrentLine: true };
-  }
-
-  if (!subscription.inputLine) {
-    const eol = text.endsWith("\r") ? "\r" : text.endsWith("\n") ? "\n" : "";
-    const line = eol ? text.slice(0, -1) : "";
-    if (eol && isPlainTerminalText(line)) {
-      return { text: line, eol, replaceCurrentLine: false };
-    }
-  }
-
-  updateTerminalInputLine(subscription, text);
-  return null;
-}
-
-function updateTerminalInputLine(subscription: TerminalHubSubscription, text: string): void {
-  for (const char of text) {
-    if (subscription.inputControlSequence) {
-      subscription.inputControlSequence = nextTerminalControlSequenceState(
-        subscription.inputControlSequence,
-        char,
-      );
-      continue;
-    }
-    if (char === "\x1b") {
-      subscription.inputControlSequence = "escape";
-      continue;
-    }
-    if (char === "\r" || char === "\n" || char === "\x03" || char === "\x15") {
-      subscription.inputLine = "";
-    } else if (char === "\x7f" || char === "\b") {
-      subscription.inputLine = subscription.inputLine.slice(0, -1);
-    } else if (isPlainTerminalText(char)) {
-      subscription.inputLine = `${subscription.inputLine}${char}`.slice(-4000);
-    }
-  }
-}
-
-function nextTerminalControlSequenceState(
-  state: "escape" | "csi" | "osc" | "oscEscape",
-  char: string,
-): "escape" | "csi" | "osc" | "oscEscape" | null {
-  if (state === "escape") {
-    if (char === "[") return "csi";
-    if (char === "]") return "osc";
-    return null;
-  }
-  if (state === "csi") {
-    const code = char.charCodeAt(0);
-    return code >= 0x40 && code <= 0x7e ? null : "csi";
-  }
-  if (state === "osc") {
-    if (char === "\x07") return null;
-    if (char === "\x1b") return "oscEscape";
-    return "osc";
-  }
-  if (char === "\\") return null;
-  return char === "\x1b" ? "oscEscape" : "osc";
-}
-
-function isPlainTerminalText(value: string): boolean {
-  for (const char of value) {
-    const code = char.charCodeAt(0);
-    if (code < 32 && char !== "\n" && char !== "\r" && char !== "\t") return false;
-    if (code === 127) return false;
-  }
-  return true;
-}
-
-function terminalSingleLineInput(value: string): string {
-  return value.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\n/g, "\\n");
-}
-
-function terminalSenderTag(user: User): string {
-  const name = terminalXmlAttribute(user.name ?? actor(user));
-  return `<sender name="${name}"/>`;
-}
-
-function terminalXmlAttribute(value: string): string {
-  return [...value]
-    .map((char) => {
-      const code = char.charCodeAt(0);
-      return code < 32 || code === 127 ? " " : char;
-    })
-    .join("")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, 120)
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&apos;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
 }
 
 function bridgeWebSockets(
@@ -5150,7 +5056,7 @@ function authMethods(env: RuntimeEnv, request?: Request): Record<string, boolean
   };
 }
 
-function actor(user: User): string {
+function actor(user: Pick<User, "subject" | "login" | "email">): string {
   return user.login ?? user.email ?? user.subject;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -530,6 +530,7 @@ const deadInteractiveSessionStatuses: readonly InteractiveSessionStatus[] = [
   "expired",
   "failed",
 ];
+const roleOptions = new Set<Role>(["viewer", "maintainer", "owner"]);
 const runtimeOptions = ["auto", "container", "crabbox"] as const;
 const mergePolicyOptions = ["open_pr", "merge_when_green", "fix_until_green_and_merge"] as const;
 const defaultStallMs = 5 * 60 * 1000;
@@ -729,12 +730,16 @@ async function api(request: Request, env: RuntimeEnv): Promise<Response> {
     return tokenLogin(request, env);
   }
 
+  if (request.method === "POST" && url.pathname === "/api/login/dev") {
+    return devIdentityLogin(request, env);
+  }
+
   if (request.method === "POST" && url.pathname === "/api/logout") {
     return logout(request, env);
   }
 
   if (request.method === "GET" && url.pathname === "/api/auth") {
-    return json({ auth: authMethods(env) });
+    return json({ auth: authMethods(env, request) });
   }
 
   if (request.method === "POST" && url.pathname === "/api/provision/interactive") {
@@ -759,7 +764,7 @@ async function api(request: Request, env: RuntimeEnv): Promise<Response> {
   const user = await requireUser(request, env);
 
   if (request.method === "GET" && url.pathname === "/api/session") {
-    return json({ user, auth: authMethods(env) });
+    return json({ user, auth: authMethods(env, request) });
   }
 
   if (request.method === "GET" && url.pathname === "/api/state") {
@@ -928,7 +933,34 @@ async function tokenLogin(request: Request, env: RuntimeEnv): Promise<Response> 
   };
   await upsertUser(env, user, now);
   const cookieHeader = await createSession(env, request, user.subject, now);
-  return json({ user, auth: authMethods(env) }, { headers: { "set-cookie": cookieHeader } });
+  return json(
+    { user, auth: authMethods(env, request) },
+    { headers: { "set-cookie": cookieHeader } },
+  );
+}
+
+async function devIdentityLogin(request: Request, env: RuntimeEnv): Promise<Response> {
+  if (!isLocalDevRequest(request)) return json({ error: "not found" }, { status: 404 });
+
+  const body = await readJson<{ id?: string; name?: string; role?: string }>(request);
+  const id = devIdentityId(body.id);
+  const role = roleOptions.has(body.role as Role) ? (body.role as Role) : "owner";
+  const user: User = {
+    subject: `dev:${id}`,
+    login: id,
+    email: null,
+    name: clean(body.name, 120) || id,
+    role,
+    allowed: true,
+    teams: [],
+  };
+  const now = Date.now();
+  await upsertUser(env, user, now);
+  const cookieHeader = await createSession(env, request, user.subject, now);
+  return json(
+    { user, auth: authMethods(env, request) },
+    { headers: { "set-cookie": cookieHeader } },
+  );
 }
 
 async function githubLogin(request: Request, env: RuntimeEnv): Promise<Response> {
@@ -1065,6 +1097,14 @@ async function requireUser(request: Request, env: RuntimeEnv): Promise<User> {
     return user;
   }
 
+  if (user.subject.startsWith("dev:")) {
+    if (!isLocalDevRequest(request)) {
+      await db.deleteFrom("sessions").where("token_hash", "=", tokenHash).execute();
+      throw unauthorized();
+    }
+    return user;
+  }
+
   if (!user.subject.startsWith("github:")) return user;
 
   const authorized = await authorize(env, user);
@@ -1116,7 +1156,7 @@ async function readState(
 
   return {
     user,
-    auth: authMethods(env),
+    auth: authMethods(env, request),
     org: settings.org ?? "OpenClaw",
     cap: numberSetting(settings.cap, 20),
     retention: settings.retention ?? "30",
@@ -5100,15 +5140,38 @@ function strongerRole(left: Role | null, right: Role): Role {
   return rank[right] > rank[left] ? right : left;
 }
 
-function authMethods(env: RuntimeEnv): Record<string, boolean> {
+function authMethods(env: RuntimeEnv, request?: Request): Record<string, boolean> {
   return {
     github: Boolean(env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET),
     token: Boolean(env.CRABYARD_BOOTSTRAP_TOKEN),
+    devIdentity: request ? isLocalDevRequest(request) : false,
   };
 }
 
 function actor(user: User): string {
   return user.login ?? user.email ?? user.subject;
+}
+
+function isLocalDevRequest(request: Request): boolean {
+  const hostname = new URL(request.url).hostname.toLowerCase();
+  return (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "[::1]"
+  );
+}
+
+function devIdentityId(value: unknown): string {
+  const id = String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/^dev:/, "")
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return id || "dev";
 }
 
 async function readJson<T>(request: Request): Promise<T> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2783,9 +2783,8 @@ function terminalSingleLineInput(value: string): string {
 }
 
 function terminalSenderTag(user: User): string {
-  const id = terminalXmlAttribute(user.subject);
   const name = terminalXmlAttribute(user.name ?? actor(user));
-  return `<sender id="${id}" name="${name}"/>`;
+  return `<sender name="${name}"/>`;
 }
 
 function terminalXmlAttribute(value: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,6 +250,7 @@ type InteractiveSession = {
   multiplayerMode: boolean;
   canControl?: boolean;
   canManage?: boolean;
+  canChangeMultiplayer?: boolean;
   canRequestControl?: boolean;
   sharedReadOnly?: boolean;
   logs: string[];
@@ -1428,7 +1429,9 @@ async function mutateInteractiveSession(
   }
 
   if (action === "enable_multiplayer" || action === "disable_multiplayer") {
-    if (!canManage) throw forbidden("only the session owner or maintainer can change multiplayer");
+    if (!canChangeInteractiveSessionMultiplayer(user, session)) {
+      throw forbidden("only the session creator can change multiplayer");
+    }
     const enabled = action === "enable_multiplayer";
     const message = enabled ? "multiplayer mode enabled" : "multiplayer mode disabled";
     await database(env)
@@ -5276,6 +5279,7 @@ function decorateInteractiveSession(
   const now = Date.now();
   const delegatedControl = env ? canGrantDelegatedControl(env, session) : true;
   const canManage = canManageInteractiveSession(user, session);
+  const canChangeMultiplayer = canChangeInteractiveSessionMultiplayer(user, session);
   const canControl = canControlInteractiveSession(user, session, now, delegatedControl);
   const activeController = activeDelegatedController(session, now);
   return {
@@ -5287,9 +5291,14 @@ function decorateInteractiveSession(
     controlGrantedAt: activeController ? session.controlGrantedAt : null,
     controlExpiresAt: activeController ? session.controlExpiresAt : null,
     canManage,
+    canChangeMultiplayer,
     canControl,
     canRequestControl: delegatedControl && !canControl,
   };
+}
+
+function canChangeInteractiveSessionMultiplayer(user: User, session: InteractiveSession): boolean {
+  return session.owner === actor(user);
 }
 
 function canManageInteractiveSession(user: User, session: InteractiveSession): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,6 +247,7 @@ type InteractiveSession = {
   controller: string | null;
   controlGrantedAt: number | null;
   controlExpiresAt: number | null;
+  multiplayerMode: boolean;
   canControl?: boolean;
   canManage?: boolean;
   canRequestControl?: boolean;
@@ -289,6 +290,7 @@ type TerminalHubSubscription = {
   canInput: () => Promise<boolean>;
   markClosing: (reason: string) => void;
   viewCheck: ReturnType<typeof setInterval> | null;
+  inputLine: string;
   cols: number;
   rows: number;
 };
@@ -443,6 +445,7 @@ type InteractiveSessionTable = {
   controller: string | null;
   control_granted_at: number | null;
   control_expires_at: number | null;
+  multiplayer_mode: number;
 };
 
 type RepoWorkflowTable = {
@@ -1183,6 +1186,7 @@ async function createInteractiveSession(
           controller: null,
           control_granted_at: null,
           control_expires_at: null,
+          multiplayer_mode: 0,
         })
         .execute();
       await appendInteractiveSessionEvent(env, id, user, "interactive workspace requested", now);
@@ -1373,6 +1377,35 @@ async function mutateInteractiveSession(
       .execute();
     await appendInteractiveSessionEvent(env, id, user, "session sharing disabled", now);
     await audit(env, user, `interactive session share disabled ${id}`, now);
+    return {
+      session: decorateInteractiveSession(
+        (await readInteractiveSession(env, id)) as InteractiveSession,
+        user,
+        env,
+      ),
+    };
+  }
+
+  if (action === "enable_multiplayer" || action === "disable_multiplayer") {
+    if (!canManage) throw forbidden("only the session owner or maintainer can change multiplayer");
+    const enabled = action === "enable_multiplayer";
+    const message = enabled ? "multiplayer mode enabled" : "multiplayer mode disabled";
+    await database(env)
+      .updateTable("interactive_sessions")
+      .set({
+        multiplayer_mode: enabled ? 1 : 0,
+        updated_at: now,
+        last_event: message,
+      })
+      .where("id", "=", id)
+      .execute();
+    await appendInteractiveSessionEvent(env, id, user, message, now);
+    await audit(
+      env,
+      user,
+      `interactive session multiplayer ${enabled ? "enabled" : "disabled"} ${id}`,
+      now,
+    );
     return {
       session: decorateInteractiveSession(
         (await readInteractiveSession(env, id)) as InteractiveSession,
@@ -1670,7 +1703,9 @@ async function interactiveTerminalHub(
             return;
           }
           if (subscription.upstream.readyState === WebSocket.OPEN) {
-            subscription.upstream.send(frame.payload);
+            subscription.upstream.send(
+              await multiplayerTerminalInputPayload(env, subscription, user, frame.payload),
+            );
           }
           return;
         }
@@ -1865,6 +1900,7 @@ async function subscribeTerminalHubSession(
       canInput,
       markClosing,
       viewCheck,
+      inputLine: "",
       cols,
       rows,
     });
@@ -2569,6 +2605,104 @@ function interactiveTerminalHeaders(
   });
   if (authorization) headers.set("authorization", authorization);
   return headers;
+}
+
+async function multiplayerTerminalInputPayload(
+  env: RuntimeEnv,
+  subscription: TerminalHubSubscription,
+  user: User | null,
+  payload: Uint8Array,
+): Promise<Uint8Array> {
+  const submitted = terminalSubmittedLine(subscription, payload);
+  if (!user || !submitted || !submitted.text.trim()) {
+    return payload;
+  }
+  const enabled = await readInteractiveSessionMultiplayerMode(
+    env,
+    subscription.session.id,
+    subscription.session.multiplayerMode,
+  );
+  if (!enabled) {
+    return payload;
+  }
+
+  const label = terminalActorLabel(actor(user));
+  const attributed = `${label}:\n${submitted.text}${submitted.eol}`;
+  return encoder.encode(submitted.replaceCurrentLine ? `\x15${attributed}` : attributed);
+}
+
+async function readInteractiveSessionMultiplayerMode(
+  env: RuntimeEnv,
+  id: string,
+  fallback: boolean,
+): Promise<boolean> {
+  try {
+    const row = await database(env)
+      .selectFrom("interactive_sessions")
+      .select(["multiplayer_mode"])
+      .where("id", "=", id)
+      .executeTakeFirst();
+    return row ? row.multiplayer_mode === 1 : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function terminalSubmittedLine(
+  subscription: TerminalHubSubscription,
+  payload: Uint8Array,
+): { text: string; eol: string; replaceCurrentLine: boolean } | null {
+  const text = decoder.decode(payload);
+  if (text === "\r" || text === "\n") {
+    const line = subscription.inputLine;
+    subscription.inputLine = "";
+    return { text: line, eol: text, replaceCurrentLine: true };
+  }
+
+  if (!subscription.inputLine) {
+    const eol = text.endsWith("\r") ? "\r" : text.endsWith("\n") ? "\n" : "";
+    const line = eol ? text.slice(0, -1) : "";
+    if (eol && isPlainTerminalText(line)) {
+      return { text: line, eol, replaceCurrentLine: false };
+    }
+  }
+
+  updateTerminalInputLine(subscription, text);
+  return null;
+}
+
+function updateTerminalInputLine(subscription: TerminalHubSubscription, text: string): void {
+  for (const char of text) {
+    if (char === "\r" || char === "\n" || char === "\x03" || char === "\x15") {
+      subscription.inputLine = "";
+    } else if (char === "\x7f" || char === "\b") {
+      subscription.inputLine = subscription.inputLine.slice(0, -1);
+    } else if (isPlainTerminalText(char)) {
+      subscription.inputLine = `${subscription.inputLine}${char}`.slice(-4000);
+    }
+  }
+}
+
+function isPlainTerminalText(value: string): boolean {
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if (code < 32 && char !== "\n" && char !== "\r" && char !== "\t") return false;
+    if (code === 127) return false;
+  }
+  return true;
+}
+
+function terminalActorLabel(value: string): string {
+  const label = [...value]
+    .map((char) => {
+      const code = char.charCodeAt(0);
+      return code < 32 || code === 127 || char === ":" ? " " : char;
+    })
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 80);
+  return label || "user";
 }
 
 function bridgeWebSockets(
@@ -4396,6 +4530,7 @@ async function readSharedInteractiveSession(
       controller: activeController,
       controlGrantedAt: activeController ? session.controlGrantedAt : null,
       controlExpiresAt: activeController ? session.controlExpiresAt : null,
+      multiplayerMode: session.multiplayerMode,
       canControl: false,
       canManage: false,
       canRequestControl: false,
@@ -5007,6 +5142,7 @@ function interactiveSession(row: InteractiveSessionTable, logs: string[]): Inter
     controller: row.controller,
     controlGrantedAt: row.control_granted_at,
     controlExpiresAt: row.control_expires_at,
+    multiplayerMode: row.multiplayer_mode === 1,
     logs,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2784,7 +2784,7 @@ function terminalSingleLineInput(value: string): string {
 
 function terminalSenderTag(user: User): string {
   const name = terminalXmlAttribute(user.name ?? actor(user));
-  return `<s n="${name}"/>`;
+  return `<sender name="${name}"/>`;
 }
 
 function terminalXmlAttribute(value: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5760,7 +5760,8 @@ function isSandboxSessionAlreadyGone(error: unknown, sessionId: string): boolean
   return (
     hasSandboxSessionErrorCode(error, "SESSION_DESTROYED", sessionId) ||
     hasSandboxSessionErrorCode(error, "SESSION_TERMINATED", sessionId) ||
-    hasSandboxSessionErrorCode(error, "FILE_NOT_FOUND", sessionId)
+    hasSandboxSessionErrorCode(error, "FILE_NOT_FOUND", sessionId) ||
+    sandboxSessionNotFoundMessage(error, sessionId)
   );
 }
 
@@ -5789,6 +5790,13 @@ function sandboxErrorSessionId(response: SandboxErrorDetails): string | null {
   if (!context || typeof context !== "object") return null;
   const sessionId = (context as { sessionId?: unknown }).sessionId;
   return typeof sessionId === "string" ? sessionId : null;
+}
+
+function sandboxSessionNotFoundMessage(error: unknown, sessionId: string): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return (
+    message === `Session '${sessionId}' not found` || message === `Session "${sessionId}" not found`
+  );
 }
 
 async function createNewSandboxSession(

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,6 +291,7 @@ type TerminalHubSubscription = {
   markClosing: (reason: string) => void;
   viewCheck: ReturnType<typeof setInterval> | null;
   inputLine: string;
+  inputControlSequence: "escape" | "csi" | "osc" | "oscEscape" | null;
   cols: number;
   rows: number;
 };
@@ -1703,9 +1704,16 @@ async function interactiveTerminalHub(
             return;
           }
           if (subscription.upstream.readyState === WebSocket.OPEN) {
-            subscription.upstream.send(
-              await multiplayerTerminalInputPayload(env, subscription, user, frame.payload),
+            const inputs = await multiplayerTerminalInputPayloads(
+              env,
+              subscription,
+              user,
+              frame.payload,
             );
+            for (const [index, input] of inputs.entries()) {
+              if (index > 0) await sleep(index === inputs.length - 1 ? 80 : 2);
+              subscription.upstream.send(input);
+            }
           }
           return;
         }
@@ -1901,6 +1909,7 @@ async function subscribeTerminalHubSession(
       markClosing,
       viewCheck,
       inputLine: "",
+      inputControlSequence: null,
       cols,
       rows,
     });
@@ -2607,15 +2616,15 @@ function interactiveTerminalHeaders(
   return headers;
 }
 
-async function multiplayerTerminalInputPayload(
+async function multiplayerTerminalInputPayloads(
   env: RuntimeEnv,
   subscription: TerminalHubSubscription,
   user: User | null,
   payload: Uint8Array,
-): Promise<Uint8Array> {
+): Promise<Uint8Array[]> {
   const submitted = terminalSubmittedLine(subscription, payload);
   if (!user || !submitted || !submitted.text.trim()) {
-    return payload;
+    return [payload];
   }
   const enabled = await readInteractiveSessionMultiplayerMode(
     env,
@@ -2623,12 +2632,13 @@ async function multiplayerTerminalInputPayload(
     subscription.session.multiplayerMode,
   );
   if (!enabled) {
-    return payload;
+    return [payload];
   }
 
-  const label = terminalActorLabel(actor(user));
-  const attributed = `${label}:\n${submitted.text}${submitted.eol}`;
-  return encoder.encode(submitted.replaceCurrentLine ? `\x15${attributed}` : attributed);
+  const sender = terminalSenderTag(user);
+  const attributed = `${sender} ${terminalSingleLineInput(submitted.text)}${submitted.eol}`;
+  const chunks = submitted.replaceCurrentLine ? ["\x15", ...attributed] : [...attributed];
+  return chunks.map((chunk) => encoder.encode(chunk));
 }
 
 async function readInteractiveSessionMultiplayerMode(
@@ -2673,6 +2683,17 @@ function terminalSubmittedLine(
 
 function updateTerminalInputLine(subscription: TerminalHubSubscription, text: string): void {
   for (const char of text) {
+    if (subscription.inputControlSequence) {
+      subscription.inputControlSequence = nextTerminalControlSequenceState(
+        subscription.inputControlSequence,
+        char,
+      );
+      continue;
+    }
+    if (char === "\x1b") {
+      subscription.inputControlSequence = "escape";
+      continue;
+    }
     if (char === "\r" || char === "\n" || char === "\x03" || char === "\x15") {
       subscription.inputLine = "";
     } else if (char === "\x7f" || char === "\b") {
@@ -2681,6 +2702,28 @@ function updateTerminalInputLine(subscription: TerminalHubSubscription, text: st
       subscription.inputLine = `${subscription.inputLine}${char}`.slice(-4000);
     }
   }
+}
+
+function nextTerminalControlSequenceState(
+  state: "escape" | "csi" | "osc" | "oscEscape",
+  char: string,
+): "escape" | "csi" | "osc" | "oscEscape" | null {
+  if (state === "escape") {
+    if (char === "[") return "csi";
+    if (char === "]") return "osc";
+    return null;
+  }
+  if (state === "csi") {
+    const code = char.charCodeAt(0);
+    return code >= 0x40 && code <= 0x7e ? null : "csi";
+  }
+  if (state === "osc") {
+    if (char === "\x07") return null;
+    if (char === "\x1b") return "oscEscape";
+    return "osc";
+  }
+  if (char === "\\") return null;
+  return char === "\x1b" ? "oscEscape" : "osc";
 }
 
 function isPlainTerminalText(value: string): boolean {
@@ -2692,17 +2735,31 @@ function isPlainTerminalText(value: string): boolean {
   return true;
 }
 
-function terminalActorLabel(value: string): string {
-  const label = [...value]
+function terminalSingleLineInput(value: string): string {
+  return value.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\n/g, "\\n");
+}
+
+function terminalSenderTag(user: User): string {
+  const id = terminalXmlAttribute(user.subject);
+  const name = terminalXmlAttribute(user.name ?? actor(user));
+  return `<sender id="${id}" name="${name}"/>`;
+}
+
+function terminalXmlAttribute(value: string): string {
+  return [...value]
     .map((char) => {
       const code = char.charCodeAt(0);
-      return code < 32 || code === 127 || char === ":" ? " " : char;
+      return code < 32 || code === 127 ? " " : char;
     })
     .join("")
     .replace(/\s+/g, " ")
     .trim()
-    .slice(0, 80);
-  return label || "user";
+    .slice(0, 120)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 function bridgeWebSockets(
@@ -5898,6 +5955,10 @@ function securityHeaders(contentType: string, cache = true): HeadersInit {
     "referrer-policy": "no-referrer",
     "cache-control": cache ? "public, max-age=300" : "no-store",
   };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function base64Bytes(value: string): Uint8Array {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2784,7 +2784,7 @@ function terminalSingleLineInput(value: string): string {
 
 function terminalSenderTag(user: User): string {
   const name = terminalXmlAttribute(user.name ?? actor(user));
-  return `<sender name="${name}"/>`;
+  return `<s n="${name}"/>`;
 }
 
 function terminalXmlAttribute(value: string): string {
@@ -5297,12 +5297,23 @@ function decorateInteractiveSession(
 }
 
 function canChangeInteractiveSessionMultiplayer(user: User, session: InteractiveSession): boolean {
-  return session.owner === actor(user);
+  return userActorCandidates(user).has(session.owner);
 }
 
 function canManageInteractiveSession(user: User, session: InteractiveSession): boolean {
-  const userActor = actor(user);
-  return session.owner === userActor || user.role === "maintainer" || user.role === "owner";
+  return (
+    userActorCandidates(user).has(session.owner) ||
+    user.role === "maintainer" ||
+    user.role === "owner"
+  );
+}
+
+function userActorCandidates(user: User): Set<string> {
+  return new Set(
+    [actor(user), user.subject, user.login, user.email].filter((value): value is string =>
+      Boolean(value),
+    ),
+  );
 }
 
 function canControlInteractiveSession(

--- a/src/terminal-multiplayer.ts
+++ b/src/terminal-multiplayer.ts
@@ -1,0 +1,145 @@
+export type TerminalInputState = {
+  line: string;
+  controlSequence: "escape" | "csi" | "osc" | "oscEscape" | null;
+};
+
+type TerminalIdentity = {
+  subject: string;
+  login: string | null;
+  email: string | null;
+  name: string | null;
+};
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export function newTerminalInputState(): TerminalInputState {
+  return { line: "", controlSequence: null };
+}
+
+export function multiplayerTerminalInputPayloadsForMode(
+  state: TerminalInputState,
+  user: TerminalIdentity | null,
+  payload: Uint8Array,
+  enabled: boolean,
+): Uint8Array[] {
+  const submitted = terminalSubmittedLine(state, payload);
+  if (!enabled || !user || !submitted || !submitted.text.trim()) {
+    return [payload];
+  }
+  return attributedTerminalInputPayloads(user, submitted);
+}
+
+export function terminalSubmittedLine(
+  state: TerminalInputState,
+  payload: Uint8Array,
+): { text: string; eol: string; replaceCurrentLine: boolean } | null {
+  const text = decoder.decode(payload);
+  if (text === "\r" || text === "\n") {
+    const line = state.line;
+    state.line = "";
+    return { text: line, eol: text, replaceCurrentLine: true };
+  }
+
+  if (!state.line) {
+    const eol = text.endsWith("\r") ? "\r" : text.endsWith("\n") ? "\n" : "";
+    const line = eol ? text.slice(0, -1) : "";
+    if (eol && isPlainTerminalText(line)) {
+      return { text: line, eol, replaceCurrentLine: false };
+    }
+  }
+
+  updateTerminalInputLine(state, text);
+  return null;
+}
+
+export function attributedTerminalInputPayloads(
+  user: TerminalIdentity,
+  submitted: { text: string; eol: string; replaceCurrentLine: boolean },
+): Uint8Array[] {
+  const sender = terminalSenderTag(user);
+  const attributed = `${sender} ${terminalSingleLineInput(submitted.text)}${submitted.eol}`;
+  const chunks = submitted.replaceCurrentLine ? ["\x15", ...attributed] : [...attributed];
+  return chunks.map((chunk) => encoder.encode(chunk));
+}
+
+function updateTerminalInputLine(state: TerminalInputState, text: string): void {
+  for (const char of text) {
+    if (state.controlSequence) {
+      state.controlSequence = nextTerminalControlSequenceState(state.controlSequence, char);
+      continue;
+    }
+    if (char === "\x1b") {
+      state.controlSequence = "escape";
+      continue;
+    }
+    if (char === "\r" || char === "\n" || char === "\x03" || char === "\x15") {
+      state.line = "";
+    } else if (char === "\x7f" || char === "\b") {
+      state.line = state.line.slice(0, -1);
+    } else if (isPlainTerminalText(char)) {
+      state.line = `${state.line}${char}`.slice(-4000);
+    }
+  }
+}
+
+function nextTerminalControlSequenceState(
+  state: "escape" | "csi" | "osc" | "oscEscape",
+  char: string,
+): "escape" | "csi" | "osc" | "oscEscape" | null {
+  if (state === "escape") {
+    if (char === "[") return "csi";
+    if (char === "]") return "osc";
+    return null;
+  }
+  if (state === "csi") {
+    const code = char.charCodeAt(0);
+    return code >= 0x40 && code <= 0x7e ? null : "csi";
+  }
+  if (state === "osc") {
+    if (char === "\x07") return null;
+    if (char === "\x1b") return "oscEscape";
+    return "osc";
+  }
+  if (char === "\\") return null;
+  return char === "\x1b" ? "oscEscape" : "osc";
+}
+
+function isPlainTerminalText(value: string): boolean {
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if (code < 32 && char !== "\n" && char !== "\r" && char !== "\t") return false;
+    if (code === 127) return false;
+  }
+  return true;
+}
+
+function terminalSingleLineInput(value: string): string {
+  return value.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\n/g, "\\n");
+}
+
+function terminalSenderTag(user: TerminalIdentity): string {
+  const name = terminalXmlAttribute(user.name ?? identityActor(user));
+  return `<sender name="${name}"/>`;
+}
+
+function terminalXmlAttribute(value: string): string {
+  return [...value]
+    .map((char) => {
+      const code = char.charCodeAt(0);
+      return code < 32 || code === 127 ? " " : char;
+    })
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 120)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function identityActor(user: TerminalIdentity): string {
+  return user.login ?? user.email ?? user.subject;
+}

--- a/src/terminal-multiplayer.ts
+++ b/src/terminal-multiplayer.ts
@@ -41,6 +41,16 @@ export function terminalSubmittedLine(
     return { text: line, eol: text, replaceCurrentLine: true };
   }
 
+  if (state.line && !state.controlSequence) {
+    const eol = text.endsWith("\r") ? "\r" : text.endsWith("\n") ? "\n" : "";
+    const line = eol ? text.slice(0, -1) : "";
+    if (eol && isPlainTerminalText(line)) {
+      const submitted = `${state.line}${line}`;
+      state.line = "";
+      return { text: submitted, eol, replaceCurrentLine: true };
+    }
+  }
+
   if (!state.line) {
     const eol = text.endsWith("\r") ? "\r" : text.endsWith("\n") ? "\n" : "";
     const line = eol ? text.slice(0, -1) : "";

--- a/tests/terminal-multiplayer.test.ts
+++ b/tests/terminal-multiplayer.test.ts
@@ -43,6 +43,29 @@ test("multiplayer input tracks interleaved writers on the shared session line", 
   );
 });
 
+test("multiplayer input attributes a final text fragment batched with enter", () => {
+  const state = newTerminalInputState();
+
+  assert.deepEqual(
+    multiplayerTerminalInputPayloadsForMode(state, user, encoder.encode("hel"), true),
+    [encoder.encode("hel")],
+  );
+
+  assert.equal(
+    text(multiplayerTerminalInputPayloadsForMode(state, user, encoder.encode("lo\r"), true)),
+    '\x15<sender name="Admin 1"/> hello\r',
+  );
+});
+
+test("multiplayer input does not attribute text while a control sequence is pending", () => {
+  const state = newTerminalInputState();
+  state.line = "hello";
+  state.controlSequence = "csi";
+
+  const payload = encoder.encode("D\r");
+  assert.deepEqual(multiplayerTerminalInputPayloadsForMode(state, user, payload, true), [payload]);
+});
+
 test("multiplayer disabled forwards input unchanged", () => {
   const state = newTerminalInputState();
   const typed = encoder.encode("hello ");

--- a/tests/terminal-multiplayer.test.ts
+++ b/tests/terminal-multiplayer.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  multiplayerTerminalInputPayloadsForMode,
+  newTerminalInputState,
+} from "../src/terminal-multiplayer.ts";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const user = {
+  subject: "dev:admin-1",
+  login: "admin-1",
+  email: null,
+  name: "Admin 1",
+};
+const secondUser = {
+  subject: "dev:user-1",
+  login: "user-1",
+  email: null,
+  name: "User 1",
+};
+
+function text(payloads: Uint8Array[]): string {
+  return payloads.map((payload) => decoder.decode(payload)).join("");
+}
+
+test("multiplayer input tracks interleaved writers on the shared session line", () => {
+  const state = newTerminalInputState();
+
+  assert.deepEqual(
+    multiplayerTerminalInputPayloadsForMode(state, user, encoder.encode("hello "), true),
+    [encoder.encode("hello ")],
+  );
+  assert.deepEqual(
+    multiplayerTerminalInputPayloadsForMode(state, secondUser, encoder.encode("world"), true),
+    [encoder.encode("world")],
+  );
+
+  assert.equal(
+    text(multiplayerTerminalInputPayloadsForMode(state, secondUser, encoder.encode("\r"), true)),
+    '\x15<sender name="User 1"/> hello world\r',
+  );
+});
+
+test("multiplayer disabled forwards input unchanged", () => {
+  const state = newTerminalInputState();
+  const typed = encoder.encode("hello ");
+  const enter = encoder.encode("\r");
+
+  assert.deepEqual(multiplayerTerminalInputPayloadsForMode(state, user, typed, false), [typed]);
+  assert.deepEqual(multiplayerTerminalInputPayloadsForMode(state, user, enter, false), [enter]);
+});


### PR DESCRIPTION
messages with <sender /> tag are from multiplayer mode

<img width="700" height="939" alt="image" src="https://github.com/user-attachments/assets/68e76913-da12-41a4-978a-35a435ecb72e" />


## Summary
- Add an opt-in multiplayer mode setting for interactive Codex sessions
- Add owner/maintainer actions to enable or disable multiplayer mode from the session controls
- When enabled, submitted terminal prompts are sent to Codex as raw text prefixed with the current actor, e.g. `dallin:\nmessage`
- Leave terminal input unchanged when multiplayer mode is off

## Checks
- pnpm run check
- pnpm test