### PR TITLE
fix: bind product apex routes

### DIFF
--- a/wrangler.product.jsonc
+++ b/wrangler.product.jsonc
@@ -5,6 +5,10 @@
   "compatibility_date": "2026-06-11",
   "account_id": "91b59577e757131d68d55a471fe32aca",
   "workers_dev": false,
+  "routes": [
+    { "pattern": "crabfleet.ai/*", "zone_name": "crabfleet.ai" },
+    { "pattern": "www.crabfleet.ai/*", "zone_name": "crabfleet.ai" },
+  ],
   "observability": {
     "enabled": true,
   },


### PR DESCRIPTION
## Summary

Bind both `crabfleet.ai/*` and `www.crabfleet.ai/*` directly in the source-controlled product Worker config.

Production verification after #18 showed the apex route using the new product router, while `www` could still bypass it and reach GitHub Pages directly.

## Verification

- `pnpm check`
- `pnpm test` (45 tests)
- `pnpm deploy:product --dry-run`
- `git diff --check`
- autoreview clean: no accepted/actionable findings
