### PR TITLE
Fix Wrangler dev rebuild loop

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,6 +6,16 @@
   "compatibility_flags": ["nodejs_compat"],
   "build": {
     "command": "node scripts/generate-assets.mjs",
+    "watch_dir": [
+      "scripts/generate-assets.mjs",
+      "vite.config.mjs",
+      "src/app.html",
+      "src/index.ts",
+      "src/terminal-protocol.ts",
+      "src/app",
+      "src/assets",
+      "docs/spec.md",
+    ],
   },
   "account_id": "91b59577e757131d68d55a471fe32aca",
   "d1_databases": [


### PR DESCRIPTION
## Summary
- Scope Wrangler custom build watching to the actual asset-generation inputs
- Exclude generated outputs like `src/generated.ts` and `dist/` from triggering their own rebuilds

## Checks
- pnpm run check
- pnpm test