### PR TITLE
feat: redesign fleet command center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## Unreleased
 
 - Add Crabfleet session supervision metadata, owner/session tree listing, transcript retrieval, PTY messaging, and summary updates for Codex-spawned Codex sessions.
-- Fix GitHub OAuth login after the canonical host move by honoring an explicit registered callback URL.
+- Redesign Fleet as an operational command view with real readiness data, compact connection paths, clearer operator groups, and denser session cards.
+- De-duplicate interactive lifecycle, status, terminal-ready, log URL, icon, and copy-command behavior across the app.
+- Fix GitHub OAuth login after the canonical host move by honoring the registered `crabfleet.openclaw.ai` callback URL.
 - Add the Crabfleet v2 fleet-control spec, redacted fleet registry API, and dashboard summary for visible Codex crabboxes.
-- Move the OpenClaw app/API canonical URL to `clawfleet.openclaw.ai`, keep legacy app hosts redirecting there, and reserve `clawfleet.ai` for the product page.
+- Make `crabfleet.openclaw.ai` the OpenClaw app/API canonical URL, redirect old OpenClaw aliases there, and keep `crabfleet.ai` independent as the public product site.
 - Route the built-in interactive provision hook in-process and default new sessions to Cloudflare Sandbox so production creates usable Codex terminals without a crabbox adapter.
 - Keep Cloudflare Sandbox model and GitHub credentials in the Worker path, add DO-backed sandbox credential/checkpoint state, and add CLI lifecycle commands for doctor/status/stop/checkpoint/restore.
 - Show failed and expired Codex sessions as stable log replays instead of remounting Ghostty terminals.
@@ -15,8 +17,7 @@
 - Split Fleet and Board into separate app pages, with Fleet as the default grouped view of every visible crabbox by person.
 - Tighten the login SSH command width for `crabd.sh` and tuck bootstrap-token login behind a recovery disclosure.
 - Redesign the Crabfleet logo and favicon around a single fleet node-grid mark, and serve a real 1200×630 social card instead of stretching the 96px logo.
-- Serve the app/API on `crabfleet.ai` and redirect the old `crabfleet.ai` host.
-- Route `crabfleet.ai` to the Crabbox Worker and move SSH onboarding defaults to `crabd.sh`, with deploy-time domain enforcement.
+- Move SSH onboarding defaults to `crabd.sh`, with deploy-time domain enforcement.
 
 ## 0.1.0 - 2026-05-24
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Mission control for Agent runs.**
 
-Crabfleet gives OpenClaw maintainers a fleet dashboard where every Codex crabbox is visible by operator, repo, terminal, and WebVNC state. The OpenClaw app/API canonical URL is `https://clawfleet.openclaw.ai`; `https://clawfleet.ai` is reserved for the public product page.
+Crabfleet gives OpenClaw maintainers a fleet dashboard where every Codex crabbox is visible by operator, repo, terminal, and WebVNC state. The OpenClaw app/API canonical URL is `https://crabfleet.openclaw.ai`; `https://crabfleet.ai` is the public product site.
 
 ## What It Does
 
@@ -125,7 +125,7 @@ merge:
 ### Prerequisites
 
 - Cloudflare account
-- `clawfleet.openclaw.ai` route in Cloudflare; legacy app hosts redirect here
+- `crabfleet.openclaw.ai` route in Cloudflare; legacy OpenClaw app hosts redirect here
 - GitHub OAuth app (optional but recommended)
 - Bootstrap token secret
 
@@ -134,10 +134,11 @@ merge:
 Pushes to `main` run `.github/workflows/deploy-worker.yml`, which checks, tests, builds,
 applies remote D1 migrations, and deploys the Worker. Configure the repository secret
 `CLOUDFLARE_API_TOKEN` with permissions for Workers deploys and D1 migrations.
-`clawfleet.openclaw.ai` and `crabd.sh` DNS/route convergence is handled by
-`scripts/ensure-cloudflare-domains.mjs`; set `CLOUDFLARE_DNS_API_TOKEN` when CI should
-manage those records. Without that DNS-scoped token, CI skips domain convergence and
-deploys to the already configured route.
+`crabfleet.ai` product routing, `crabfleet.openclaw.ai`, and `crabd.sh` DNS/route
+convergence is handled by `scripts/ensure-cloudflare-domains.mjs`; set
+`CLOUDFLARE_DNS_API_TOKEN` when CI should manage those records. Without that
+DNS-scoped token, CI skips domain convergence. The app Worker still proxies the generic
+product site for `crabfleet.ai` as a defensive fallback, never the authenticated app.
 
 Manual deploy is still available:
 
@@ -188,10 +189,10 @@ The Crabbox namespace cutover intentionally has no old-name compatibility. Exist
 ### Verify Deployment
 
 ```bash
-curl -I https://clawfleet.openclaw.ai/healthz
+curl -I https://crabfleet.openclaw.ai/healthz
 # Should return: 200 OK
 
-curl https://clawfleet.openclaw.ai/docs/spec
+curl https://crabfleet.openclaw.ai/docs/spec
 # Should return: HTML spec document
 ```
 
@@ -241,7 +242,7 @@ The Worker exposes an internal SSH onboarding API guarded by `CRABFLEET_SSH_GATE
 Run the Go gateway next to a host that can accept raw SSH:
 
 ```bash
-CRABFLEET_API_URL=https://clawfleet.openclaw.ai \
+CRABFLEET_API_URL=https://crabfleet.openclaw.ai \
 CRABFLEET_SSH_GATEWAY_TOKEN=... \
 CRABFLEET_SSH_HOST_KEY=/var/lib/crabfleet/ssh_host_ed25519_key \
 CRABFLEET_SSH_ADDR=:2222 \
@@ -287,7 +288,7 @@ The release workflow builds macOS, Linux, and Windows archives, then updates `op
 OpenClaw can create repo-ready crabboxes for Discord-triggered work through the internal service endpoint:
 
 ```bash
-curl -fsS https://clawfleet.openclaw.ai/api/openclaw/crabboxes \
+curl -fsS https://crabfleet.openclaw.ai/api/openclaw/crabboxes \
   -H "authorization: Bearer $CRABBOX_OPENCLAW_TOKEN" \
   -H "content-type: application/json" \
   -d '{"owner":"@steipete","repo":"openclaw/crabfleet","prompt":"prep the meeting follow-up"}'

--- a/cmd/crabfleet/main.go
+++ b/cmd/crabfleet/main.go
@@ -20,13 +20,13 @@ import (
 	"github.com/coder/websocket"
 )
 
