### PR TITLE
Retry missing sandbox terminal sessions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3210,8 +3210,8 @@ async function openSandboxTerminalResponse(
     shell: sandboxTerminalShellPath(session.id),
   };
   await ensureSandboxTerminalPrepared(sandbox, env, session, lease.terminalSessionId);
-  let terminalSession = await sandbox.getSession(lease.terminalSessionId);
   const open = async () => {
+    const terminalSession = await sandbox.getSession(lease.terminalSessionId);
     return terminalSession.terminal(request, options);
   };
 
@@ -3223,7 +3223,6 @@ async function openSandboxTerminalResponse(
   }
 
   await recreateSandboxTerminalSession(sandbox, env, session, lease.terminalSessionId);
-  terminalSession = await sandbox.getSession(lease.terminalSessionId);
   return open();
 }
 


### PR DESCRIPTION
## Summary
- Move sandbox terminal session lookup inside the existing attach retry path
- Recreate the sandbox terminal session when `getSession` fails before opening the PTY

## Checks
- pnpm run check
- pnpm test