### PR TITLE
fix: preserve product routes during deploy

### DIFF
--- a/wrangler.product.jsonc
+++ b/wrangler.product.jsonc
@@ -5,10 +5,8 @@
   "compatibility_date": "2026-06-11",
   "account_id": "91b59577e757131d68d55a471fe32aca",
   "workers_dev": false,
-  "routes": [
-    { "pattern": "crabfleet.ai/*", "zone_name": "crabfleet.ai" },
-    { "pattern": "www.crabfleet.ai/*", "zone_name": "crabfleet.ai" },
-  ],
+  // Classic product routes are converged by ensure-cloudflare-domains.mjs.
+  // The regular Worker deploy token intentionally has no zone-route access.
   "observability": {
     "enabled": true,
   },


### PR DESCRIPTION
## Summary

Keep product route ownership in `scripts/ensure-cloudflare-domains.mjs` and let the recurring product Worker deploy update script versions without touching zone routes.

The live routes were corrected by #19, but the regular CI token intentionally lacks zone-route permission, so declaring routes in the deploy config caused workflow run 27392846683 to fail after upload.

## Verification

- `pnpm check`
- `pnpm test` (45 tests)
- `pnpm deploy:product --dry-run`
- `git diff --check`
- external fetch: both `crabfleet.ai` and `www.crabfleet.ai` return generic product content
- autoreview clean: no accepted/actionable findings