-const defaultAPIURL = "https://clawfleet.openclaw.ai"
+const defaultAPIURL = "https://crabfleet.openclaw.ai"
 const defaultSSHHost = "crabd.sh"
 
 var version = "dev"
 
 type cli struct {
-	API         string `help:"Crabfleet API URL." default:"https://clawfleet.openclaw.ai" env:"CRABFLEET_API_URL"`
+	API         string `help:"Crabfleet API URL." default:"https://crabfleet.openclaw.ai" env:"CRABFLEET_API_URL"`
 	SSHHost     string `help:"Crabfleet SSH host." default:"crabd.sh" env:"CRABFLEET_SSH_HOST"`
 	Token       string `help:"Internal API token." env:"CRABFLEET_SSH_GATEWAY_TOKEN"`
 	Fingerprint string `help:"Linked SSH key fingerprint." env:"CRABFLEET_SSH_FINGERPRINT"`

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -9,13 +9,13 @@
     <meta property="og:description" content="{{ page.description | default: site.description }}" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://docs.crabfleet.ai{{ page.url }}" />
-    <meta property="og:image" content="https://clawfleet.openclaw.ai/crabfleet-og.png" />
+    <meta property="og:image" content="https://crabfleet.openclaw.ai/crabfleet-og.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="{{ page.title }} | {{ site.title }}" />
     <meta name="twitter:description" content="{{ page.description | default: site.description }}" />
-    <meta name="twitter:image" content="https://clawfleet.openclaw.ai/crabfleet-og.png" />
+    <meta name="twitter:image" content="https://crabfleet.openclaw.ai/crabfleet-og.png" />
     <link rel="icon" type="image/png" href="/crabbox-logo.png" />
     <style>
       :root {
@@ -226,7 +226,7 @@
           <h2>Reference</h2>
           <a href="{{ '/api/' | relative_url }}">API</a>
           <a href="{{ '/spec/' | relative_url }}">Spec</a>
-          <a href="https://clawfleet.openclaw.ai/app/">App</a>
+          <a href="https://crabfleet.openclaw.ai/app/">App</a>
         </nav>
       </aside>
       <main>

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -319,7 +319,7 @@ Recommended for production.
 **Setup:**
 
 1. Create GitHub OAuth app in your org
-2. Callback URL: the Worker `GITHUB_REDIRECT_URI` value, currently `https://crabfleet.ai/auth/github/callback`
+2. Callback URL: the Worker `GITHUB_REDIRECT_URI` value, currently `https://crabfleet.openclaw.ai/auth/github/callback`
 3. Scopes: `read:user`, `read:org`
 4. Add secrets to Cloudflare Worker:
    - `GITHUB_CLIENT_ID`

--- a/docs/api.md
+++ b/docs/api.md
@@ -362,7 +362,7 @@ Response:
 ```json
 {
   "session": {},
-  "shareUrl": "https://clawfleet.openclaw.ai/app/sessions/IS-105?token=..."
+  "shareUrl": "https://crabfleet.openclaw.ai/app/sessions/IS-105?token=..."
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ crabfleet new --repo openclaw/crabfleet "fix the failing check"
 crabfleet vnc <session-id>
 ```
 
-The web app at [clawfleet.openclaw.ai/app](https://clawfleet.openclaw.ai/app/) exposes the same control plane: GitHub OAuth, repo-gated cards, runtime policy, live session tiles, WebVNC links, and admin allowlists.
+The web app at [crabfleet.openclaw.ai/app](https://crabfleet.openclaw.ai/app/) exposes the same control plane: GitHub OAuth, repo-gated cards, runtime policy, live session tiles, WebVNC links, and admin allowlists.
 
 ## What Crabfleet Does
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,11 +13,11 @@ This gets you from login to a real D1-backed crabbox, card, and run attempt.
 
 - OpenClaw GitHub org membership.
 - GitHub OAuth configured for browser access, or an SSH key to link through `crabd.sh`.
-- Access to `https://clawfleet.openclaw.ai/app/`.
+- Access to `https://crabfleet.openclaw.ai/app/`.
 
 ## 1. Log In
 
-Open `https://clawfleet.openclaw.ai/app/`.
+Open `https://crabfleet.openclaw.ai/app/`.
 
 - Use GitHub OAuth if configured.
 - Use `ssh link@crabd.sh` when you want terminal-first onboarding.

--- a/docs/spec-v2.md
+++ b/docs/spec-v2.md
@@ -2,9 +2,9 @@
 
 Status: implementation plan plus shipped v2 slice.
 
-Canonical app/API URL: <https://clawfleet.openclaw.ai>
+Canonical app/API URL: <https://crabfleet.openclaw.ai>
 
-Product page URL: <https://clawfleet.ai>
+Product page URL: <https://crabfleet.ai>
 
 ## Goal
 
@@ -49,8 +49,8 @@ Fleet state shape:
 
 ```json
 {
-  "canonicalUrl": "https://clawfleet.openclaw.ai",
-  "productUrl": "https://clawfleet.ai",
+  "canonicalUrl": "https://crabfleet.openclaw.ai",
+  "productUrl": "https://crabfleet.ai",
   "generatedAt": 1770000000000,
   "registryAvailable": true,
   "egress": {
@@ -233,10 +233,10 @@ Local result:
 - Landed: `72f205b`.
 - Deploy workflow: `deploy-worker` run `26694996052` passed.
 - Pages workflow: run `26694996080` passed.
-- Live smoke: `https://clawfleet.openclaw.ai/healthz` returned `200`.
-- Live smoke: `https://clawfleet.openclaw.ai/docs/spec-v2` returned this spec.
-- Live smoke: unauthenticated `https://clawfleet.openclaw.ai/api/fleet` returned `401`.
-- Product split: `https://clawfleet.ai/` stayed the product-page redirect shell.
+- Live smoke: `https://crabfleet.openclaw.ai/healthz` returned `200`.
+- Live smoke: `https://crabfleet.openclaw.ai/docs/spec-v2` returned this spec.
+- Live smoke: unauthenticated `https://crabfleet.openclaw.ai/api/fleet` returned `401`.
+- Product split: `https://crabfleet.ai/` stayed independent as the product-page host.
 
 Autoreview:
 
@@ -254,11 +254,11 @@ PR:
 Deploy:
 
 - Confirm Worker deploy workflow for merged commit.
-- Confirm `https://clawfleet.openclaw.ai/healthz` returns `200`.
-- Confirm `https://clawfleet.openclaw.ai/docs/spec-v2` returns HTML.
-- Confirm `https://clawfleet.openclaw.ai/docs/spec-v2.md` returns Markdown.
-- Confirm unauthenticated `https://clawfleet.openclaw.ai/api/fleet` is rejected.
-- Confirm `https://clawfleet.ai` stays product-page host, not the app/API host.
+- Confirm `https://crabfleet.openclaw.ai/healthz` returns `200`.
+- Confirm `https://crabfleet.openclaw.ai/docs/spec-v2` returns HTML.
+- Confirm `https://crabfleet.openclaw.ai/docs/spec-v2.md` returns Markdown.
+- Confirm unauthenticated `https://crabfleet.openclaw.ai/api/fleet` is rejected.
+- Confirm `https://crabfleet.ai` stays product-page host, not the app/API host.
 
 ## Future Work
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -13,7 +13,7 @@ Crabfleet is a Cloudflare-native control plane for running Codex crabboxes in cl
 ## Decisions
 
 - Product name: Crabfleet.
-- Domains: `clawfleet.openclaw.ai` for the OpenClaw app/API/OAuth, `clawfleet.ai` for the public product page, and `crabd.sh` for SSH/install/bootstrap.
+- Domains: `crabfleet.openclaw.ai` for the OpenClaw app/API/OAuth, `crabfleet.ai` for the public product page, and `crabd.sh` for SSH/install/bootstrap.
 - Primary object: card.
 - UI direction: Linear-like, minimal, dense, subtle crustacean branding.
 - Access: OpenClaw GitHub org plus admin-managed allowlists for users/teams and repos.
@@ -724,7 +724,7 @@ Picker behavior:
 
 Target domain:
 
-- `https://clawfleet.openclaw.ai`
+- `https://crabfleet.openclaw.ai`
 
 Current DNS expectation:
 
@@ -749,8 +749,8 @@ Initial deployable artifact:
 Required deploy checks:
 
 - `npx wrangler whoami` shows expected Cloudflare account.
-- `clawfleet.openclaw.ai` is routed to deployed Worker.
-- `curl -I https://clawfleet.openclaw.ai/healthz` returns 200.
+- `crabfleet.openclaw.ai` is routed to deployed Worker.
+- `curl -I https://crabfleet.openclaw.ai/healthz` returns 200.
 - `/docs/spec` renders this spec.
 
 ## Security

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "oxfmt": "^0.54.0",
     "oxlint": "^1.69.0",
     "vite": "^8.0.16",
-    "wrangler": "^4.99.0"
+    "wrangler": "^4.100.0"
   },
   "packageManager": "pnpm@10.23.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
     devDependencies:
       '@cloudflare/workers-types':
         specifier: latest
-        version: 4.20260609.1
+        version: 4.20260612.1
       '@preact/preset-vite':
         specifier: ^2.10.5
         version: 2.10.5(@babel/core@7.29.7)(preact@10.29.2)(vite@8.0.16(esbuild@0.27.3))
@@ -43,8 +43,8 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(esbuild@0.27.3)
       wrangler:
-        specifier: ^4.99.0
-        version: 4.99.0(@cloudflare/workers-types@4.20260609.1)
+        specifier: ^4.100.0
+        version: 4.100.0(@cloudflare/workers-types@4.20260612.1)
 
 packages:
 
@@ -171,38 +171,38 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260609.1':
-    resolution: {integrity: sha512-AK8tYLQm+8BqQMzjZ55ZfuhfIm1eCkj+Ykxz6kWXojdACwjjU03MrwdM9fBDdgzU3upXOs4e1scOFHySlfVQjA==}
+  '@cloudflare/workerd-darwin-64@1.20260611.1':
+    resolution: {integrity: sha512-iJICldmi4sBGgi7IrQles8cStOGXM/Tmv95C4OODVs6VIbMsJPqThUM5h3uYVQNULuJ8I/aVvnJ3Eh/wZCKwuA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260609.1':
-    resolution: {integrity: sha512-4kKXfr7ZHU6xQ/R9ShdSuj1A1bEouoRcHzUWdjnuMPBlRsAAVanlxAVYISotFUulLEinayOpRFbhpsfwzrpSSw==}
+  '@cloudflare/workerd-darwin-arm64@1.20260611.1':
+    resolution: {integrity: sha512-yBbVXvbZyltR3I7NJdC4C4ItkItjZSiabcA/3HzEWOUQjLVKFqRh4so6ToHr70VCYh8VGeR8EDZL23igLhXqFQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260609.1':
-    resolution: {integrity: sha512-T2Ebir2OPHAvvZ0HUh5mi1lN8q30sVi4lf7LIpc28AHoWtoOmJ0jA5AJK4IYJm1MKEbBldq+QsckaHOCQFmRpQ==}
+  '@cloudflare/workerd-linux-64@1.20260611.1':
+    resolution: {integrity: sha512-PfNjpxOlaIgZFYuhD7+neEEewCN2Ud993wEEN0fmbtSOax1AK53LGqmXUDvFhnbkHxJLFAxYCSNISW8QbzaAIg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260609.1':
-    resolution: {integrity: sha512-INfcYoSsKqEIvPL69/3RkqYoP8WUR0VEN6loWN/3tekXLoJrVOj3E5NjIetsdS8MJN6zc3st/ae4bMuWRRzoDg==}
+  '@cloudflare/workerd-linux-arm64@1.20260611.1':
+    resolution: {integrity: sha512-GEp4XbuIKjlF8pakqXcUDJfKiJosD/Q7S83J0d+r+z9XIlYGfF3ntm08e2aiF5TFTwp3fnG4yMoPUAKNhNJpvQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260609.1':
-    resolution: {integrity: sha512-EWhfxKI1aqUr7S8xuGxgmRCumEzB8iSsCIz6oEqJN+3pZuW3EWiKDGFW4EY1BmwNINLW1eO5VMGYb8Fj6FVYxA==}
+  '@cloudflare/workerd-windows-64@1.20260611.1':
+    resolution: {integrity: sha512-S6JkS0kEbcCKs19RGqEPhjCRbP8GBkQwqYLp2fhBJtD/KTlwqLzOJ9E6PQ7gQKgWHtxy1NBG3oXarlNFRNU/dw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20260609.1':
-    resolution: {integrity: sha512-krGHtwSApCFBjTe1NTx/TFQ0P5i/bHGQOqCPnCLssb8rOKaAG4JkPFJZsossr0z/ZTMnpP2Tid5jWju+/i0hCA==}
+  '@cloudflare/workers-types@4.20260612.1':
+    resolution: {integrity: sha512-PMQI7XP/wrMhxyjseUHoHj6XFqkHaf4utWQ/hhefVY8oMK2LJ730oeQ7H/nZSVMexZe39DzsdOx7sf1PqMr7+Q==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -213,9 +213,6 @@ packages:
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
-  '@emnapi/runtime@1.11.0':
-    resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -406,105 +403,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -604,56 +585,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.54.0':
     resolution: {integrity: sha512-QrwJlBFFKnxOd95TAaszpMbZBLzMoYMpGaQTZF8oibacnF5rv8l12IhILhQRPmksWiBqg0YSe2Mnl7ayeJAHSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.54.0':
     resolution: {integrity: sha512-WILatiol/TUHTlhod7R09+7Az/XlhKwmY1MHfLZNmewltPWNN/EwxP2rQSHahibZ/cB8gmckEBjBOByD+5bYsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.54.0':
     resolution: {integrity: sha512-f05YMG4BH4G8S4ME6UM6fi1MnJ9094mrnvO5Pa4SJlMfWlUM+1/ZWMEF4NnjM7shZAvbHsHRuVYpUo0PHC4P9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.54.0':
     resolution: {integrity: sha512-UfL+2hj1ClNqcCRT9s8vBU4axDpjxgVxX96G+9DYAYjoc5b0u15CJtn2jgsi9iM+EbGNc5CW1HVRgwVu76UsSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.54.0':
     resolution: {integrity: sha512-3/XZe931Hka+J6NjnaqJzYpsWWxDTuRdUdwSQHnOuJEgbC+SehIMFJS8hsEjV7LBhVSL2OCnRLvbVW8O97XIyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.54.0':
     resolution: {integrity: sha512-Ik93RlObtu43GbxApafayFjwYE06L6Xr08cSwpBPYbDrLp2ReZx0Jm1DqwRyYRnukUJy+rK2WaEvUQOxdytU9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.54.0':
     resolution: {integrity: sha512-yZcakmPlD86CNymknd7KfW+FH+qfbqJH+i0h69CYfV1+KMoVeM9UED+8+TDVoU4haxI0NxY7RPCvRLy3Sqd2Qg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.54.0':
     resolution: {integrity: sha512-GiVBZNnEZnKu00f1jTg49nomv187d0GQX+O+ocykoLeiaALuEO+swoTehHn9TehTfi7V8H0i0e/yvUjCqnwk1w==}
@@ -726,56 +699,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.69.0':
     resolution: {integrity: sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.69.0':
     resolution: {integrity: sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.69.0':
     resolution: {integrity: sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.69.0':
     resolution: {integrity: sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.69.0':
     resolution: {integrity: sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.69.0':
     resolution: {integrity: sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.69.0':
     resolution: {integrity: sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.69.0':
     resolution: {integrity: sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==}
@@ -868,42 +833,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -1184,28 +1143,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1232,8 +1187,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  miniflare@4.20260609.0:
-    resolution: {integrity: sha512-4ZfNh9ACDa/mKKQvTSO2vigyQS2MB7dEU02KRPle4FqL7S6nek+2Fq6WGzazZbt1OORYgb4OGVLnOCx+My2NNA==}
+  miniflare@4.20260611.0:
+    resolution: {integrity: sha512-i+JwEo8vN96naz1WL3ntFgFyRluBDYL408zwhHKvR2jefJ464KsZ/gCmJAQ5k+oaWeb5Ug+s7yne5AyiAEswjg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -1314,8 +1269,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.8.3:
-    resolution: {integrity: sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==}
+  semver@7.8.2:
+    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1414,17 +1369,17 @@ packages:
       yaml:
         optional: true
 
-  workerd@1.20260609.1:
-    resolution: {integrity: sha512-KF/Y/8f4VoXCk87NuU6RqmO0X5fdzcrxU3XzAgoPUpnH9t1ZyzRgX1O/9sJvjItxroCBTEBzKssda02Dz9i6BA==}
+  workerd@1.20260611.1:
+    resolution: {integrity: sha512-CS/640T7pIJ2HYX6x2DwKFGbcSckAWN3tgcdq+ptB6SaqjWUhlzIgA/YhPuwIU+/NnMnGpqOFX/hC18Oyge63w==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.99.0:
-    resolution: {integrity: sha512-i7GA2mZETTyq3ljWdEzM908FjLaMWZ1AaAHKaOJ8pFA/tonf2VqIWDyBGzKleIVBbNQxOTIY2wnbv0iaK3rC6g==}
+  wrangler@4.100.0:
+    resolution: {integrity: sha512-dSQO7DO+mD6XDzkVWIWBoGLO3yw+lacWSc/KhFvd7pgfpth+kX98qb5SGRHZN8ACCDhhfwzDLXwB6qHsIHhfBg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260609.1
+      '@cloudflare/workers-types': ^4.20260611.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -1595,28 +1550,28 @@ snapshots:
       capnweb: 0.8.0
       hono: 4.12.25
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260609.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260611.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260609.1
+      workerd: 1.20260611.1
 
-  '@cloudflare/workerd-darwin-64@1.20260609.1':
+  '@cloudflare/workerd-darwin-64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260609.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260609.1':
+  '@cloudflare/workerd-linux-64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260609.1':
+  '@cloudflare/workerd-linux-arm64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260609.1':
+  '@cloudflare/workerd-windows-64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workers-types@4.20260609.1': {}
+  '@cloudflare/workers-types@4.20260612.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -1629,11 +1584,6 @@ snapshots:
     optional: true
 
   '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.11.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1805,7 +1755,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.11.0
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -2306,12 +2256,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  miniflare@4.20260609.0:
+  miniflare@4.20260611.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
       undici: 7.24.8
-      workerd: 1.20260609.1
+      workerd: 1.20260611.1
       ws: 8.20.1
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -2420,13 +2370,13 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.8.3: {}
+  semver@7.8.2: {}
 
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.8.3
+      semver: 7.8.2
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -2508,26 +2458,26 @@ snapshots:
       esbuild: 0.27.3
       fsevents: 2.3.3
 
-  workerd@1.20260609.1:
+  workerd@1.20260611.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260609.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260609.1
-      '@cloudflare/workerd-linux-64': 1.20260609.1
-      '@cloudflare/workerd-linux-arm64': 1.20260609.1
-      '@cloudflare/workerd-windows-64': 1.20260609.1
+      '@cloudflare/workerd-darwin-64': 1.20260611.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260611.1
+      '@cloudflare/workerd-linux-64': 1.20260611.1
+      '@cloudflare/workerd-linux-arm64': 1.20260611.1
+      '@cloudflare/workerd-windows-64': 1.20260611.1
 
-  wrangler@4.99.0(@cloudflare/workers-types@4.20260609.1):
+  wrangler@4.100.0(@cloudflare/workers-types@4.20260612.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260609.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260611.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260609.0
+      miniflare: 4.20260611.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260609.1
+      workerd: 1.20260611.1
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20260609.1
+      '@cloudflare/workers-types': 4.20260612.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/scripts/ensure-cloudflare-domains.mjs
+++ b/scripts/ensure-cloudflare-domains.mjs
@@ -1,14 +1,13 @@
 const token = process.env.CLOUDFLARE_API_TOKEN;
-const workerScript = "crabbox-ai";
-const appHost = "clawfleet.openclaw.ai";
+const appHost = "crabfleet.openclaw.ai";
+const productWorkerScript = "crabfleet-canonical-router";
 // OpenClaw app hosts are Worker Custom Domains in wrangler.jsonc; this script
 // only removes stale classic routes for them and keeps other aliases tidy.
 const openClawCustomDomainHosts = new Set([
   appHost,
-  "crabfleet.openclaw.ai",
+  "clawfleet.openclaw.ai",
   "crabyard.openclaw.ai",
 ]);
-const legacyCrabfleetHosts = new Set(["crabfleet.ai", "www.crabfleet.ai"]);
 
 if (!token) {
   throw new Error("CLOUDFLARE_API_TOKEN is required");
@@ -42,7 +41,7 @@ async function zone(name) {
   return selected;
 }
 
-async function ensureWorkerHost(zoneName, host) {
+async function ensureProductHost(zoneName, host) {
   const targetZone = await zone(zoneName);
   const dns = await request(`/zones/${targetZone.id}/dns_records?name=${encodeURIComponent(host)}`);
   for (const record of dns.filter((entry) => entry.type === "AAAA" || entry.type === "CNAME")) {
@@ -83,16 +82,16 @@ async function ensureWorkerHost(zoneName, host) {
   const pattern = `${host}/*`;
   const routes = await request(`/zones/${targetZone.id}/workers/routes`);
   for (const route of routes.filter(
-    (entry) => entry.pattern === pattern && entry.script !== workerScript,
+    (entry) => entry.pattern === pattern && entry.script !== productWorkerScript,
   )) {
     await request(`/zones/${targetZone.id}/workers/routes/${route.id}`, { method: "DELETE" });
     console.log(`deleted stale ${host} route ${route.id}`);
   }
   const current = await request(`/zones/${targetZone.id}/workers/routes`);
-  if (!current.some((route) => route.pattern === pattern && route.script === workerScript)) {
+  if (!current.some((route) => route.pattern === pattern && route.script === productWorkerScript)) {
     const route = await request(`/zones/${targetZone.id}/workers/routes`, {
       method: "POST",
-      body: JSON.stringify({ pattern, script: workerScript }),
+      body: JSON.stringify({ pattern, script: productWorkerScript }),
     });
     console.log(`created ${host} route ${route.id}`);
   } else {
@@ -204,8 +203,8 @@ async function ensureCrabdSshRecord() {
 }
 
 await removeOpenClawClassicRoutes();
-for (const host of legacyCrabfleetHosts) {
-  await ensureWorkerHost("crabfleet.ai", host);
+for (const host of ["crabfleet.ai", "www.crabfleet.ai"]) {
+  await ensureProductHost("crabfleet.ai", host);
 }
 await ensureCrabfleetDocsRecord();
 await ensureCrabdSshRecord();

--- a/scripts/generate-assets.mjs
+++ b/scripts/generate-assets.mjs
@@ -24,7 +24,7 @@ const generatedPath = new URL("../src/generated.ts", import.meta.url);
 const distRoot = new URL("../dist/", import.meta.url);
 const distApp = new URL("../dist/app/", import.meta.url);
 const distDocs = new URL("../dist/docs/", import.meta.url);
-const appOrigin = "https://clawfleet.openclaw.ai";
+const appOrigin = "https://crabfleet.openclaw.ai";
 
 await run(process.execPath, [
   new URL("../node_modules/vite/bin/vite.js", import.meta.url).pathname,

--- a/src/app.html
+++ b/src/app.html
@@ -14,8 +14,8 @@
       content="OpenClaw Codex crabboxes, grouped fleet visibility, WebVNC, SSH, and repo-ready workspaces."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://clawfleet.openclaw.ai/" />
-    <meta property="og:image" content="https://clawfleet.openclaw.ai/crabfleet-og.png" />
+    <meta property="og:url" content="https://crabfleet.openclaw.ai/" />
+    <meta property="og:image" content="https://crabfleet.openclaw.ai/crabfleet-og.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -24,7 +24,7 @@
       name="twitter:description"
       content="OpenClaw Codex crabboxes, grouped fleet visibility, WebVNC, SSH, and repo-ready workspaces."
     />
-    <meta name="twitter:image" content="https://clawfleet.openclaw.ai/crabfleet-og.png" />
+    <meta name="twitter:image" content="https://crabfleet.openclaw.ai/crabfleet-og.png" />
     <link rel="icon" type="image/png" href="/crabbox-logo.png" />
     <script>
       try {
@@ -653,40 +653,6 @@
         line-height: 1.6;
         font-size: 15px;
       }
-      .status-strip {
-        display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 12px;
-      }
-      .metric {
-        border: 1px solid var(--line);
-        border-radius: 8px;
-        background: var(--dashboard-surface);
-        padding: 14px 16px;
-        box-shadow: none;
-        transition: all 0.2s ease;
-      }
-      .metric:hover {
-        box-shadow: none;
-        border-color: var(--line-strong);
-      }
-      .metric span {
-        display: block;
-        color: var(--muted);
-        font-size: 12px;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-      }
-      .metric strong {
-        display: block;
-        margin-top: 6px;
-        font-size: 26px;
-        font-weight: 700;
-        color: var(--ink);
-        letter-spacing: 0;
-      }
-
       .dashboard {
         display: grid;
         gap: 20px;
@@ -696,227 +662,371 @@
         display: grid;
         gap: 24px;
       }
-      .setup-stack {
-        display: grid;
+      .section-kicker {
+        color: var(--muted);
+        font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+        font-size: 11px;
+        font-weight: 800;
+        letter-spacing: 0.13em;
+      }
+      .fleet-dashboard {
         gap: 16px;
       }
-      .setup-card {
+      .fleet-hero {
+        position: relative;
         display: grid;
         grid-template-columns: minmax(0, 1fr) auto;
-        gap: 18px;
-        align-items: center;
-        border: 1px solid var(--line);
-        border-radius: 8px;
-        background: var(--dashboard-surface);
-        padding: 18px;
+        gap: 24px;
+        overflow: hidden;
+        border: 1px solid rgb(240 90 112 / 0.24);
+        border-radius: 12px;
+        background:
+          linear-gradient(120deg, rgb(240 90 112 / 0.12), transparent 44%),
+          linear-gradient(180deg, rgb(18 12 17 / 0.96), rgb(10 11 17 / 0.98));
+        padding: 28px;
       }
-      .setup-card h2 {
-        display: flex;
-        align-items: center;
-        gap: 9px;
-        margin: 0;
-        color: var(--ink);
-        font-size: 15px;
+      :root[data-theme="light"] .fleet-hero {
+        background:
+          linear-gradient(120deg, rgb(240 90 112 / 0.1), transparent 48%),
+          linear-gradient(180deg, #fff, #f7f8fb);
+      }
+      .fleet-hero::after {
+        content: "";
+        position: absolute;
+        inset: 0 0 auto auto;
+        width: 42%;
+        height: 100%;
+        opacity: 0.32;
+        background-image:
+          linear-gradient(var(--line) 1px, transparent 1px),
+          linear-gradient(90deg, var(--line) 1px, transparent 1px);
+        background-size: 24px 24px;
+        mask-image: linear-gradient(90deg, transparent, #000);
+        pointer-events: none;
+      }
+      .fleet-hero-copy,
+      .fleet-hero-actions,
+      .fleet-signal-grid {
+        position: relative;
+        z-index: 1;
+      }
+      .fleet-hero h2 {
+        margin: 9px 0 0;
+        font-size: clamp(28px, 5vw, 48px);
+        font-weight: 620;
+        letter-spacing: -0.04em;
+        line-height: 1;
+      }
+      .fleet-hero h2 strong {
+        color: var(--primary);
+        font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
         font-weight: 750;
       }
-      .setup-card h2 svg {
-        width: 16px;
-        height: 16px;
-        color: var(--primary);
-      }
-      .setup-card p {
-        margin: 6px 0 0;
-        color: var(--muted);
-        font-size: 14px;
-        line-height: 1.45;
-      }
-      .dashboard-grid {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 16px;
-      }
-      .fleet-control-panel {
-        display: grid;
-        grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
-        gap: 16px;
-        align-items: start;
-        border: 1px solid var(--line);
-        border-radius: 8px;
-        background: var(--dashboard-surface);
-        padding: 18px;
-      }
-      .fleet-control-panel h2 {
-        margin: 8px 0 0;
-        color: var(--ink);
-        font-size: 20px;
-        font-weight: 720;
-      }
-      .fleet-control-panel p {
-        margin: 7px 0 0;
+      .fleet-hero p {
         max-width: 620px;
+        margin: 12px 0 0;
         color: var(--muted);
         font-size: 14px;
-        line-height: 1.5;
       }
-      .fleet-control-grid {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 10px;
-      }
-      .fleet-control-grid .metric {
-        padding: 11px 12px;
-      }
-      .fleet-control-grid .metric strong {
-        font-size: 21px;
-      }
-      .fleet-control-meta {
-        grid-column: 1 / -1;
+      .fleet-hero-actions {
         display: flex;
-        flex-wrap: wrap;
         gap: 8px;
+        align-items: start;
       }
-      .fleet-control-meta span,
-      .fleet-control-meta a {
-        min-height: 26px;
-        border: 1px solid var(--line);
-        border-radius: 6px;
-        padding: 4px 8px;
-        color: var(--muted);
-        font-size: 12px;
-        font-weight: 650;
+      .fleet-signal-grid {
+        grid-column: 1 / -1;
+        display: grid;
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        border-top: 1px solid var(--line);
       }
-      .fleet-control-meta a {
-        color: var(--primary);
+      .fleet-signal {
+        min-width: 0;
+        padding: 16px 16px 0;
+        border-left: 1px solid var(--line);
       }
-      .chart-card {
-        border: 1px solid var(--line);
-        border-radius: 8px;
-        background: var(--dashboard-surface);
-        padding: 18px;
+      .fleet-signal:first-child {
+        padding-left: 0;
+        border-left: 0;
       }
-      .chart-head {
-        display: flex;
-        justify-content: space-between;
-        gap: 12px;
-        color: var(--muted);
-        font-size: 12px;
-        font-weight: 700;
-        letter-spacing: 0.06em;
-      }
-      .chart-head strong {
-        color: var(--ink);
-        font-size: 20px;
-        font-weight: 650;
-        letter-spacing: 0;
-      }
-      .chart-card svg {
+      .fleet-signal span,
+      .fleet-signal strong {
         display: block;
-        width: 100%;
-        height: 132px;
-        margin-top: 10px;
       }
-      .chart-grid {
-        fill: none;
-        stroke: var(--chart-grid);
-        stroke-dasharray: 4 6;
-        stroke-width: 1;
+      .fleet-signal span {
+        color: var(--muted);
+        font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+        font-size: 10px;
+        font-weight: 750;
+        letter-spacing: 0.09em;
+        text-transform: uppercase;
       }
-      .chart-line {
-        fill: none;
-        stroke: var(--accent);
-        stroke-linecap: round;
-        stroke-width: 2.5;
+      .fleet-signal strong {
+        margin-top: 2px;
+        color: var(--ink);
+        font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+        font-size: 24px;
       }
-      .chart-foot {
+      .fleet-signal.live strong {
+        color: var(--success);
+      }
+      .fleet-signal.provisioning strong {
+        color: var(--warning);
+      }
+      .fleet-signal.failed strong {
+        color: #f87171;
+      }
+      .fleet-ops-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1.2fr) minmax(340px, 0.8fr);
+        gap: 16px;
+      }
+      .readiness-panel,
+      .connection-deck,
+      .fleet-roster {
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        background: var(--dashboard-surface);
+      }
+      .readiness-panel,
+      .connection-deck {
+        padding: 20px;
+      }
+      .readiness-head,
+      .connection-deck > header,
+      .fleet-roster-head {
         display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+      }
+      .readiness-head h2,
+      .connection-deck h2,
+      .fleet-roster-head h2 {
+        margin: 7px 0 0;
+        color: var(--ink);
+        font-size: 18px;
+        font-weight: 680;
+        letter-spacing: -0.02em;
+      }
+      .registry-state {
+        display: inline-flex;
         align-items: center;
         gap: 7px;
         color: var(--muted);
         font-size: 12px;
+        font-weight: 650;
       }
-      .dot {
-        width: 8px;
-        height: 8px;
+      .registry-state i {
+        width: 7px;
+        height: 7px;
         border-radius: 50%;
-        background: var(--accent);
+        background: var(--success);
+        box-shadow: 0 0 0 4px rgb(52 211 153 / 0.1);
       }
-      .section-kicker {
-        color: var(--muted);
-        font-size: 13px;
-        font-weight: 750;
-        letter-spacing: 0.07em;
+      .registry-state.failed i {
+        background: #f87171;
+        box-shadow: 0 0 0 4px rgb(248 113 113 / 0.1);
       }
-      .vm-list {
+      .readiness-bars {
         display: grid;
+        gap: 11px;
+        margin-top: 22px;
+      }
+      .readiness-row {
+        display: grid;
+        grid-template-columns: 88px minmax(80px, 1fr) 28px;
         gap: 10px;
-      }
-      .vm-row {
-        display: grid;
-        grid-template-columns: minmax(0, 1fr) auto;
-        gap: 16px;
         align-items: center;
-        border: 1px solid var(--line);
-        border-radius: 8px;
-        background: var(--dashboard-surface);
-        padding: 15px 16px;
-      }
-      .vm-row strong,
-      .vm-row code,
-      .vm-row span {
-        display: block;
-      }
-      .vm-row strong {
-        color: var(--ink);
-        font-size: 14px;
-      }
-      .vm-row code {
-        margin-top: 6px;
-        color: var(--ink);
-        font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
-        font-size: 13px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-      .vm-row span {
-        margin-top: 4px;
         color: var(--muted);
         font-size: 12px;
       }
-      .vm-badges {
+      .readiness-row strong {
+        color: var(--ink);
+        font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+        text-align: right;
+      }
+      .readiness-track {
+        height: 6px;
+        overflow: hidden;
+        border-radius: 999px;
+        background: var(--line);
+      }
+      .readiness-track i {
+        display: block;
+        height: 100%;
+        border-radius: inherit;
+        background: var(--muted);
+      }
+      .readiness-track i.live {
+        background: var(--success);
+      }
+      .readiness-track i.provisioning {
+        background: var(--warning);
+      }
+      .readiness-track i.failed {
+        background: #f87171;
+      }
+      .readiness-track i.stopped {
+        background: var(--faint);
+      }
+      .readiness-meta {
         display: flex;
+        flex-wrap: wrap;
+        gap: 7px;
+        margin-top: 20px;
+        padding-top: 15px;
+        border-top: 1px solid var(--line);
+      }
+      .readiness-meta span,
+      .readiness-meta a {
+        border: 1px solid var(--line);
+        border-radius: 5px;
+        padding: 4px 7px;
+        color: var(--muted);
+        font-size: 11px;
+      }
+      .readiness-meta strong {
+        color: var(--ink);
+      }
+      .connection-deck {
+        display: grid;
+        gap: 0;
+      }
+      .connection-step {
+        display: grid;
+        grid-template-columns: 30px minmax(0, 1fr);
+        gap: 12px;
         align-items: center;
-        gap: 9px;
+        min-width: 0;
+        padding: 15px 0;
+        border-top: 1px solid var(--line);
+      }
+      .connection-deck > header + .connection-step {
+        margin-top: 13px;
+      }
+      .connection-index,
+      .fleet-empty-index {
+        color: var(--primary);
+        font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+        font-size: 11px;
+        font-weight: 750;
+      }
+      .connection-step strong,
+      .connection-step p {
+        display: block;
+      }
+      .connection-step strong {
+        color: var(--ink);
+        font-size: 13px;
+      }
+      .connection-step p {
+        margin: 3px 0 0;
+        color: var(--muted);
+        font-size: 11px;
+        line-height: 1.4;
+      }
+      .connection-step .terminal-command {
+        width: min(100%, 420px);
+      }
+      .connection-step > button {
+        grid-column: 2;
+        justify-self: start;
+      }
+      .copy-feedback {
+        min-width: 16px;
+        color: var(--muted);
+        font-size: 10px;
+      }
+      .copy-feedback svg {
+        display: block;
+      }
+      .fleet-roster {
+        padding: 20px;
+      }
+      .fleet-roster-head {
+        padding-bottom: 16px;
+        border-bottom: 1px solid var(--line);
+      }
+      .fleet-roster-head > span {
+        color: var(--muted);
+        font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+        font-size: 11px;
+      }
+      .fleet-owner-list {
+        display: grid;
+        gap: 22px;
+        margin-top: 20px;
       }
       .fleet-owner {
         display: grid;
         gap: 10px;
       }
       .fleet-owner-head {
+        min-height: 34px;
+      }
+      .fleet-owner-lockup {
         display: flex;
         align-items: center;
-        justify-content: space-between;
-        gap: 12px;
-        color: var(--muted);
+        gap: 10px;
+      }
+      .fleet-owner-mark {
+        display: grid;
+        width: 30px;
+        height: 30px;
+        place-items: center;
+        border: 1px solid rgb(240 90 112 / 0.3);
+        border-radius: 7px;
+        background: rgb(240 90 112 / 0.09);
+        color: var(--primary);
+        font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+        font-size: 12px;
+        font-weight: 800;
+      }
+      .fleet-owner-lockup strong,
+      .fleet-owner-lockup span {
+        display: block;
+      }
+      .fleet-owner-lockup strong {
+        color: var(--ink);
         font-size: 13px;
       }
-      .fleet-owner-head strong {
-        color: var(--ink);
-        font-size: 14px;
+      .fleet-owner-lockup span {
+        margin-top: 1px;
+        color: var(--muted);
+        font-size: 11px;
       }
       .fleet-box-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(248px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
         gap: 10px;
       }
       .fleet-box {
+        position: relative;
         display: grid;
         gap: 10px;
-        min-height: 174px;
+        min-height: 206px;
+        overflow: hidden;
         border: 1px solid var(--line);
         border-radius: 8px;
-        background: var(--dashboard-surface);
-        padding: 14px;
+        background: var(--panel);
+        padding: 15px;
+      }
+      .fleet-box::before {
+        content: "";
+        position: absolute;
+        inset: 0 auto 0 0;
+        width: 2px;
+        background: var(--faint);
+      }
+      .fleet-box.live::before,
+      .fleet-box.shared::before {
+        background: var(--success);
+      }
+      .fleet-box.provisioning::before {
+        background: var(--warning);
+      }
+      .fleet-box.failed::before {
+        background: #f87171;
       }
       .fleet-box-head {
         display: grid;
@@ -924,7 +1034,16 @@
         gap: 10px;
         align-items: start;
       }
+      .fleet-box-id {
+        display: block;
+        margin-bottom: 3px;
+        color: var(--muted);
+        font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+        font-size: 10px;
+        letter-spacing: 0.05em;
+      }
       .fleet-box-head strong {
+        display: block;
         min-width: 0;
         overflow: hidden;
         color: var(--ink);
@@ -939,17 +1058,10 @@
       }
       .fleet-box-meta span {
         border: 1px solid var(--line);
-        border-radius: 6px;
+        border-radius: 4px;
         color: var(--muted);
         padding: 2px 7px;
-        font-size: 12px;
-      }
-      .fleet-box code {
-        min-width: 0;
-        overflow: hidden;
-        color: var(--ink);
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        font-size: 11px;
       }
       .fleet-box-event {
         min-height: 36px;
@@ -962,6 +1074,28 @@
         -webkit-box-orient: vertical;
         -webkit-line-clamp: 2;
       }
+      .fleet-box-command {
+        display: grid;
+        gap: 4px;
+        min-width: 0;
+        padding: 9px 10px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: var(--command-bg);
+      }
+      .fleet-box-command code {
+        min-width: 0;
+        overflow: hidden;
+        color: var(--ink);
+        font-size: 11px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .fleet-box-command span {
+        color: var(--muted);
+        font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+        font-size: 10px;
+      }
       .fleet-box-actions {
         display: flex;
         flex-wrap: wrap;
@@ -973,30 +1107,62 @@
         box-shadow: none;
       }
       .state-pill {
-        min-width: 78px;
-        border-radius: 6px;
-        border: 1px solid rgb(52 211 153 / 0.22);
-        background: rgb(52 211 153 / 0.12);
-        color: var(--success) !important;
-        padding: 5px 9px;
+        min-width: 64px;
+        border-radius: 999px;
+        border: 1px solid var(--line);
+        background: var(--panel-2);
+        color: var(--muted) !important;
+        padding: 4px 8px;
         text-align: center;
-        font-size: 12px;
+        font-size: 10px;
         font-weight: 700;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
       }
-      .state-pill.failed,
-      .state-pill.expired,
-      .state-pill.stopped,
-      .state-pill.unavailable {
+      .state-pill.live,
+      .state-pill.shared {
+        border-color: rgb(52 211 153 / 0.22);
+        background: rgb(52 211 153 / 0.1);
+        color: var(--success) !important;
+      }
+      .state-pill.failed {
         border-color: rgb(239 68 68 / 0.26);
         background: rgb(239 68 68 / 0.11);
         color: #f87171 !important;
       }
-      .state-pill.pending,
-      .state-pill.pending_adapter,
       .state-pill.provisioning {
         border-color: rgb(251 191 36 / 0.25);
         background: rgb(251 191 36 / 0.1);
         color: var(--warning) !important;
+      }
+      :root[data-theme="light"] .state-pill.live,
+      :root[data-theme="light"] .state-pill.shared {
+        color: #047857 !important;
+      }
+      :root[data-theme="light"] .state-pill.provisioning {
+        color: #92400e !important;
+      }
+      :root[data-theme="light"] .state-pill.failed {
+        color: #b91c1c !important;
+      }
+      .fleet-empty {
+        display: grid;
+        grid-template-columns: 36px minmax(0, 1fr) auto;
+        gap: 14px;
+        align-items: center;
+        margin-top: 18px;
+        border: 1px dashed var(--line-strong);
+        border-radius: 8px;
+        padding: 18px;
+      }
+      .fleet-empty strong {
+        display: block;
+        color: var(--ink);
+      }
+      .fleet-empty p {
+        margin: 3px 0 10px;
+        color: var(--muted);
+        font-size: 12px;
       }
 
       .toolbar {
@@ -1948,13 +2114,7 @@
         .top {
           grid-template-columns: 1fr;
         }
-        .status-strip {
-          min-width: 0;
-        }
-        .dashboard-grid {
-          grid-template-columns: 1fr;
-        }
-        .fleet-control-panel {
+        .fleet-ops-grid {
           grid-template-columns: 1fr;
         }
         .board {
@@ -1980,6 +2140,9 @@
         .rail .spacer {
           display: none;
         }
+        .rail .spec-link {
+          display: none;
+        }
         .brand-lockup {
           min-width: 0;
           margin-right: auto;
@@ -1994,30 +2157,55 @@
         .login-back {
           left: 18px;
         }
-        .setup-card,
-        .vm-row {
-          grid-template-columns: 1fr;
-        }
         .command-row,
-        .vm-badges,
         .fleet-box-actions {
           flex-direction: column;
           align-items: stretch;
         }
-        .setup-card .terminal-command,
-        .vm-badges button,
         .fleet-box-actions button {
           width: 100%;
         }
         .toolbar,
-        .status-strip,
-        .fleet-control-grid,
         .dev-identity-panel,
         .board,
         .run-layout,
         .form-grid,
         .session-head {
           grid-template-columns: 1fr;
+        }
+        .fleet-hero {
+          grid-template-columns: 1fr;
+          padding: 20px;
+        }
+        .fleet-hero-actions {
+          flex-wrap: wrap;
+        }
+        .fleet-signal-grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+        .fleet-signal {
+          padding: 12px 10px 0;
+          border-top: 1px solid var(--line);
+        }
+        .fleet-signal:first-child {
+          padding-left: 10px;
+          border-left: 1px solid var(--line);
+        }
+        .readiness-head,
+        .fleet-roster-head {
+          align-items: flex-start;
+          flex-direction: column;
+        }
+        .connection-step > button {
+          width: 100%;
+          justify-self: stretch;
+        }
+        .fleet-empty {
+          grid-template-columns: 28px minmax(0, 1fr);
+        }
+        .fleet-empty > button {
+          grid-column: 2;
+          width: 100%;
         }
         .session-grid {
           grid-template-columns: 1fr;

--- a/src/app/components.jsx
+++ b/src/app/components.jsx
@@ -1,0 +1,50 @@
+import { useState } from "preact/hooks";
+
+export function CopyCommand({ value, className = "" }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    if (!navigator.clipboard) return;
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1400);
+  }
+
+  return (
+    <button
+      class={`terminal-command ${className}`.trim()}
+      type="button"
+      onClick={() => void copy()}
+      title="Copy command"
+    >
+      <code>{value}</code>
+      <span class="copy-feedback" aria-live="polite">
+        {copied ? "Copied" : <Icon name="copy" />}
+      </span>
+    </button>
+  );
+}
+
+export function Icon({ name }) {
+  const nodes = globalThis.lucideIconNodes?.[name];
+  if (!nodes) return null;
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      {nodes.map(([tag, attrs], index) => {
+        const Tag = tag;
+        return <Tag key={`${tag}-${index}`} {...attrs} />;
+      })}
+    </svg>
+  );
+}

--- a/src/app/fleet.jsx
+++ b/src/app/fleet.jsx
@@ -1,0 +1,367 @@
+import { CopyCommand } from "./components.jsx";
+import {
+  canMaintain,
+  elapsed,
+  interactiveSessionStatus,
+  isTerminalReadyInteractiveSession,
+  runCapabilities,
+  sessionLogsUrl,
+} from "./utils.js";
+
+const productDomain = "crabfleet.openclaw.ai";
+const sshHost = "crabd.sh";
+
+export function FleetPage(props) {
+  const sessions = props.state.interactiveSessions || [];
+  const fleet = props.state.fleet;
+  const totals = fleet?.totals || {};
+  const fleetSessionsById = new Map(
+    (fleet?.sessions || []).map((session) => [session.id, session]),
+  );
+  const groups = groupedFleetSessions(sessions);
+  const ownerCount = groups.length;
+  const sessionCount = totals.sessions ?? sessions.length;
+  const readyCount = totals.ready ?? countStatuses(sessions, ["ready", "attached", "detached"]);
+  const provisioningCount =
+    totals.provisioning ?? countStatuses(sessions, ["provisioning", "pending_adapter"]);
+  const failedCount = totals.failed ?? countStatuses(sessions, ["failed"]);
+  const stoppedCount =
+    totals.stopped ?? countStatuses(sessions, ["stopped", "expired", "unavailable"]);
+
+  return (
+    <section class="dashboard fleet-dashboard" aria-label="Crabfleet dashboard">
+      <section class="fleet-hero">
+        <div class="fleet-hero-copy">
+          <div class="section-kicker">OPENCLAW / FLEET COMMAND</div>
+          <h2>
+            <strong>{readyCount}</strong> crabboxes live
+          </h2>
+          <p>
+            One operational view across people, repositories, terminals, WebVNC, and sandbox policy.
+          </p>
+        </div>
+        <div class="fleet-hero-actions">
+          <button
+            class="primary"
+            disabled={!canMaintain(props.state.user)}
+            onClick={() => props.openDrawer("interactive")}
+          >
+            New crabbox
+          </button>
+          <button onClick={() => props.openSessionGrid(null)}>Open sessions</button>
+        </div>
+        <div class="fleet-signal-grid" aria-label="Fleet status summary">
+          <Signal label="Live" value={readyCount} tone="live" />
+          <Signal label="Starting" value={provisioningCount} tone="provisioning" />
+          <Signal label="Attention" value={failedCount} tone="failed" />
+          <Signal label="People" value={ownerCount} />
+          <Signal label="Total" value={sessionCount} />
+        </div>
+      </section>
+
+      <div class="fleet-ops-grid">
+        <ReadinessPanel
+          fleet={fleet}
+          repos={props.state.repos?.length || 0}
+          sessionCount={sessionCount}
+          ready={readyCount}
+          provisioning={provisioningCount}
+          failed={failedCount}
+          stopped={stoppedCount}
+          board={{
+            active: props.active,
+            cap: props.state.cap,
+            queue: props.queue,
+            review: props.review,
+          }}
+          cli={props.cli}
+        />
+        <ConnectionDeck
+          signedIn={props.signedIn}
+          userLabel={props.userLabel}
+          beginLogin={props.beginLogin}
+        />
+      </div>
+
+      <section class="fleet-roster">
+        <header class="fleet-roster-head">
+          <div>
+            <div class="section-kicker">ACTIVE ROSTER</div>
+            <h2>Crabboxes by operator</h2>
+          </div>
+          <span>
+            {ownerCount} {ownerCount === 1 ? "operator" : "operators"} / {sessionCount} sessions
+          </span>
+        </header>
+        {groups.length ? (
+          <div class="fleet-owner-list">
+            {groups.map(([owner, items]) => (
+              <section class="fleet-owner" key={owner}>
+                <header class="fleet-owner-head">
+                  <div class="fleet-owner-lockup">
+                    <span class="fleet-owner-mark">{ownerInitial(owner)}</span>
+                    <div>
+                      <strong>{sessionOwnerLabel(owner)}</strong>
+                      <span>
+                        {liveFleetCount(items)} live / {items.length} total
+                      </span>
+                    </div>
+                  </div>
+                </header>
+                <div class="fleet-box-grid">
+                  {items.map((session) => (
+                    <FleetBox
+                      key={session.id}
+                      session={{ ...session, fleet: fleetSessionsById.get(session.id) }}
+                      openSessionGrid={props.openSessionGrid}
+                    />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        ) : (
+          <div class="fleet-empty">
+            <span class="fleet-empty-index">00</span>
+            <div>
+              <strong>No crabboxes on the board</strong>
+              <p>Create one from SSH, the Go CLI, or the app.</p>
+              <CopyCommand value={`ssh ${sshHost} new --repo openclaw/crabfleet`} />
+            </div>
+            <button
+              class="primary"
+              onClick={() => props.openDrawer("interactive")}
+              disabled={!canMaintain(props.state.user)}
+            >
+              New crabbox
+            </button>
+          </div>
+        )}
+      </section>
+    </section>
+  );
+}
+
+function ReadinessPanel({
+  fleet,
+  repos,
+  sessionCount,
+  ready,
+  provisioning,
+  failed,
+  stopped,
+  board,
+  cli,
+}) {
+  const egress = fleet?.egress || {};
+  const registry = fleet?.registryAvailable === false ? "Registry degraded" : "Registry online";
+  const statuses = [
+    { label: "Ready", value: ready, tone: "live" },
+    { label: "Provisioning", value: provisioning, tone: "provisioning" },
+    { label: "Failed", value: failed, tone: "failed" },
+    { label: "Stopped", value: stopped, tone: "stopped" },
+  ];
+  return (
+    <section class="readiness-panel" aria-label="Fleet readiness">
+      <header class="readiness-head">
+        <div>
+          <div class="section-kicker">CONTROL PLANE</div>
+          <h2>{fleet?.canonicalUrl || `https://${productDomain}`}</h2>
+        </div>
+        <span class={`registry-state ${fleet?.registryAvailable === false ? "failed" : ""}`}>
+          <i aria-hidden="true" />
+          {registry}
+        </span>
+      </header>
+      <div class="readiness-bars">
+        {statuses.map((status) => (
+          <div class="readiness-row" key={status.label}>
+            <span>{status.label}</span>
+            <div class="readiness-track" aria-hidden="true">
+              <i
+                class={status.tone}
+                style={{ width: `${percentage(status.value, sessionCount)}%` }}
+              />
+            </div>
+            <strong>{status.value}</strong>
+          </div>
+        ))}
+      </div>
+      <div class="readiness-meta">
+        <span>
+          <strong>
+            {board.active}/{board.cap}
+          </strong>{" "}
+          board running
+        </span>
+        <span>
+          <strong>{board.queue}</strong> queued
+        </span>
+        <span>
+          <strong>{board.review}</strong> review
+        </span>
+        <span>
+          <strong>{cli || 0}</strong> attachable
+        </span>
+        <span>
+          <strong>{repos}</strong> repos
+        </span>
+        <span>
+          <strong>{egress.sessionsWithPolicy ?? 0}</strong> policies
+        </span>
+        <span>
+          <strong>{egress.defaultHostCount ?? 0}</strong> default hosts
+        </span>
+        <a href="/docs/spec-v2">Spec v2</a>
+      </div>
+    </section>
+  );
+}
+
+function ConnectionDeck({ signedIn, userLabel, beginLogin }) {
+  return (
+    <section class="connection-deck" aria-label="Connect to Crabfleet">
+      <header>
+        <div class="section-kicker">CONNECT</div>
+        <h2>Three paths into the fleet</h2>
+      </header>
+      <div class="connection-step">
+        <span class="connection-index">01</span>
+        <div>
+          <strong>GitHub identity</strong>
+          <p>{signedIn ? userLabel : "Scope repositories, pull requests, and gh credentials."}</p>
+        </div>
+        <button onClick={beginLogin} disabled={signedIn}>
+          {signedIn ? "Connected" : "Connect"}
+        </button>
+      </div>
+      <div class="connection-step">
+        <span class="connection-index">02</span>
+        <div>
+          <strong>Link SSH</strong>
+          <p>Attach a public key once for terminal-first control.</p>
+        </div>
+        <CopyCommand value={`ssh link@${sshHost}`} />
+      </div>
+      <div class="connection-step">
+        <span class="connection-index">03</span>
+        <div>
+          <strong>Launch work</strong>
+          <p>Start with a prepared repo and Codex ready.</p>
+        </div>
+        <CopyCommand
+          value={`ssh ${sshHost} new --repo openclaw/crabfleet "fix the failing check"`}
+        />
+      </div>
+    </section>
+  );
+}
+
+function FleetBox({ session, openSessionGrid }) {
+  const capabilities = runCapabilities(session);
+  const archiveCount = session.logArchive?.eventCount || session.logs?.length || 0;
+  const fleetPolicy = session.fleet?.policy;
+  const status = interactiveSessionStatus(session);
+  const seen = session.lastSeenAt || session.updatedAt || session.createdAt;
+  return (
+    <article class={`fleet-box ${status.tone || "idle"}`}>
+      <header class="fleet-box-head">
+        <div>
+          <span class="fleet-box-id">{session.id}</span>
+          <strong>{session.repo || session.title || session.id}</strong>
+        </div>
+        <span class={`state-pill ${status.tone || "idle"}`}>{status.label}</span>
+      </header>
+      <div class="fleet-box-meta">
+        <span>{session.branch || "main"}</span>
+        <span>{session.runtime || "crabbox"}</span>
+        {capabilities.vnc ? <span>webvnc</span> : null}
+        {archiveCount ? <span>{archiveCount} logs</span> : null}
+        {fleetPolicy?.present ? <span>{fleetPolicy.allowedHostCount} egress</span> : null}
+      </div>
+      <p class="fleet-box-event">{session.lastEvent || "Waiting for crabbox"}</p>
+      <div class="fleet-box-command">
+        <code>
+          ssh {sshHost} attach {session.id}
+        </code>
+        <span>{seen ? `seen ${elapsed(seen)}` : "no heartbeat"}</span>
+      </div>
+      <div class="fleet-box-actions">
+        <button class="primary" onClick={() => openSessionGrid(session.id)}>
+          Terminal
+        </button>
+        {session.vncUrl ? (
+          <button onClick={() => window.open(session.vncUrl, "_blank", "noopener")}>VNC</button>
+        ) : capabilities.vnc ? (
+          <button
+            class="pending-vnc"
+            disabled
+            title="WebVNC URL appears after crabbox provisioning"
+          >
+            VNC pending
+          </button>
+        ) : null}
+        {!session.sharedReadOnly ? (
+          <button onClick={() => window.open(sessionLogsUrl(session.id), "_blank", "noopener")}>
+            Logs
+          </button>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
+function Signal({ label, value, tone = "" }) {
+  return (
+    <div class={`fleet-signal ${tone}`}>
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function sessionOwner(session) {
+  return session.owner || session.operator || "unassigned";
+}
+
+function sessionOwnerLabel(owner) {
+  return String(owner || "unassigned").replace(/^github:/, "@");
+}
+
+function ownerInitial(owner) {
+  return sessionOwnerLabel(owner).replace(/^@/, "").slice(0, 1).toUpperCase() || "?";
+}
+
+function groupedFleetSessions(sessions) {
+  const groups = new Map();
+  for (const session of sessions) {
+    const owner = sessionOwner(session);
+    if (!groups.has(owner)) groups.set(owner, []);
+    groups.get(owner).push(session);
+  }
+  return [...groups.entries()]
+    .map(([owner, items]) => [
+      owner,
+      [...items].sort(
+        (a, b) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0),
+      ),
+    ])
+    .sort((a, b) => {
+      const activeDelta = liveFleetCount(b[1]) - liveFleetCount(a[1]);
+      return activeDelta || sessionOwnerLabel(a[0]).localeCompare(sessionOwnerLabel(b[0]));
+    });
+}
+
+function liveFleetCount(sessions) {
+  return sessions.filter(isTerminalReadyInteractiveSession).length;
+}
+
+function countStatuses(sessions, statuses) {
+  const allowed = new Set(statuses);
+  return sessions.filter((session) => allowed.has(session.status)).length;
+}
+
+function percentage(value, total) {
+  if (!total || value <= 0) return 0;
+  return Math.max(2, Math.round((value / total) * 100));
+}

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -1,14 +1,19 @@
 import { render } from "preact";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
 import { api } from "./api.js";
+import { CopyCommand, Icon } from "./components.jsx";
+import { FleetPage } from "./fleet.jsx";
 import {
   canMaintain,
   canOwn,
   elapsed,
   hasRunCapability,
+  humanStatus,
   issueNumber,
   isActiveRun,
+  isDeadInteractiveSession,
   isProvisioningInteractiveSession,
+  interactiveSessionStatus,
   lanes,
   linkedInteractiveSessionPlaceholder,
   optimisticInteractiveSession,
@@ -16,6 +21,7 @@ import {
   preferredRepos,
   runCapabilities,
   runtimeCapabilityLabel,
+  sessionLogsUrl,
   sessionItems,
   statusLabel,
   terminalText,
@@ -32,7 +38,7 @@ import {
 
 const logo = "__CRABBOX_LOGO__";
 const productName = "Crabfleet";
-const productDomain = "clawfleet.openclaw.ai";
+const productDomain = "crabfleet.openclaw.ai";
 const sshHost = "crabd.sh";
 const loginReturnKey = "crabbox-login-return";
 const skipAutoGithubLoginKey = "crabbox-skip-auto-github-login";
@@ -49,8 +55,6 @@ const emptyState = {
   retention: "30",
   merge: "guarded",
 };
-const deadInteractiveStatuses = new Set(["stopped", "expired", "failed", "unavailable"]);
-
 function initialState(initialSessionLink) {
   if (!initialSessionLink.id) return emptyState;
   return {
@@ -960,6 +964,7 @@ function LoginScreen({ hidden, authMethods, message, onGithub, onToken, onDevIde
                 Bootstrap token
                 <input
                   type="password"
+                  name="bootstrap-token"
                   autocomplete="current-password"
                   disabled={!authMethods.token}
                   value={token}
@@ -1092,7 +1097,12 @@ function AppShell(props) {
         >
           <Icon name={props.theme === "dark" ? "sun" : "moon"} />
         </button>
-        <button title="Spec" aria-label="Spec" onClick={() => (location.href = "/docs/spec")}>
+        <button
+          class="spec-link"
+          title="Spec"
+          aria-label="Spec"
+          onClick={() => (location.href = "/docs/spec")}
+        >
           <Icon name="book-open" />
         </button>
       </aside>
@@ -1135,38 +1145,6 @@ function AppShell(props) {
   );
 }
 
-function sessionOwner(session) {
-  return session.owner || session.operator || "unassigned";
-}
-
-function sessionOwnerLabel(owner) {
-  return String(owner || "unassigned").replace(/^github:/, "@");
-}
-
-function groupedFleetSessions(sessions) {
-  const groups = new Map();
-  for (const session of sessions) {
-    const owner = sessionOwner(session);
-    if (!groups.has(owner)) groups.set(owner, []);
-    groups.get(owner).push(session);
-  }
-  return [...groups.entries()]
-    .map(([owner, items]) => [
-      owner,
-      [...items].sort(
-        (a, b) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0),
-      ),
-    ])
-    .sort((a, b) => {
-      const activeDelta = activeFleetCount(b[1]) - activeFleetCount(a[1]);
-      return activeDelta || sessionOwnerLabel(a[0]).localeCompare(sessionOwnerLabel(b[0]));
-    });
-}
-
-function activeFleetCount(sessions) {
-  return sessions.filter((session) => !isDeadInteractiveSession(session)).length;
-}
-
 function BoardPage(props) {
   return (
     <section class="board-page" aria-label="Crabfleet board page">
@@ -1174,6 +1152,7 @@ function BoardPage(props) {
         <div class="search-wrap">
           <input
             type="search"
+            name="board-search"
             placeholder="Search cards, repos, runs, #76552"
             value={props.search}
             onInput={(event) => props.setSearch(event.currentTarget.value)}
@@ -1210,229 +1189,6 @@ function BoardPage(props) {
       </section>
       <Board {...props} />
     </section>
-  );
-}
-
-function FleetPage(props) {
-  const sessions = props.state.interactiveSessions || [];
-  const fleet = props.state.fleet;
-  const totals = fleet?.totals || {};
-  const fleetSessionsById = new Map(
-    (fleet?.sessions || []).map((session) => [session.id, session]),
-  );
-  const groups = groupedFleetSessions(sessions);
-  const ownerCount = groups.length;
-  const repos = props.state.repos?.length || 0;
-  const sessionLabel = props.cli ? `${props.cli} attachable` : "none attached";
-  return (
-    <section class="dashboard" aria-label="Crabfleet dashboard">
-      <div class="setup-stack">
-        <DashboardAction
-          icon="git-pull-request"
-          title="GitHub access"
-          text={`Repos, pull requests, and gh credentials are scoped to ${props.userLabel}.`}
-          action={props.signedIn ? "Connected" : "Connect"}
-          disabled={props.signedIn}
-          onClick={props.beginLogin}
-        />
-        <div class="setup-card">
-          <div>
-            <h2>
-              <Icon name="terminal" />
-              Connect over SSH
-            </h2>
-            <p>Link a public key once, then create, list, attach, and open VNC for crabboxes.</p>
-          </div>
-          <CopyCommand value={`ssh link@${sshHost}`} />
-        </div>
-        <div class="setup-card">
-          <div>
-            <h2>
-              <Icon name="square-terminal" />
-              Start a Crabbox
-            </h2>
-            <p>Crabboxes boot with the repo prepared and Codex ready for OpenClaw supervision.</p>
-          </div>
-          <CopyCommand
-            value={`ssh ${sshHost} new --repo openclaw/crabfleet "fix the failing check"`}
-          />
-        </div>
-      </div>
-      <div class="status-strip">
-        <Metric label="Running" value={totals.active ?? activeFleetCount(sessions)} />
-        <Metric label="People" value={ownerCount} />
-        <Metric label="Crabboxes" value={totals.sessions ?? sessions.length} />
-      </div>
-      <FleetControlPanel fleet={fleet} repos={repos} />
-      <div class="dashboard-grid">
-        <DashboardChart
-          title="OPENCLAW QUEUE"
-          value={`${props.active}/${props.state.cap}`}
-          meta={`${props.queue} queued`}
-        />
-        <DashboardChart
-          title="CRABBOX FLEET"
-          value={sessionLabel}
-          meta={`${repos} repos`}
-          secondary
-        />
-      </div>
-      <section class="vm-list">
-        <div class="section-kicker">ALL CRABBOXES BY PERSON</div>
-        {groups.length ? (
-          groups.map(([owner, items]) => (
-            <section class="fleet-owner" key={owner}>
-              <header class="fleet-owner-head">
-                <strong>{sessionOwnerLabel(owner)}</strong>
-                <span>{activeFleetCount(items)} active</span>
-              </header>
-              <div class="fleet-box-grid">
-                {items.map((session) => (
-                  <FleetBox
-                    key={session.id}
-                    session={{ ...session, fleet: fleetSessionsById.get(session.id) }}
-                    openSessionGrid={props.openSessionGrid}
-                  />
-                ))}
-              </div>
-            </section>
-          ))
-        ) : (
-          <div class="vm-row empty-row">
-            <div>
-              <strong>No crabboxes yet</strong>
-              <code>ssh {sshHost} new --repo openclaw/crabfleet</code>
-              <span>Create one from SSH, the Go CLI, or the app.</span>
-            </div>
-            <button
-              onClick={() => props.openDrawer("interactive")}
-              disabled={!canMaintain(props.state.user)}
-            >
-              New crabbox
-            </button>
-          </div>
-        )}
-      </section>
-    </section>
-  );
-}
-
-function FleetControlPanel({ fleet, repos }) {
-  const totals = fleet?.totals || {};
-  const egress = fleet?.egress || {};
-  const registry = fleet?.registryAvailable === false ? "registry unavailable" : "registry online";
-  return (
-    <section class="fleet-control-panel" aria-label="Fleet control plane">
-      <div>
-        <div class="section-kicker">CONTROL PLANE</div>
-        <h2>{fleet?.canonicalUrl || `https://${productDomain}`}</h2>
-        <p>
-          Tracks every visible Codex crabbox, its runtime, log archive, attach state, and redacted
-          sandbox egress policy.
-        </p>
-      </div>
-      <div class="fleet-control-grid">
-        <Metric label="Ready" value={totals.ready ?? 0} />
-        <Metric label="Provisioning" value={totals.provisioning ?? 0} />
-        <Metric label="Archived" value={totals.archived ?? 0} />
-        <Metric label="Policies" value={egress.sessionsWithPolicy ?? 0} />
-      </div>
-      <div class="fleet-control-meta">
-        <span>{registry}</span>
-        <span>{egress.defaultHostCount ?? 0} default egress hosts</span>
-        <span>{repos} allowed repos</span>
-        <a href="/docs/spec-v2">Spec v2</a>
-      </div>
-    </section>
-  );
-}
-
-function FleetBox({ session, openSessionGrid }) {
-  const capabilities = runCapabilities(session);
-  const archiveCount = session.logArchive?.eventCount || session.logs?.length || 0;
-  const fleetPolicy = session.fleet?.policy;
-  return (
-    <article class="fleet-box">
-      <header class="fleet-box-head">
-        <strong>{session.repo || session.title || session.id}</strong>
-        <span class={`state-pill ${session.status || "pending"}`}>
-          {session.status || "pending"}
-        </span>
-      </header>
-      <div class="fleet-box-meta">
-        <span>{session.branch || "main"}</span>
-        <span>{session.runtime || "crabbox"}</span>
-        {capabilities.vnc ? <span>webvnc</span> : null}
-        {archiveCount ? <span>{archiveCount} logs</span> : null}
-        {fleetPolicy?.present ? <span>{fleetPolicy.allowedHostCount} egress</span> : null}
-      </div>
-      <p class="fleet-box-event">{session.lastEvent || "Waiting for crabbox"}</p>
-      <code>
-        ssh {sshHost} attach {session.id}
-      </code>
-      <div class="fleet-box-actions">
-        <button onClick={() => openSessionGrid(session.id)}>Terminal</button>
-        {session.vncUrl ? (
-          <button onClick={() => window.open(session.vncUrl, "_blank", "noopener")}>VNC</button>
-        ) : capabilities.vnc ? (
-          <button
-            class="pending-vnc"
-            disabled
-            title="WebVNC URL appears after crabbox provisioning"
-          >
-            VNC pending
-          </button>
-        ) : null}
-        {!session.sharedReadOnly ? (
-          <button onClick={() => window.open(sessionLogsUrl(session.id), "_blank", "noopener")}>
-            Logs
-          </button>
-        ) : null}
-      </div>
-    </article>
-  );
-}
-
-function sessionLogsUrl(id) {
-  return `/api/interactive-sessions/${encodeURIComponent(id)}/logs`;
-}
-
-function DashboardAction({ icon, title, text, action, disabled, onClick }) {
-  return (
-    <div class="setup-card">
-      <div>
-        <h2>
-          <Icon name={icon} />
-          {title}
-        </h2>
-        <p>{text}</p>
-      </div>
-      <button onClick={onClick} disabled={disabled}>
-        {action}
-      </button>
-    </div>
-  );
-}
-
-function DashboardChart({ title, value, meta, secondary }) {
-  const path = secondary
-    ? "M8 82 C 40 74, 52 76, 78 58 S 130 50, 158 42 S 214 32, 250 34"
-    : "M8 84 C 28 72, 42 78, 58 64 S 92 62, 112 50 S 140 72, 158 46 S 210 38, 250 28";
-  return (
-    <article class="chart-card">
-      <div class="chart-head">
-        <span>{title}</span>
-        <strong>{value}</strong>
-      </div>
-      <svg viewBox="0 0 260 96" role="img" aria-label={`${title} ${value}`}>
-        <path class="chart-grid" d="M8 24 H252 M8 54 H252 M8 84 H252" />
-        <path class="chart-line" d={path} />
-      </svg>
-      <div class="chart-foot">
-        <span class="dot" />
-        {meta}
-      </div>
-    </article>
   );
 }
 
@@ -1480,15 +1236,29 @@ function DevIdentityPanel({ hidden, user, onDevIdentity }) {
       </div>
       <label>
         ID
-        <input value={id} onInput={(event) => setId(event.currentTarget.value)} />
+        <input
+          name="dev-identity-id"
+          autocomplete="username"
+          value={id}
+          onInput={(event) => setId(event.currentTarget.value)}
+        />
       </label>
       <label>
         Name
-        <input value={name} onInput={(event) => setName(event.currentTarget.value)} />
+        <input
+          name="dev-identity-name"
+          autocomplete="name"
+          value={name}
+          onInput={(event) => setName(event.currentTarget.value)}
+        />
       </label>
       <label>
         Role
-        <select value={role} onInput={(event) => setRole(event.currentTarget.value)}>
+        <select
+          name="dev-identity-role"
+          value={role}
+          onInput={(event) => setRole(event.currentTarget.value)}
+        >
           <option value="owner">Owner</option>
           <option value="maintainer">Maintainer</option>
           <option value="viewer">Viewer</option>
@@ -1498,28 +1268,6 @@ function DevIdentityPanel({ hidden, user, onDevIdentity }) {
         Apply
       </button>
     </div>
-  );
-}
-
-function Metric({ label, value }) {
-  return (
-    <div class="metric">
-      <span>{label}</span>
-      <strong>{value}</strong>
-    </div>
-  );
-}
-
-function CopyCommand({ value }) {
-  async function copy() {
-    if (!navigator.clipboard) return;
-    await navigator.clipboard.writeText(value);
-  }
-  return (
-    <button class="terminal-command" type="button" onClick={() => void copy()} title="Copy command">
-      <code>{value}</code>
-      <Icon name="copy" />
-    </button>
   );
 }
 
@@ -2016,6 +1764,7 @@ function SessionTools({
       <label class="session-columns-field">
         <span>Columns</span>
         <select
+          name="session-columns"
           value={focused ? "1" : sessionLayout.columns}
           disabled={focused}
           onChange={(event) =>
@@ -2308,14 +2057,6 @@ function InteractiveSessionActions(props) {
   );
 }
 
-function isDeadInteractiveSession(session) {
-  return (
-    session &&
-    (session.kind === undefined || session.kind === "interactive") &&
-    deadInteractiveStatuses.has(session.status)
-  );
-}
-
 function canCleanInteractiveSession(session, user) {
   return isDeadInteractiveSession(session) && (session.canManage || canMaintain(user));
 }
@@ -2332,28 +2073,7 @@ function SessionStatus({ session }) {
 
 function sessionStatus(session) {
   if (session.kind === "interactive") {
-    if (session.routePlaceholder && session.status === "loading") {
-      return { label: "Loading", tone: "provisioning" };
-    }
-    if (session.routePlaceholder && session.status === "unavailable") {
-      return { label: "Unavailable", tone: "failed" };
-    }
-    if (["failed"].includes(session.status)) return { label: "Failed", tone: "failed" };
-    if (["stopped", "expired"].includes(session.status))
-      return { label: "Stopped", tone: "stopped" };
-    if (session.status === "provisioning" || session.status === "pending_adapter") {
-      return { label: "Provisioning", tone: "provisioning" };
-    }
-    if (session.shareMode === "link_read" || session.sharedReadOnly) {
-      return { label: "Shared", tone: "shared" };
-    }
-    if (session.multiplayerMode) {
-      return { label: "Multiplayer", tone: "shared" };
-    }
-    if (["ready", "attached", "detached"].includes(session.status)) {
-      return { label: "Live", tone: "live" };
-    }
-    return { label: humanStatus(session.status), tone: "" };
+    return interactiveSessionStatus(session);
   }
   if (session.run?.status === "failed" || session.lane === "Human Review") {
     return { label: humanStatus(session.run?.status || session.lane), tone: "failed" };
@@ -2382,12 +2102,6 @@ function sessionFooterSummary(session) {
   if (session.run?.status) parts.push(humanStatus(session.run.status));
   if (session.run?.runtime || session.runtime) parts.push(session.run?.runtime || session.runtime);
   return parts.join(" · ");
-}
-
-function humanStatus(value) {
-  return String(value || "")
-    .replace(/[_-]+/g, " ")
-    .replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
 function TerminalMount({ session, focused, singleSession, drawerOpen }) {
@@ -2593,6 +2307,7 @@ function AdminList({ title, placeholder, disabled, select, rows, onAdd, onRemove
       <div class="form-grid">
         <input
           class="full"
+          name="admin-entry"
           placeholder={placeholder}
           value={value}
           disabled={disabled}
@@ -2601,6 +2316,7 @@ function AdminList({ title, placeholder, disabled, select, rows, onAdd, onRemove
         {select ? (
           <select
             class="full"
+            name="admin-role"
             value={role}
             disabled={disabled}
             onChange={(event) => setRole(event.currentTarget.value)}
@@ -2657,6 +2373,7 @@ function PolicyBox({ disabled, state, updatePolicy }) {
         Concurrent cap
         <input
           type="number"
+          name="concurrent-cap"
           min="1"
           max="200"
           value={cap}
@@ -2667,6 +2384,7 @@ function PolicyBox({ disabled, state, updatePolicy }) {
       <label>
         Direct merge
         <select
+          name="merge-policy"
           value={merge}
           disabled={disabled}
           onChange={(event) => setMerge(event.currentTarget.value)}
@@ -2679,6 +2397,7 @@ function PolicyBox({ disabled, state, updatePolicy }) {
       <label>
         Log retention
         <select
+          name="log-retention"
           value={retention}
           disabled={disabled}
           onChange={(event) => setRetention(event.currentTarget.value)}
@@ -2722,6 +2441,7 @@ function WorkflowBox({ disabled, workflows, refreshWorkflow }) {
       <div class="form-grid">
         <input
           class="full"
+          name="workflow-repo"
           placeholder={preferredRepo}
           value={repo}
           disabled={disabled}
@@ -2781,30 +2501,6 @@ function Drawer({ id, open, title, wide, onClose, children }) {
         <div class="panel-body">{children}</div>
       </section>
     </div>
-  );
-}
-
-function Icon({ name }) {
-  const nodes = globalThis.lucideIconNodes?.[name];
-  if (!nodes) return null;
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      aria-hidden="true"
-    >
-      {nodes.map(([tag, attrs], index) => {
-        const Tag = tag;
-        return <Tag key={`${tag}-${index}`} {...attrs} />;
-      })}
-    </svg>
   );
 }
 

--- a/src/app/terminal.js
+++ b/src/app/terminal.js
@@ -7,7 +7,7 @@ import {
   encodeSubscribePayload,
   encodeTerminalFrame,
 } from "../terminal-protocol.ts";
-import { clipboardName, terminalText } from "./utils.js";
+import { clipboardName, isTerminalReadyInteractiveSession, terminalText } from "./utils.js";
 
 const terminalTheme = {
   background: "#101827",
@@ -246,20 +246,18 @@ export function disposeTerminal(id) {
 
 function shouldConnectLiveTerminal(session) {
   return (
-    session.kind === "interactive" &&
+    isTerminalReadyInteractiveSession(session) &&
     (session.canControl === true ||
       session.sharedReadOnly === true ||
-      (terminalHubOptions.sharedToken && session.id === terminalHubOptions.sharedSessionId)) &&
-    ["ready", "attached", "detached"].includes(session.status)
+      (terminalHubOptions.sharedToken && session.id === terminalHubOptions.sharedSessionId))
   );
 }
 
 function canSendTerminalInput(session) {
   return (
-    session.kind === "interactive" &&
+    isTerminalReadyInteractiveSession(session) &&
     session.canControl === true &&
-    session.sharedReadOnly !== true &&
-    ["ready", "attached", "detached"].includes(session.status)
+    session.sharedReadOnly !== true
   );
 }
 

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -1,6 +1,17 @@
 export const lanes = ["Todo", "Running", "Human Review", "Done"];
 export const preferredRepo = "openclaw/crabfleet";
 
+const activeInteractiveStatuses = new Set([
+  "provisioning",
+  "pending_adapter",
+  "ready",
+  "attached",
+  "detached",
+]);
+const deadInteractiveStatuses = new Set(["stopped", "expired", "failed", "unavailable"]);
+const provisioningInteractiveStatuses = new Set(["provisioning", "pending_adapter"]);
+const terminalReadyInteractiveStatuses = new Set(["ready", "attached", "detached"]);
+
 export function roleRank(role) {
   return { viewer: 1, maintainer: 2, owner: 3 }[role] || 0;
 }
@@ -86,9 +97,7 @@ export function hasRunCapability(session, name) {
 export function isActiveRun(session) {
   if (session.routePlaceholder) return true;
   if (session.kind === "interactive") {
-    return ["provisioning", "pending_adapter", "ready", "attached", "detached"].includes(
-      session.status,
-    );
+    return activeInteractiveStatuses.has(session.status);
   }
   return ["queued", "leasing", "running"].includes(session.run?.status);
 }
@@ -97,8 +106,58 @@ export function isProvisioningInteractiveSession(session) {
   return (
     session?.kind === "interactive" &&
     ((session.routePlaceholder && session.status === "loading") ||
-      ["provisioning", "pending_adapter"].includes(session.status))
+      provisioningInteractiveStatuses.has(session.status))
   );
+}
+
+export function isDeadInteractiveSession(session) {
+  return (
+    session &&
+    (session.kind === undefined || session.kind === "interactive") &&
+    deadInteractiveStatuses.has(session.status)
+  );
+}
+
+export function isTerminalReadyInteractiveSession(session) {
+  return (
+    session &&
+    (session.kind === undefined || session.kind === "interactive") &&
+    terminalReadyInteractiveStatuses.has(session.status)
+  );
+}
+
+export function humanStatus(value) {
+  return String(value || "")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+export function interactiveSessionStatus(session) {
+  if (session.routePlaceholder && session.status === "loading") {
+    return { label: "Loading", tone: "provisioning" };
+  }
+  if (session.routePlaceholder && session.status === "unavailable") {
+    return { label: "Unavailable", tone: "failed" };
+  }
+  if (session.status === "failed") return { label: "Failed", tone: "failed" };
+  if (session.status === "stopped" || session.status === "expired") {
+    return { label: "Stopped", tone: "stopped" };
+  }
+  if (provisioningInteractiveStatuses.has(session.status)) {
+    return { label: "Provisioning", tone: "provisioning" };
+  }
+  if (session.shareMode === "link_read" || session.sharedReadOnly) {
+    return { label: "Shared", tone: "shared" };
+  }
+  if (session.multiplayerMode) return { label: "Multiplayer", tone: "shared" };
+  if (terminalReadyInteractiveStatuses.has(session.status)) {
+    return { label: "Live", tone: "live" };
+  }
+  return { label: humanStatus(session.status), tone: "" };
+}
+
+export function sessionLogsUrl(id) {
+  return `/api/interactive-sessions/${encodeURIComponent(id)}/logs`;
 }
 
 export function runtimeCapabilityLabel(session) {

--- a/src/canonical-host.ts
+++ b/src/canonical-host.ts
@@ -1,0 +1,74 @@
+export const appCanonicalHost = "crabfleet.openclaw.ai";
+export const appCanonicalOrigin = `https://${appCanonicalHost}`;
+const productCanonicalHost = "crabfleet.ai";
+const productOriginHost = "crabbox.sh";
+const productHosts = new Set([productCanonicalHost, `www.${productCanonicalHost}`]);
+export const appRedirectHosts = new Set([
+  "clawfleet.openclaw.ai",
+  "crabyard.openclaw.ai",
+  "crabbox-ai.services-91b.workers.dev",
+]);
+
+export async function productHostResponse(
+  request: Request,
+  fetcher: typeof fetch = fetch,
+): Promise<Response | null> {
+  const url = new URL(request.url);
+  if (!productHosts.has(url.hostname)) return null;
+
+  if (url.hostname !== productCanonicalHost) {
+    url.hostname = productCanonicalHost;
+    return Response.redirect(url.toString(), 308);
+  }
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response("Method not allowed\n", {
+      status: 405,
+      headers: { allow: "GET, HEAD", "content-type": "text/plain; charset=utf-8" },
+    });
+  }
+
+  const upstreamUrl = new URL(url);
+  upstreamUrl.hostname = productOriginHost;
+  const upstreamHeaders = new Headers();
+  for (const name of [
+    "accept",
+    "accept-encoding",
+    "accept-language",
+    "if-modified-since",
+    "if-none-match",
+    "range",
+  ]) {
+    const value = request.headers.get(name);
+    if (value) upstreamHeaders.set(name, value);
+  }
+  const upstream = await fetcher(upstreamUrl, {
+    method: request.method,
+    headers: upstreamHeaders,
+    redirect: "manual",
+  });
+  const headers = new Headers(upstream.headers);
+  const location = headers.get("location");
+  if (location) {
+    const redirect = new URL(location, upstreamUrl);
+    if (redirect.hostname === productOriginHost) {
+      redirect.hostname = productCanonicalHost;
+      headers.set("location", redirect.toString());
+    }
+  }
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  });
+}
+
+export function canonicalAppRedirect(url: URL): Response | null {
+  if (!appRedirectHosts.has(url.hostname)) return null;
+  // Existing CLI, agent, and terminal clients may attach Authorization headers.
+  // Cross-host redirects commonly strip them, so legacy API hosts stay usable.
+  if (url.pathname === "/api" || url.pathname.startsWith("/api/")) return null;
+  const target = new URL(appCanonicalOrigin);
+  target.pathname = url.pathname;
+  target.search = url.search;
+  return Response.redirect(target.toString(), 308);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,13 @@ import {
   SPEC_V2_HTML,
   SPEC_V2_MARKDOWN,
 } from "./generated";
+import {
+  appCanonicalHost,
+  appCanonicalOrigin,
+  appRedirectHosts,
+  canonicalAppRedirect,
+  productHostResponse,
+} from "./canonical-host";
 
 type Role = "viewer" | "maintainer" | "owner";
 
@@ -680,15 +687,6 @@ const sshLinkSeconds = 5 * 60;
 const terminalClipboardMaxBytes = 10 * 1024 * 1024;
 const lanes = ["Todo", "Running", "Human Review", "Done"];
 const preferredRepo = "openclaw/crabfleet";
-const appCanonicalHost = "clawfleet.openclaw.ai";
-const appCanonicalOrigin = `https://${appCanonicalHost}`;
-const appRedirectHosts = new Set([
-  "crabfleet.ai",
-  "www.crabfleet.ai",
-  "crabfleet.openclaw.ai",
-  "crabyard.openclaw.ai",
-  "crabbox-ai.services-91b.workers.dev",
-]);
 const sandboxLeasePrefix = "sandbox:";
 const sandboxLeaseProfile = "autostart-v4";
 const activeRunStatuses: readonly RunStatus[] = ["queued", "leasing", "running"];
@@ -1103,6 +1101,9 @@ export default {
     const url = new URL(request.url);
 
     try {
+      const productResponse = await productHostResponse(request);
+      if (productResponse) return productResponse;
+
       const canonicalRedirect = canonicalAppRedirect(url);
       if (canonicalRedirect) return canonicalRedirect;
 
@@ -2467,7 +2468,7 @@ async function readFleetState(
   ]);
   return buildFleetState(interactiveSessions, policyResult.policies, {
     canonicalUrl: appCanonicalOrigin,
-    productUrl: "https://clawfleet.ai",
+    productUrl: "https://crabfleet.ai",
     defaultEgressHosts: defaultSandboxEgressHosts,
     generatedAt: Date.now(),
     registryAvailable: policyResult.available,
@@ -8067,14 +8068,6 @@ function isConstraintError(error: unknown): boolean {
 function wantsMarkdown(request: Request): boolean {
   const accept = request.headers.get("accept") ?? "";
   return accept.includes("text/markdown");
-}
-
-function canonicalAppRedirect(url: URL): Response | null {
-  if (!appRedirectHosts.has(url.hostname)) return null;
-  const target = new URL(appCanonicalOrigin);
-  target.pathname = url.pathname;
-  target.search = url.search;
-  return Response.redirect(target.toString(), 308);
 }
 
 function text(

--- a/tests/app-utils.test.ts
+++ b/tests/app-utils.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  humanStatus,
   isActiveRun,
+  isDeadInteractiveSession,
+  isTerminalReadyInteractiveSession,
+  interactiveSessionStatus,
   interactiveCommand,
   linkedInteractiveSessionPlaceholder,
   optimisticInteractiveSession,
@@ -102,4 +106,23 @@ test("linked session placeholders render a best-effort Codex card", () => {
   assert.equal(isActiveRun(session), true);
   assert.match(terminalText(session), /^Preparing Codex\r\n/);
   assert.match(terminalText(session), /Loading session/);
+});
+
+test("interactive lifecycle helpers keep UI and terminal state aligned", () => {
+  const live = { kind: "interactive", status: "attached" };
+  const rawLive = { status: "ready" };
+  const provisioning = { kind: "interactive", status: "pending_adapter" };
+  const failed = { kind: "interactive", status: "failed" };
+
+  assert.equal(isActiveRun(live), true);
+  assert.equal(isTerminalReadyInteractiveSession(live), true);
+  assert.equal(isTerminalReadyInteractiveSession(rawLive), true);
+  assert.deepEqual(interactiveSessionStatus(live), { label: "Live", tone: "live" });
+  assert.deepEqual(interactiveSessionStatus(provisioning), {
+    label: "Provisioning",
+    tone: "provisioning",
+  });
+  assert.equal(isDeadInteractiveSession(failed), true);
+  assert.deepEqual(interactiveSessionStatus(failed), { label: "Failed", tone: "failed" });
+  assert.equal(humanStatus("pending_adapter"), "Pending Adapter");
 });

--- a/tests/canonical-host.test.ts
+++ b/tests/canonical-host.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { canonicalAppRedirect, productHostResponse } from "../src/canonical-host.ts";
+
+test("product hosts never fall through to the app worker", async () => {
+  let upstreamRequest: Request | undefined;
+  const response = await productHostResponse(
+    new Request("https://crabfleet.ai/docs?mode=full", {
+      headers: { accept: "text/html", authorization: "Bearer private" },
+    }),
+    async (input, init) => {
+      upstreamRequest = new Request(input, init);
+      return new Response("<title>CrabFleet</title>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    },
+  );
+
+  assert.equal(response?.status, 200);
+  assert.equal(await response?.text(), "<title>CrabFleet</title>");
+  assert.equal(upstreamRequest?.url, "https://crabbox.sh/docs?mode=full");
+  assert.equal(upstreamRequest?.headers.get("accept"), "text/html");
+  assert.equal(upstreamRequest?.headers.has("authorization"), false);
+});
+
+test("product www host redirects to the product apex", async () => {
+  const response = await productHostResponse(
+    new Request("https://www.crabfleet.ai/docs?mode=full"),
+  );
+
+  assert.equal(response?.status, 308);
+  assert.equal(response?.headers.get("location"), "https://crabfleet.ai/docs?mode=full");
+});
+
+test("legacy app pages redirect to the canonical host", () => {
+  const response = canonicalAppRedirect(
+    new URL("https://clawfleet.openclaw.ai/app/sessions/IS-1?view=grid"),
+  );
+
+  assert.equal(response?.status, 308);
+  assert.equal(
+    response?.headers.get("location"),
+    "https://crabfleet.openclaw.ai/app/sessions/IS-1?view=grid",
+  );
+});
+
+test("legacy API requests stay on-host so authorization survives", () => {
+  assert.equal(
+    canonicalAppRedirect(new URL("https://clawfleet.openclaw.ai/api/ssh/sessions")),
+    null,
+  );
+  assert.equal(
+    canonicalAppRedirect(new URL("https://clawfleet.openclaw.ai/api/terminal/ws")),
+    null,
+  );
+});

--- a/tests/fleet-state.test.ts
+++ b/tests/fleet-state.test.ts
@@ -57,10 +57,10 @@ test("fleet state aggregates sessions and redacted sandbox policies", () => {
       },
     ],
     {
-      canonicalUrl: "https://clawfleet.openclaw.ai",
+      canonicalUrl: "https://crabfleet.openclaw.ai",
       defaultEgressHosts: ["github.com", "api.github.com"],
       generatedAt: 100,
-      productUrl: "https://clawfleet.ai",
+      productUrl: "https://crabfleet.ai",
     },
   );
 

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -5,16 +5,16 @@ import { githubOAuthRedirectUri } from "../src/oauth.ts";
 test("githubOAuthRedirectUri uses configured callback when present", () => {
   assert.equal(
     githubOAuthRedirectUri(
-      "https://clawfleet.openclaw.ai/login/github",
-      " https://crabfleet.ai/auth/github/callback ",
+      "https://crabfleet.openclaw.ai/login/github",
+      " https://crabfleet.openclaw.ai/auth/github/callback ",
     ),
-    "https://crabfleet.ai/auth/github/callback",
+    "https://crabfleet.openclaw.ai/auth/github/callback",
   );
 });
 
 test("githubOAuthRedirectUri defaults to request origin callback", () => {
   assert.equal(
-    githubOAuthRedirectUri("https://clawfleet.openclaw.ai/login/github"),
-    "https://clawfleet.openclaw.ai/auth/github/callback",
+    githubOAuthRedirectUri("https://crabfleet.openclaw.ai/login/github"),
+    "https://crabfleet.openclaw.ai/auth/github/callback",
   );
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "crabbox-ai",
   "main": "src/index.ts",
-  "compatibility_date": "2026-05-17",
+  "compatibility_date": "2026-06-11",
   "compatibility_flags": ["nodejs_compat"],
   "build": {
     "command": "node scripts/generate-assets.mjs",
@@ -22,8 +22,8 @@
   "vars": {
     "BACKUP_BUCKET_NAME": "crabfleet-session-logs",
     "CLOUDFLARE_ACCOUNT_ID": "91b59577e757131d68d55a471fe32aca",
-    "CRABBOX_INTERACTIVE_PROVISION_URL": "https://clawfleet.openclaw.ai/api/provision/interactive",
-    "GITHUB_REDIRECT_URI": "https://crabfleet.ai/auth/github/callback",
+    "CRABBOX_INTERACTIVE_PROVISION_URL": "https://crabfleet.openclaw.ai/api/provision/interactive",
+    "GITHUB_REDIRECT_URI": "https://crabfleet.openclaw.ai/auth/github/callback",
   },
   "d1_databases": [
     {
@@ -73,11 +73,11 @@
     },
   ],
   "workers_dev": true,
-  // The canonical app/API host is deployed as a Worker Custom Domain so the
-  // normal deploy token can converge DNS without the separate DNS token.
+  // The canonical app/API host and legacy OpenClaw aliases are Worker Custom
+  // Domains. The public crabfleet.ai product site is managed separately.
   "routes": [
-    { "pattern": "clawfleet.openclaw.ai", "custom_domain": true },
     { "pattern": "crabfleet.openclaw.ai", "custom_domain": true },
+    { "pattern": "clawfleet.openclaw.ai", "custom_domain": true },
     { "pattern": "crabyard.openclaw.ai", "custom_domain": true },
   ],
   "observability": {


### PR DESCRIPTION
## Summary

- redesign Fleet as a denser operator command center with real readiness and owner signals
- extract shared fleet/components/lifecycle helpers and remove duplicated status/UI logic
- establish `crabfleet.openclaw.ai` as the app/install canonical host while keeping `crabfleet.ai` on the generic product site
- preserve authenticated legacy API clients and add a credential-safe product-host fallback
- update CLI defaults, deployment config, docs, changelog, and domain convergence

## Verification

- `pnpm check`
- `pnpm test` (44 tests)
- `go test ./... && go vet ./...`
- `node --check scripts/ensure-cloudflare-domains.mjs`
- `git diff --check`
- `pnpm exec wrangler deploy --dry-run`
- local D1 migrations plus seeded ready, attached, provisioning, failed, and stopped sessions
- existing-profile Chrome E2E: login, Fleet dashboard, copy action, themes, mobile layout, session grid, navigation
- Lighthouse desktop/mobile: Accessibility 100, Best Practices 100, SEO 100, Agentic Browsing 100
- performance trace: LCP 524 ms, CLS 0.00
- autoreview clean: no accepted/actionable findings
