### PR TITLE
chore: migrate multipass repo seed to crabline

### DIFF
--- a/migrations/0005_openclaw_repos.sql
+++ b/migrations/0005_openclaw_repos.sql
@@ -52,7 +52,7 @@ INSERT OR IGNORE INTO repos (repo, enabled, created_at, updated_at) VALUES
   ('openclaw/maintainers', 1, unixepoch() * 1000, unixepoch() * 1000),
   ('openclaw/mcporter', 1, unixepoch() * 1000, unixepoch() * 1000),
   ('openclaw/moltbench', 1, unixepoch() * 1000, unixepoch() * 1000),
-  ('openclaw/multipass', 1, unixepoch() * 1000, unixepoch() * 1000),
+  ('openclaw/crabline', 1, unixepoch() * 1000, unixepoch() * 1000),
   ('openclaw/nix-openclaw', 1, unixepoch() * 1000, unixepoch() * 1000),
   ('openclaw/nix-openclaw-tools', 1, unixepoch() * 1000, unixepoch() * 1000),
   ('openclaw/notcrawl', 1, unixepoch() * 1000, unixepoch() * 1000),

--- a/migrations/0019_crabline_repo_cutover.sql
+++ b/migrations/0019_crabline_repo_cutover.sql
@@ -7,35 +7,8 @@ SELECT
 FROM repos
 WHERE repo = 'openclaw/multipass';
 
-UPDATE cards
+UPDATE repos
 SET
-  repo = 'openclaw/crabline',
+  enabled = 0,
   updated_at = unixepoch() * 1000
 WHERE repo = 'openclaw/multipass';
-
-INSERT OR IGNORE INTO repo_workflows (
-  repo,
-  status,
-  source_path,
-  source_sha,
-  config_json,
-  prompt,
-  error,
-  evaluated_at,
-  updated_at
-)
-SELECT
-  'openclaw/crabline',
-  status,
-  source_path,
-  source_sha,
-  config_json,
-  prompt,
-  error,
-  evaluated_at,
-  unixepoch() * 1000
-FROM repo_workflows
-WHERE repo = 'openclaw/multipass';
-
-DELETE FROM repo_workflows WHERE repo = 'openclaw/multipass';
-DELETE FROM repos WHERE repo = 'openclaw/multipass';

--- a/migrations/0019_crabline_repo_cutover.sql
+++ b/migrations/0019_crabline_repo_cutover.sql
@@ -6,9 +6,3 @@ SELECT
   unixepoch() * 1000
 FROM repos
 WHERE repo = 'openclaw/multipass';
-
-UPDATE repos
-SET
-  enabled = 0,
-  updated_at = unixepoch() * 1000
-WHERE repo = 'openclaw/multipass';

--- a/migrations/0019_crabline_repo_cutover.sql
+++ b/migrations/0019_crabline_repo_cutover.sql
@@ -1,0 +1,41 @@
+INSERT OR IGNORE INTO repos (repo, enabled, created_at, updated_at)
+SELECT
+  'openclaw/crabline',
+  enabled,
+  created_at,
+  unixepoch() * 1000
+FROM repos
+WHERE repo = 'openclaw/multipass';
+
+UPDATE cards
+SET
+  repo = 'openclaw/crabline',
+  updated_at = unixepoch() * 1000
+WHERE repo = 'openclaw/multipass';
+
+INSERT OR IGNORE INTO repo_workflows (
+  repo,
+  status,
+  source_path,
+  source_sha,
+  config_json,
+  prompt,
+  error,
+  evaluated_at,
+  updated_at
+)
+SELECT
+  'openclaw/crabline',
+  status,
+  source_path,
+  source_sha,
+  config_json,
+  prompt,
+  error,
+  evaluated_at,
+  unixepoch() * 1000
+FROM repo_workflows
+WHERE repo = 'openclaw/multipass';
+
+DELETE FROM repo_workflows WHERE repo = 'openclaw/multipass';
+DELETE FROM repos WHERE repo = 'openclaw/multipass';


### PR DESCRIPTION
## Summary
- update the fresh-install repo seed from openclaw/multipass to openclaw/crabline
- add a tiny D1 migration for existing deployments that enables openclaw/crabline when openclaw/multipass exists
- leave openclaw/multipass enabled for existing deployments so persisted cards can drain without blocked-repo errors

## Verification
- sqlite3 :memory: '.read migrations/0001_initial.sql' '.read migrations/0005_openclaw_repos.sql' "select repo, enabled from repos where repo in ('openclaw/multipass','openclaw/crabline') order by repo;" → openclaw/crabline|1
- sqlite3 :memory: '.read migrations/0001_initial.sql' "insert into repos (repo, enabled, created_at, updated_at) values ('openclaw/multipass', 1, 1, 1);" "insert into cards (id, title, prompt, repo, source, runtime, policy, lane, owner, created_at, updated_at) values ('TEST-1', 'test', 'test', 'openclaw/multipass', 'Prompt', 'container', 'open_pr', 'Todo', 'system', 1, 1);" '.read migrations/0019_crabline_repo_cutover.sql' "select repo, enabled from repos where repo in ('openclaw/multipass','openclaw/crabline') order by repo;" "select id, repo from cards where id = 'TEST-1';" → openclaw/crabline|1, openclaw/multipass|1, TEST-1|openclaw/multipass
- pnpm check *(fails on existing lint debt unrelated to this SQL-only change: curly/no-array-sort/etc. in existing source files)*