### PR TITLE
fix: replace native browser session dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Replace native browser confirms and prompts with accessible Crabfleet dialogs for session cleanup, shutdown, and share-link fallback.
 - Sharpen the app visual system with flatter controls, tighter surfaces, and restrained overlay elevation.
 - Add Crabfleet session supervision metadata, owner/session tree listing, transcript retrieval, PTY messaging, and summary updates for Codex-spawned Codex sessions.
 - Redesign Fleet as an operational command view with real readiness data, compact connection paths, clearer operator groups, and denser session cards.

--- a/scripts/generate-assets.mjs
+++ b/scripts/generate-assets.mjs
@@ -135,14 +135,17 @@ function viteAssetUrl(path) {
 function buildLucideIconScript(iconNodes) {
   const names = [
     "book-open",
+    "check",
     "copy",
     "git-pull-request",
     "layout-grid",
+    "link-2",
     "moon",
     "settings",
     "square-terminal",
     "sun",
     "terminal",
+    "triangle-alert",
     "x",
   ];
   const selected = Object.fromEntries(names.map((name) => [name, iconNodes[name]]));

--- a/src/app.html
+++ b/src/app.html
@@ -52,6 +52,9 @@
         --accent: #0ea5e9;
         --success: #10b981;
         --warning: #f59e0b;
+        --danger: #dc465f;
+        --danger-dark: #c43750;
+        --danger-ink: #ffffff;
         --nav-surface: rgb(255 255 255 / 0.86);
         --dashboard-surface: linear-gradient(180deg, #ffffff, #f9fafb);
         --command-bg: #f9fafb;
@@ -93,6 +96,9 @@
         --accent: #3b82f6;
         --success: #34d399;
         --warning: #fbbf24;
+        --danger: #f05a70;
+        --danger-dark: #d94b62;
+        --danger-ink: #17090c;
         --nav-surface: rgb(7 10 16 / 0.82);
         --dashboard-surface: linear-gradient(180deg, rgb(17 11 15 / 0.92), rgb(14 10 13 / 0.96));
         --command-bg: rgb(15 15 20 / 0.78);
@@ -2089,6 +2095,147 @@
         animation: slideInRight 0.3s cubic-bezier(0.4, 0, 0.2, 1);
       }
 
+      .action-dialog {
+        width: min(480px, calc(100vw - 32px));
+        max-height: calc(100vh - 32px);
+        margin: auto;
+        padding: 0;
+        overflow: hidden;
+        border: 1px solid var(--line-strong);
+        border-radius: var(--radius-large);
+        background: var(--panel);
+        color: var(--ink);
+        box-shadow: var(--elevation-popover);
+        animation: dialogEnter 0.18s cubic-bezier(0.2, 0.8, 0.2, 1);
+      }
+      .action-dialog::backdrop {
+        background: rgb(2 4 8 / 0.74);
+        backdrop-filter: blur(4px);
+        animation: fadeIn 0.16s ease;
+      }
+      .action-dialog-surface {
+        display: grid;
+        grid-template-rows: minmax(0, 1fr) auto;
+        max-height: calc(100vh - 32px);
+      }
+      .action-dialog-content {
+        display: grid;
+        grid-template-columns: 40px minmax(0, 1fr);
+        gap: 0 14px;
+        padding: 24px;
+        overflow: auto;
+      }
+      .action-dialog-icon {
+        width: 40px;
+        height: 40px;
+        display: grid;
+        place-items: center;
+        border: 1px solid var(--line);
+        border-radius: var(--radius-control);
+        background: var(--panel-2);
+        color: var(--primary);
+      }
+      .action-dialog.danger .action-dialog-icon {
+        border-color: color-mix(in srgb, var(--danger) 35%, var(--line));
+        background: color-mix(in srgb, var(--danger) 10%, var(--panel));
+        color: var(--danger);
+      }
+      .action-dialog-icon svg {
+        width: 18px;
+        height: 18px;
+      }
+      .action-dialog-copy {
+        min-width: 0;
+      }
+      .action-dialog-eyebrow {
+        display: block;
+        margin: 0 0 3px;
+        color: var(--muted);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      .action-dialog h2 {
+        margin: 0;
+        font-size: 19px;
+        line-height: 1.3;
+        letter-spacing: -0.02em;
+      }
+      .action-dialog p {
+        margin: 8px 0 0;
+        color: var(--muted);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .action-dialog-subject,
+      .action-dialog-value,
+      .action-dialog-error {
+        grid-column: 1 / -1;
+        margin-top: 18px;
+      }
+      .action-dialog-subject {
+        display: block;
+        min-width: 0;
+        overflow: hidden;
+        padding: 9px 11px;
+        border: 1px solid var(--line);
+        border-radius: var(--radius-control);
+        background: var(--panel-2);
+        color: var(--ink);
+        font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+        font-size: 12px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .action-dialog-value input {
+        font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+        font-size: 12px;
+      }
+      .action-dialog-error {
+        padding: 9px 11px;
+        border: 1px solid color-mix(in srgb, var(--danger) 35%, var(--line));
+        border-radius: var(--radius-control);
+        background: color-mix(in srgb, var(--danger) 9%, var(--panel));
+        color: var(--danger);
+        font-size: 12px;
+      }
+      .action-dialog-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        padding: 14px 16px;
+        border-top: 1px solid var(--line);
+        background: var(--panel-2);
+      }
+      .action-dialog-actions button {
+        min-width: 94px;
+      }
+      .action-dialog-actions button svg {
+        margin-right: 6px;
+        vertical-align: -3px;
+      }
+      button.action-dialog-danger {
+        border-color: var(--danger);
+        background: var(--danger);
+        color: var(--danger-ink);
+        font-weight: 600;
+      }
+      button.action-dialog-danger:hover {
+        border-color: var(--danger-dark);
+        background: var(--danger-dark);
+      }
+      @keyframes dialogEnter {
+        from {
+          opacity: 0;
+          transform: translateY(8px) scale(0.985);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0) scale(1);
+        }
+      }
+
       @media (max-width: 1320px) {
         .top {
           grid-template-columns: 1fr;
@@ -2218,6 +2365,17 @@
         }
         .drawer {
           padding: 8px;
+        }
+        .action-dialog {
+          width: calc(100vw - 20px);
+          max-height: calc(100vh - 20px);
+        }
+        .action-dialog-content {
+          padding: 20px;
+        }
+        .action-dialog-actions {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
         }
       }
     </style>

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -99,6 +99,7 @@ function App() {
   const [theme, setThemeState] = useState(
     document.documentElement.dataset.theme === "light" ? "light" : "dark",
   );
+  const [dialog, setDialog] = useState(null);
   const [sessionLayout, setSessionLayout] = useState(loadSessionLayout);
   const [terminalStatus, setTerminalStatus] = useState({});
   const stateRef = useRef(state);
@@ -113,6 +114,7 @@ function App() {
   const refPreviewSeq = useRef(0);
   const draggedSessionId = useRef(null);
   const autoLoginStarted = useRef(false);
+  const dialogSequence = useRef(0);
 
   const allSessionItems = useMemo(() => sessionItems(state), [state]);
   const sessionItemById = useMemo(
@@ -481,6 +483,42 @@ function App() {
     setThemeState(value === "light" ? "light" : "dark");
   }
 
+  function openActionDialog(options) {
+    dialogSequence.current += 1;
+    setDialog({
+      id: dialogSequence.current,
+      pending: false,
+      error: "",
+      ...options,
+    });
+  }
+
+  function closeActionDialog() {
+    setDialog((current) => (current?.pending ? current : null));
+  }
+
+  async function confirmActionDialog() {
+    const current = dialog;
+    if (!current?.action || current.pending) return;
+    setDialog((value) =>
+      value?.id === current.id ? { ...value, pending: true, error: "" } : value,
+    );
+    try {
+      await current.action();
+      setDialog((value) => (value?.id === current.id ? null : value));
+    } catch (error) {
+      setDialog((value) =>
+        value?.id === current.id
+          ? {
+              ...value,
+              pending: false,
+              error: error?.message || "The action could not be completed.",
+            }
+          : value,
+      );
+    }
+  }
+
   async function beginLogin() {
     try {
       sessionStorage.removeItem(skipAutoGithubLoginKey);
@@ -599,11 +637,18 @@ function App() {
     return result;
   }
 
-  async function closeInteractiveSession(id) {
+  function closeInteractiveSession(id) {
     const session = findInteractiveSession(id);
     const label = session ? `${session.repo} (${session.id})` : id;
-    if (!window.confirm(`End Codex session ${label}?`)) return null;
-    return interactiveSessionAction(id, "stop");
+    openActionDialog({
+      kind: "danger",
+      eyebrow: "Live session",
+      title: "End Codex session?",
+      description: "This stops the terminal. Its final status and logs stay visible in Crabfleet.",
+      subject: label,
+      confirmLabel: "End session",
+      action: () => interactiveSessionAction(id, "stop"),
+    });
   }
 
   async function cleanupInteractiveSessions(ids) {
@@ -621,28 +666,45 @@ function App() {
     return result;
   }
 
-  async function cleanupInteractiveSession(id) {
+  function cleanupInteractiveSession(id) {
     const session = findInteractiveSession(id);
     const label = session ? `${session.repo} (${session.id})` : id;
-    if (!window.confirm(`Clean up dead Codex session ${label}?`)) return null;
-    if (session?.routePlaceholder) {
-      removeInteractiveSession(id);
-      if (focusedSessionIdRef.current === id) setFocusedSessionId(null);
-      if (!sharedToken) setSessionUrl(null, { grid: true });
-      return { removedIds: [id] };
-    }
-    return cleanupInteractiveSessions([id]);
+    openActionDialog({
+      kind: "danger",
+      eyebrow: "Dead session",
+      title: "Clean up Codex session?",
+      description:
+        "This permanently removes the session record, event history, and archived logs from Crabfleet.",
+      subject: label,
+      confirmLabel: "Clean up",
+      action: async () => {
+        if (session?.routePlaceholder) {
+          removeInteractiveSession(id);
+          if (focusedSessionIdRef.current === id) setFocusedSessionId(null);
+          if (!sharedToken) setSessionUrl(null, { grid: true });
+          return;
+        }
+        await cleanupInteractiveSessions([id]);
+      },
+    });
   }
 
-  async function cleanupDeadInteractiveSessions() {
+  function cleanupDeadInteractiveSessions() {
     const user = stateRef.current.user;
     const ids = (stateRef.current.interactiveSessions || [])
       .filter((session) => canCleanInteractiveSession(session, user))
       .map((session) => session.id);
     if (!ids.length) return null;
-    if (!window.confirm(`Clean up ${ids.length} dead Codex session${ids.length === 1 ? "" : "s"}?`))
-      return null;
-    return cleanupInteractiveSessions(ids);
+    openActionDialog({
+      kind: "danger",
+      eyebrow: "Fleet cleanup",
+      title: `Clean up ${ids.length} dead Codex session${ids.length === 1 ? "" : "s"}?`,
+      description:
+        "This permanently removes their session records, event history, and archived logs from Crabfleet.",
+      subject: ids.length === 1 ? ids[0] : `${ids.length} stopped or failed sessions`,
+      confirmLabel: `Clean up ${ids.length}`,
+      action: () => cleanupInteractiveSessions(ids),
+    });
   }
 
   async function shareInteractiveSession(id) {
@@ -655,7 +717,15 @@ function App() {
         copied = true;
       }
     } catch {}
-    if (!copied) window.prompt("Copy share link", result.shareUrl);
+    if (!copied) {
+      openActionDialog({
+        kind: "share",
+        eyebrow: "Read-only access",
+        title: "Share link ready",
+        description: "Clipboard access is unavailable. Copy this link manually.",
+        value: result.shareUrl,
+      });
+    }
   }
 
   async function openRunDetails(id) {
@@ -834,6 +904,7 @@ function App() {
     showSessionGrid,
     refPreview,
     theme,
+    dialog,
     terminalStatus,
     sessionLayout,
     setSessionLayout: updateSessionLayout,
@@ -850,6 +921,8 @@ function App() {
     devIdentityLogin,
     logout,
     setTheme,
+    closeActionDialog,
+    confirmActionDialog,
     cardAction,
     attachCard,
     interactiveSessionAction,
@@ -902,6 +975,11 @@ function CrabfleetApp(props) {
       <RunDrawer {...props} />
       <SessionsDrawer {...props} />
       <AdminDrawer {...props} />
+      <ActionDialog
+        dialog={props.dialog}
+        onCancel={props.closeActionDialog}
+        onConfirm={props.confirmActionDialog}
+      />
     </>
   );
 }
@@ -2501,6 +2579,114 @@ function Drawer({ id, open, title, wide, onClose, children }) {
         <div class="panel-body">{children}</div>
       </section>
     </div>
+  );
+}
+
+function ActionDialog({ dialog, onCancel, onConfirm }) {
+  const elementRef = useRef(null);
+  const cancelRef = useRef(null);
+  const valueRef = useRef(null);
+  const [copied, setCopied] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!dialog) return;
+    const element = elementRef.current;
+    const previousFocus = document.activeElement;
+    setCopied(false);
+    if (element && !element.open) element.showModal();
+    const focusTarget = dialog.kind === "share" ? valueRef.current : cancelRef.current;
+    focusTarget?.focus();
+    if (dialog.kind === "share") focusTarget?.select();
+    return () => {
+      if (element?.open) element.close();
+      previousFocus?.focus?.();
+    };
+  }, [dialog?.id]);
+
+  if (!dialog) return null;
+  const titleId = `action-dialog-title-${dialog.id}`;
+  const descriptionId = `action-dialog-description-${dialog.id}`;
+
+  async function copyValue() {
+    const value = dialog.value || "";
+    let success = false;
+    try {
+      await navigator.clipboard?.writeText(value);
+      success = Boolean(navigator.clipboard);
+    } catch {}
+    if (!success && valueRef.current) {
+      valueRef.current.select();
+      success = Boolean(document.execCommand?.("copy"));
+    }
+    setCopied(success);
+  }
+
+  return (
+    <dialog
+      ref={elementRef}
+      class={`action-dialog ${dialog.kind === "danger" ? "danger" : ""}`}
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!dialog.pending) onCancel();
+      }}
+      onClick={(event) => {
+        if (event.target === event.currentTarget && !dialog.pending) onCancel();
+      }}
+      onKeyDown={(event) => event.stopPropagation()}
+    >
+      <section class="action-dialog-surface">
+        <div class="action-dialog-content">
+          <div class="action-dialog-icon" aria-hidden="true">
+            <Icon name={dialog.kind === "danger" ? "triangle-alert" : "link-2"} />
+          </div>
+          <div class="action-dialog-copy">
+            <span class="action-dialog-eyebrow">{dialog.eyebrow}</span>
+            <h2 id={titleId}>{dialog.title}</h2>
+            <p id={descriptionId}>{dialog.description}</p>
+          </div>
+          {dialog.subject ? <code class="action-dialog-subject">{dialog.subject}</code> : null}
+          {dialog.kind === "share" ? (
+            <label class="action-dialog-value">
+              Share URL
+              <input ref={valueRef} readonly value={dialog.value || ""} />
+            </label>
+          ) : null}
+          {dialog.error ? (
+            <div class="action-dialog-error" role="alert">
+              {dialog.error}
+            </div>
+          ) : null}
+        </div>
+        <div class="action-dialog-actions">
+          {dialog.kind === "share" ? (
+            <>
+              <button ref={cancelRef} onClick={onCancel}>
+                Done
+              </button>
+              <button class="primary" onClick={() => void copyValue()}>
+                <Icon name={copied ? "check" : "copy"} />
+                {copied ? "Copied" : "Copy link"}
+              </button>
+            </>
+          ) : (
+            <>
+              <button ref={cancelRef} disabled={dialog.pending} onClick={onCancel}>
+                Cancel
+              </button>
+              <button
+                class="action-dialog-danger"
+                disabled={dialog.pending}
+                onClick={() => void onConfirm()}
+              >
+                {dialog.pending ? "Working..." : dialog.confirmLabel}
+              </button>
+            </>
+          )}
+        </div>
+      </section>
+    </dialog>
   );
 }
 

--- a/tests/html-dialogs.test.ts
+++ b/tests/html-dialogs.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+test("app actions use styled HTML dialogs instead of browser prompts", async () => {
+  const source = await readFile(new URL("../src/app/main.jsx", import.meta.url), "utf8");
+
+  assert.doesNotMatch(source, /\bwindow\.(?:alert|confirm|prompt)\s*\(/);
+  assert.match(source, /<dialog/);
+  assert.match(source, /showModal\(\)/);
+});


### PR DESCRIPTION
## Summary

- replace native browser confirms with a reusable HTML dialog for session shutdown and cleanup
- replace the share-link prompt fallback with a selectable, copyable in-app dialog
- add destructive-action progress/error handling, safe focus restoration, responsive styling, and bundled icons

## Verification

- `pnpm check`
- `pnpm test` (46 passed)
- `go test ./...`
- autoreview clean: no accepted/actionable findings
- existing-Chrome local E2E: single and bulk cleanup, Escape cancellation/focus restore, clipboard-denied share fallback, successful cleanup mutation, light/dark themes, 430px viewport, no console errors
