### PR TITLE
fix: converge routes in manual deploys

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -58,10 +58,10 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           for attempt in 1 2 3; do
-            pnpm deploy:product && exit 0
+            pnpm deploy:product:worker && exit 0
             sleep $((attempt * 5))
           done
-          pnpm deploy:product
+          pnpm deploy:product:worker
 
       - name: Apply D1 migrations
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add the Crabfleet v2 fleet-control spec, redacted fleet registry API, and dashboard summary for visible Codex crabboxes.
 - Make `crabfleet.openclaw.ai` the OpenClaw app/API canonical URL, redirect old OpenClaw aliases there, and keep `crabfleet.ai` independent as the public product site.
 - Deploy the source-controlled `crabfleet.ai` product router before the app Worker so product traffic cannot drift back to an app redirect.
+- Make manual product and aggregate deploys converge their Cloudflare routes instead of silently depending on existing bindings.
 - Route the built-in interactive provision hook in-process and default new sessions to Cloudflare Sandbox so production creates usable Codex terminals without a crabbox adapter.
 - Keep Cloudflare Sandbox model and GitHub credentials in the Worker path, add DO-backed sandbox credential/checkpoint state, and add CLI lifecycle commands for doctor/status/stop/checkpoint/restore.
 - Show failed and expired Codex sessions as stable log replays instead of remounting Ghostty terminals.

--- a/README.md
+++ b/README.md
@@ -137,27 +137,23 @@ Worker. Configure the repository secret `CLOUDFLARE_API_TOKEN` with permissions 
 Workers deploys and D1 migrations.
 `crabfleet.ai` product routing, `crabfleet.openclaw.ai`, and `crabd.sh` DNS/route
 convergence is handled by `scripts/ensure-cloudflare-domains.mjs`; set
-`CLOUDFLARE_DNS_API_TOKEN` when CI should manage those records. Without that
-DNS-scoped token, CI skips domain convergence. The app Worker still proxies the generic
-product site for `crabfleet.ai` as a defensive fallback, never the authenticated app.
+`CLOUDFLARE_DNS_API_TOKEN` for manual deploys and when CI should manage those
+records. Without that DNS-scoped repository secret, CI skips domain convergence. The
+app Worker still proxies the generic product site for `crabfleet.ai` as a defensive
+fallback, never the authenticated app.
 The product router source and deploy configuration live in `src/product-router.ts` and
 `wrangler.product.jsonc`.
 
-Manual deploy is still available:
+Manual deploy, including domain convergence, is still available:
 
 ```bash
-# Build assets
-pnpm build
-
-# Deploy the generic product router
-pnpm deploy:product
-
-# Apply migrations
-wrangler d1 migrations apply DB --remote
-
-# Deploy to Cloudflare
-wrangler deploy
+CLOUDFLARE_API_TOKEN=... \
+CLOUDFLARE_DNS_API_TOKEN=... \
+pnpm run deploy
 ```
+
+`pnpm deploy:product` deploys only the generic product Worker and its two public
+routes. Use `pnpm deploy:product:worker` only when route convergence runs separately.
 
 ### Environment Variables
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "scripts": {
     "build": "node scripts/generate-assets.mjs && tsgo --noEmit",
     "build:static": "node scripts/generate-assets.mjs --static",
-    "deploy": "pnpm build && pnpm deploy:product && wrangler d1 migrations apply DB --remote && wrangler deploy",
-    "deploy:product": "wrangler deploy --config wrangler.product.jsonc",
+    "deploy": "pnpm build && pnpm deploy:product:worker && wrangler d1 migrations apply DB --remote && wrangler deploy && pnpm deploy:domains",
+    "deploy:product": "pnpm deploy:product:worker && pnpm deploy:domains:product",
+    "deploy:product:worker": "wrangler deploy --config wrangler.product.jsonc",
+    "deploy:domains": "node scripts/ensure-cloudflare-domains.mjs",
+    "deploy:domains:product": "node scripts/ensure-cloudflare-domains.mjs --product-only",
     "test": "node --test --experimental-strip-types tests/*.test.ts",
     "lint": "oxlint --ignore-pattern node_modules --ignore-pattern src/generated.ts .",
     "format": "oxfmt --check .",

--- a/scripts/ensure-cloudflare-domains.mjs
+++ b/scripts/ensure-cloudflare-domains.mjs
@@ -1,4 +1,5 @@
-const token = process.env.CLOUDFLARE_API_TOKEN;
+const token = process.env.CLOUDFLARE_DNS_API_TOKEN || process.env.CLOUDFLARE_API_TOKEN;
+const productOnly = process.argv.includes("--product-only");
 const appHost = "crabfleet.openclaw.ai";
 const productWorkerScript = "crabfleet-canonical-router";
 // OpenClaw app hosts are Worker Custom Domains in wrangler.jsonc; this script
@@ -10,7 +11,7 @@ const openClawCustomDomainHosts = new Set([
 ]);
 
 if (!token) {
-  throw new Error("CLOUDFLARE_API_TOKEN is required");
+  throw new Error("CLOUDFLARE_DNS_API_TOKEN or CLOUDFLARE_API_TOKEN is required");
 }
 
 async function request(path, init = {}) {
@@ -202,9 +203,13 @@ async function ensureCrabdSshRecord() {
   }
 }
 
-await removeOpenClawClassicRoutes();
+if (!productOnly) {
+  await removeOpenClawClassicRoutes();
+}
 for (const host of ["crabfleet.ai", "www.crabfleet.ai"]) {
   await ensureProductHost("crabfleet.ai", host);
 }
-await ensureCrabfleetDocsRecord();
-await ensureCrabdSshRecord();
+if (!productOnly) {
+  await ensureCrabfleetDocsRecord();
+  await ensureCrabdSshRecord();
+}


### PR DESCRIPTION
## Summary

- make `pnpm deploy:product` converge the product Worker routes
- make the aggregate manual deploy finish with full domain convergence
- keep CI on the Worker-only command because its regular deploy token cannot edit zone routes
- accept the dedicated DNS token directly in the convergence script

## Verification

- `pnpm check`
- `pnpm test` (45 tests)
- `node --check scripts/ensure-cloudflare-domains.mjs`
- `pnpm deploy:product:worker --dry-run`
- missing-token failure path
- `git diff --check`
- autoreview clean: no accepted/actionable findings