### PR TITLE
Fix missing sandbox terminal session recreation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Treat missing Cloudflare Sandbox terminal sessions as already removed before recreation so fresh Codex session provisioning can recover instead of failing with `Session 'terminal-...' not found`.
 - Persist per-session GitHub OAuth credentials inside Cloudflare Sandbox terminals so `gh` and `git push` keep working after Codex starts.
 - Expand the Codex sessions grid to full available height when only one session is visible.
 - Pre-bake Cloudflare Sandbox images with Codex, pnpm, GitHub CLI, Crabbox, and common build/debug tools, plus a session diagnostics endpoint.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5567,7 +5567,8 @@ function isSandboxSessionAlreadyGone(error: unknown, sessionId: string): boolean
   return (
     hasSandboxSessionErrorCode(error, "SESSION_DESTROYED", sessionId) ||
     hasSandboxSessionErrorCode(error, "SESSION_TERMINATED", sessionId) ||
-    hasSandboxSessionErrorCode(error, "FILE_NOT_FOUND", sessionId)
+    hasSandboxSessionErrorCode(error, "FILE_NOT_FOUND", sessionId) ||
+    sandboxSessionNotFoundMessage(error, sessionId)
   );
 }
 
@@ -5596,6 +5597,13 @@ function sandboxErrorSessionId(response: SandboxErrorDetails): string | null {
   if (!context || typeof context !== "object") return null;
   const sessionId = (context as { sessionId?: unknown }).sessionId;
   return typeof sessionId === "string" ? sessionId : null;
+}
+
+function sandboxSessionNotFoundMessage(error: unknown, sessionId: string): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return (
+    message === `Session '${sessionId}' not found` || message === `Session "${sessionId}" not found`
+  );
 }
 
 async function createNewSandboxSession(


### PR DESCRIPTION
## Summary
- Treat plain Cloudflare Sandbox `Session 'terminal-...' not found` delete failures as already gone before recreating terminal sessions
- Keep fresh Codex session provisioning from failing when the terminal session has not been created yet
- Add a changelog note

## Verification
- pnpm run check
- pnpm test