### PR TITLE
fix: harden terminal flow and product domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bound Crabbox terminal output with negotiated acknowledgements and legacy-client compatibility.
 - Enable the OpenClaw deployment's versioned Crabbox runtime adapter with a stable tenant namespace.
 - Add comprehensive documentation for durable GitHub Actions sessions, including registration, runner and viewer relay, work-state heartbeats, Codex steering, resumption, completion, cancellation, authentication, archives, and troubleshooting.
 - Keep GitHub Actions sessions out of legacy workspace-stop reconciliation and give them a dedicated cancel lifecycle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Move the public product hosts to safely converged Worker Custom Domains.
 - Bound Crabbox terminal output with negotiated acknowledgements and legacy-client compatibility.
 - Enable the OpenClaw deployment's versioned Crabbox runtime adapter with a stable tenant namespace.
 - Add comprehensive documentation for durable GitHub Actions sessions, including registration, runner and viewer relay, work-state heartbeats, Codex steering, resumption, completion, cancellation, authentication, archives, and troubleshooting.

--- a/README.md
+++ b/README.md
@@ -164,8 +164,10 @@ Pushes to `main` run `.github/workflows/deploy-worker.yml`, which checks, tests,
 deploys the generic product router, applies remote D1 migrations, and deploys the app
 Worker. Configure the repository secret `CLOUDFLARE_API_TOKEN` with permissions for
 Workers deploys and D1 migrations.
-`crabfleet.ai` product routing, `crabfleet.openclaw.ai`, and `crabd.sh` DNS/route
-convergence is handled by `scripts/ensure-cloudflare-domains.mjs`; set
+`crabfleet.openclaw.ai` is a Worker Custom Domain declared in the app Wrangler
+config. The `crabfleet.ai` product Custom Domains, stale classic-route cleanup,
+and `crabd.sh` DNS convergence are handled by
+`scripts/ensure-cloudflare-domains.mjs`; set
 `CLOUDFLARE_DNS_API_TOKEN` for manual deploys and when CI should manage those
 records. Without that DNS-scoped repository secret, CI skips domain convergence. The
 app Worker still proxies the generic product site for `crabfleet.ai` as a defensive
@@ -181,8 +183,8 @@ CLOUDFLARE_DNS_API_TOKEN=... \
 pnpm run deploy
 ```
 
-`pnpm deploy:product` deploys only the generic product Worker and its two public
-routes. Use `pnpm deploy:product:worker` only when route convergence runs separately.
+`pnpm deploy:product` deploys only the generic product Worker, then converges its
+two public Custom Domains and stale classic-route cleanup.
 
 ### Environment Variables
 

--- a/scripts/ensure-cloudflare-domains.mjs
+++ b/scripts/ensure-cloudflare-domains.mjs
@@ -1,6 +1,7 @@
 const token = process.env.CLOUDFLARE_DNS_API_TOKEN || process.env.CLOUDFLARE_API_TOKEN;
 const productOnly = process.argv.includes("--product-only");
 const appHost = "crabfleet.openclaw.ai";
+const cloudflareAccountId = "91b59577e757131d68d55a471fe32aca";
 const productWorkerScript = "crabfleet-canonical-router";
 // OpenClaw app hosts are Worker Custom Domains in wrangler.jsonc; this script
 // only removes stale classic routes for them and keeps other aliases tidy.
@@ -42,61 +43,28 @@ async function zone(name) {
   return selected;
 }
 
-async function ensureProductHost(zoneName, host) {
+async function ensureProductHosts(zoneName, hosts) {
   const targetZone = await zone(zoneName);
-  const dns = await request(`/zones/${targetZone.id}/dns_records?name=${encodeURIComponent(host)}`);
-  for (const record of dns.filter((entry) => entry.type === "AAAA" || entry.type === "CNAME")) {
-    await request(`/zones/${targetZone.id}/dns_records/${record.id}`, { method: "DELETE" });
-    console.log(`deleted conflicting ${host} ${record.type} record ${record.id}`);
-  }
-
-  const refreshed = await request(
-    `/zones/${targetZone.id}/dns_records?name=${encodeURIComponent(host)}`,
-  );
-  const [primaryA, ...extraARecords] = refreshed.filter((record) => record.type === "A");
-  const body = {
-    type: "A",
-    name: host,
-    content: "192.0.2.1",
-    proxied: true,
-    ttl: 1,
-  };
-  if (primaryA) {
-    await request(`/zones/${targetZone.id}/dns_records/${primaryA.id}`, {
+  await request(
+    `/accounts/${cloudflareAccountId}/workers/scripts/${productWorkerScript}/domains/records`,
+    {
       method: "PUT",
-      body: JSON.stringify(body),
-    });
-    console.log(`set ${host} proxied placeholder`);
-  } else {
-    await request(`/zones/${targetZone.id}/dns_records`, {
-      method: "POST",
-      body: JSON.stringify(body),
-    });
-    console.log(`created ${host} proxied placeholder`);
-  }
+      body: JSON.stringify({
+        override_scope: true,
+        override_existing_origin: true,
+        override_existing_dns_record: true,
+        origins: hosts.map((hostname) => ({ hostname, zone_id: targetZone.id })),
+      }),
+    },
+  );
+  console.log(`set ${hosts.join(", ")} Worker Custom Domains`);
 
-  for (const record of extraARecords) {
-    await request(`/zones/${targetZone.id}/dns_records/${record.id}`, { method: "DELETE" });
-    console.log(`deleted extra ${host} A record ${record.id}`);
-  }
-
-  const pattern = `${host}/*`;
   const routes = await request(`/zones/${targetZone.id}/workers/routes`);
-  for (const route of routes.filter(
-    (entry) => entry.pattern === pattern && entry.script !== productWorkerScript,
+  for (const route of routes.filter((entry) =>
+    hosts.some((host) => entry.pattern === `${host}/*`),
   )) {
     await request(`/zones/${targetZone.id}/workers/routes/${route.id}`, { method: "DELETE" });
-    console.log(`deleted stale ${host} route ${route.id}`);
-  }
-  const current = await request(`/zones/${targetZone.id}/workers/routes`);
-  if (!current.some((route) => route.pattern === pattern && route.script === productWorkerScript)) {
-    const route = await request(`/zones/${targetZone.id}/workers/routes`, {
-      method: "POST",
-      body: JSON.stringify({ pattern, script: productWorkerScript }),
-    });
-    console.log(`created ${host} route ${route.id}`);
-  } else {
-    console.log(`${host} route ok`);
+    console.log(`deleted stale ${route.pattern} classic route ${route.id}`);
   }
 }
 
@@ -206,9 +174,7 @@ async function ensureCrabdSshRecord() {
 if (!productOnly) {
   await removeOpenClawClassicRoutes();
 }
-for (const host of ["crabfleet.ai", "www.crabfleet.ai"]) {
-  await ensureProductHost("crabfleet.ai", host);
-}
+await ensureProductHosts("crabfleet.ai", ["crabfleet.ai", "www.crabfleet.ai"]);
 if (!productOnly) {
   await ensureCrabfleetDocsRecord();
   await ensureCrabdSshRecord();

--- a/src/app/terminal.js
+++ b/src/app/terminal.js
@@ -3,6 +3,7 @@ import {
   TerminalSubscribeFlags,
   decodeJsonPayload,
   decodeTerminalFrame,
+  encodeAckPayload,
   encodeResizePayload,
   encodeSubscribePayload,
   encodeTerminalFrame,
@@ -344,7 +345,10 @@ function subscribeTerminalHost(session, host, term) {
   if (!terminalHubSocket || terminalHubSocket.readyState !== WebSocket.OPEN) return;
   host.subscribed = true;
   const flags =
-    TerminalSubscribeFlags.Output | TerminalSubscribeFlags.Snapshot | TerminalSubscribeFlags.Events;
+    TerminalSubscribeFlags.Output |
+    TerminalSubscribeFlags.Snapshot |
+    TerminalSubscribeFlags.Events |
+    TerminalSubscribeFlags.OutputAcknowledgements;
   sendTerminalFrame(
     session.id,
     TerminalMessageType.Subscribe,
@@ -367,6 +371,11 @@ function handleTerminalHubFrame(frame) {
   if (frame.type === TerminalMessageType.Output) {
     sendTerminalColorQueryResponses(host, frame.payload);
     host.term?.write(frame.payload);
+    sendTerminalFrame(
+      frame.sessionId,
+      TerminalMessageType.Ack,
+      encodeAckPayload(frame.payload.byteLength),
+    );
     return;
   }
   const event = decodeJsonPayload(frame.payload);

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ import {
 import { DurableObject } from "cloudflare:workers";
 import {
   TerminalMessageType,
+  TerminalSubscribeFlags,
+  decodeAckPayload,
   decodeTerminalFrame,
   decodeResizePayload,
   decodeSubscribePayload,
@@ -628,6 +630,8 @@ type TerminalHubSubscription = {
   viewCheck: ReturnType<typeof setInterval> | null;
   cols: number;
   rows: number;
+  outputAcknowledgements: boolean;
+  outputAcknowledgementBytes: number;
 };
 
 type PendingTerminalSubscription = {
@@ -637,6 +641,7 @@ type PendingTerminalSubscription = {
 type TerminalUpstream = {
   socket: WebSocket;
   markConnected: () => Promise<void>;
+  outputAcknowledgements: boolean;
 };
 
 type StandaloneSandboxTerminalOwnership = {
@@ -6959,6 +6964,19 @@ async function interactiveTerminalHub(
           });
           return;
         }
+        if (frame.type === TerminalMessageType.Ack) {
+          const bytes = decodeAckPayload(frame.payload);
+          if (
+            bytes &&
+            subscription.outputAcknowledgements &&
+            bytes <= subscription.outputAcknowledgementBytes &&
+            subscription.upstream.readyState === WebSocket.OPEN
+          ) {
+            subscription.outputAcknowledgementBytes -= bytes;
+            sendTerminalOutputAcknowledgement(subscription.upstream, bytes);
+          }
+          return;
+        }
         if (frame.type === TerminalMessageType.Stop) {
           closeSubscription(frame.sessionId, 1000, "stopped by client");
         }
@@ -7071,6 +7089,9 @@ async function subscribeTerminalHubSession(
     const reconcileSubscription = terminalSubscriptionReconciler(env, id);
     const cols = canInputNow ? terminalDimension(subscription.cols, 120) : 120;
     const rows = canInputNow ? terminalDimension(subscription.rows, 34) : 34;
+    const outputAcknowledgements = Boolean(
+      subscription.flags & TerminalSubscribeFlags.OutputAcknowledgements,
+    );
     let closingReason: string | undefined;
     const markClosing = (reason: string) => {
       closingReason = reason;
@@ -7137,7 +7158,7 @@ async function subscribeTerminalHubSession(
         })
         .catch(() => revokeView());
     }, 5000);
-    subscriptions.set(id, {
+    const activeSubscription: TerminalHubSubscription = {
       session,
       upstream,
       canView,
@@ -7146,7 +7167,10 @@ async function subscribeTerminalHubSession(
       viewCheck,
       cols,
       rows,
-    });
+      outputAcknowledgements: outputAcknowledgements && upstreamConnection.outputAcknowledgements,
+      outputAcknowledgementBytes: 0,
+    };
+    subscriptions.set(id, activeSubscription);
     let outputQueue = Promise.resolve();
     sendTerminalJson(client, TerminalMessageType.Event, id, {
       type: "subscribed",
@@ -7166,10 +7190,22 @@ async function subscribeTerminalHubSession(
               sendTerminalJson(client, TerminalMessageType.Event, id, parsed);
               return;
             }
-            sendTerminalFrame(client, TerminalMessageType.Output, id, encoder.encode(data));
+            const output = encoder.encode(data);
+            sendTerminalFrame(client, TerminalMessageType.Output, id, output);
+            if (activeSubscription.outputAcknowledgements) {
+              activeSubscription.outputAcknowledgementBytes += output.byteLength;
+            } else if (upstreamConnection.outputAcknowledgements) {
+              sendTerminalOutputAcknowledgement(upstream, output.byteLength);
+            }
             return;
           }
-          sendTerminalFrame(client, TerminalMessageType.Output, id, new Uint8Array(data));
+          const output = new Uint8Array(data);
+          sendTerminalFrame(client, TerminalMessageType.Output, id, output);
+          if (activeSubscription.outputAcknowledgements) {
+            activeSubscription.outputAcknowledgementBytes += output.byteLength;
+          } else if (upstreamConnection.outputAcknowledgements) {
+            sendTerminalOutputAcknowledgement(upstream, output.byteLength);
+          }
         });
     });
     upstream.addEventListener("close", (event) => {
@@ -7255,6 +7291,7 @@ async function openInteractiveTerminalUpstream(
     upstream.accept();
     return {
       socket: upstream,
+      outputAcknowledgements: false,
       markConnected: () =>
         markInteractiveTerminalConnected(
           env,
@@ -7289,6 +7326,7 @@ async function openInteractiveTerminalUpstream(
     upstream.accept();
     return {
       socket: upstream,
+      outputAcknowledgements: false,
       markConnected: () =>
         markInteractiveTerminalConnected(
           env,
@@ -7312,6 +7350,7 @@ async function openInteractiveTerminalUpstream(
   upstream.accept();
   return {
     socket: upstream,
+    outputAcknowledgements: terminalOutputAcknowledgements(target.url),
     markConnected: () =>
       markInteractiveTerminalConnected(env, user, session.id, now, "PTY terminal connected"),
   };
@@ -7657,6 +7696,8 @@ async function interactiveSessionPty(
 
   const target = interactiveTerminalTarget(env, session, routeKind);
   if (!target) throw serviceUnavailable("PTY bridge is not configured for this session");
+  const upstreamOutputAcknowledgements = terminalOutputAcknowledgements(target.url);
+  const downstreamOutputAcknowledgements = terminalOutputAcknowledgements(request.url);
   const targetUrl = sizedTerminalTargetUrl(
     target.url,
     routeKind,
@@ -7703,6 +7744,9 @@ async function interactiveSessionPty(
     upstream,
     terminalInputGrant(env, user, session),
     terminalSubscriptionReconciler(env, id),
+    "terminal control revoked",
+    upstreamOutputAcknowledgements && downstreamOutputAcknowledgements,
+    upstreamOutputAcknowledgements && !downstreamOutputAcknowledgements,
   );
 
   const now = Date.now();
@@ -8343,12 +8387,15 @@ function bridgeWebSockets(
   canSendLeft?: () => Promise<boolean>,
   reconcileSubscription?: () => void,
   deniedReason = "terminal control revoked",
+  forwardRightOutputAcknowledgements = false,
+  acknowledgeRightOutputImmediately = false,
 ): void {
   let leftInputQueue = Promise.resolve();
   let rightOutputQueue = Promise.resolve();
   let controlCheckTimer: ReturnType<typeof setInterval> | undefined;
   let controlCheckInFlight: Promise<void> | undefined;
   let leftCanSend = true;
+  let rightOutputAcknowledgementBytes = 0;
   const stopControlCheck = () => {
     if (controlCheckTimer !== undefined) clearInterval(controlCheckTimer);
     controlCheckTimer = undefined;
@@ -8388,7 +8435,18 @@ function bridgeWebSockets(
           closePair(left, right, 1008, deniedReason);
           return;
         }
-        right.send(await webSocketMessageData(data));
+        const forwarded = await webSocketMessageData(data);
+        const acknowledgedBytes = forwardRightOutputAcknowledgements
+          ? terminalOutputAcknowledgement(forwarded)
+          : null;
+        if (acknowledgedBytes !== null) {
+          if (acknowledgedBytes <= rightOutputAcknowledgementBytes) {
+            rightOutputAcknowledgementBytes -= acknowledgedBytes;
+            sendTerminalOutputAcknowledgement(right, acknowledgedBytes);
+          }
+          return;
+        }
+        right.send(forwarded);
       });
   });
   right.addEventListener("message", (event) => {
@@ -8397,7 +8455,13 @@ function bridgeWebSockets(
       .catch(() => undefined)
       .then(async () => {
         if (left.readyState !== WebSocket.OPEN || right.readyState !== WebSocket.OPEN) return;
-        left.send(await webSocketMessageData(data));
+        const forwarded = await webSocketMessageData(data);
+        left.send(forwarded);
+        if (forwardRightOutputAcknowledgements) {
+          rightOutputAcknowledgementBytes += terminalMessageByteLength(forwarded);
+        } else if (acknowledgeRightOutputImmediately) {
+          sendTerminalOutputAcknowledgement(right, terminalMessageByteLength(forwarded));
+        }
       });
   });
   left.addEventListener("close", (event) => {
@@ -8416,6 +8480,40 @@ function bridgeWebSockets(
     stopControlCheck();
     closePair(right, left, 1011, "peer error");
   });
+}
+
+function terminalOutputAcknowledgements(value: string): boolean {
+  try {
+    return new URL(value).searchParams.get("flow") === "ack-v1";
+  } catch {
+    return false;
+  }
+}
+
+function terminalOutputAcknowledgement(value: string | ArrayBuffer): number | null {
+  if (typeof value !== "string" || !value.startsWith("{") || value.length > 100) return null;
+  try {
+    const parsed = JSON.parse(value) as Record<string, unknown>;
+    const bytes = parsed.bytes;
+    return parsed.type === "ack" &&
+      Number.isInteger(bytes) &&
+      Number(bytes) > 0 &&
+      Number(bytes) <= 1024 * 1024
+      ? Number(bytes)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function terminalMessageByteLength(value: string | ArrayBuffer): number {
+  return typeof value === "string" ? encoder.encode(value).byteLength : value.byteLength;
+}
+
+function sendTerminalOutputAcknowledgement(socket: WebSocket, bytes: number): void {
+  if (bytes > 0 && socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify({ type: "ack", bytes }));
+  }
 }
 
 async function webSocketMessageData(data: unknown): Promise<string | ArrayBuffer> {

--- a/src/terminal-protocol.ts
+++ b/src/terminal-protocol.ts
@@ -20,6 +20,7 @@ export const TerminalMessageType = {
   ControlRevoked: 53,
   Ping: 60,
   Pong: 61,
+  Ack: 62,
 } as const;
 
 export type TerminalMessageType = (typeof TerminalMessageType)[keyof typeof TerminalMessageType];
@@ -28,6 +29,7 @@ export const TerminalSubscribeFlags = {
   Output: 1 << 0,
   Snapshot: 1 << 1,
   Events: 1 << 2,
+  OutputAcknowledgements: 1 << 3,
 } as const;
 
 export type TerminalFrame = {
@@ -142,6 +144,17 @@ export function decodeResizePayload(payload: Uint8Array): { cols: number; rows: 
   if (payload.byteLength < 8) return null;
   const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
   return { cols: view.getUint32(0, true), rows: view.getUint32(4, true) };
+}
+
+export function encodeAckPayload(bytes: number): Uint8Array {
+  const payload = new Uint8Array(4);
+  new DataView(payload.buffer).setUint32(0, bytes >>> 0, true);
+  return payload;
+}
+
+export function decodeAckPayload(payload: Uint8Array): number | null {
+  if (payload.byteLength < 4) return null;
+  return new DataView(payload.buffer, payload.byteOffset, payload.byteLength).getUint32(0, true);
 }
 
 export function encodeJsonPayload(value: unknown): Uint8Array {

--- a/tests/canonical-host.test.ts
+++ b/tests/canonical-host.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import { test } from "node:test";
 import {
   canonicalAppRedirect,
@@ -41,6 +42,33 @@ test("product aliases redirect to the product apex", async () => {
 
   assert.equal(response.status, 308);
   assert.equal(response.headers.get("location"), "https://crabfleet.ai/docs?mode=full");
+});
+
+test("product deployment converges its hosts as Worker Custom Domains", async () => {
+  const config = await readFile(new URL("../wrangler.product.jsonc", import.meta.url), "utf8");
+  const convergence = await readFile(
+    new URL("../scripts/ensure-cloudflare-domains.mjs", import.meta.url),
+    "utf8",
+  );
+  const productStart = convergence.indexOf("async function ensureProductHosts");
+  const productEnd = convergence.indexOf("async function ensureCrabfleetDocsRecord", productStart);
+  const productSource = convergence.slice(productStart, productEnd);
+
+  assert.doesNotMatch(config, /"routes"/);
+  assert.match(
+    productSource,
+    /\/accounts\/\$\{cloudflareAccountId\}\/workers\/scripts\/\$\{productWorkerScript\}\/domains\/records/,
+  );
+  assert.match(productSource, /method: "PUT"/);
+  assert.match(productSource, /override_existing_origin: true/);
+  assert.match(productSource, /override_existing_dns_record: true/);
+  assert.match(productSource, /origins: hosts\.map/);
+  assert.ok(
+    productSource.indexOf('console.log(`set ${hosts.join(", ")} Worker Custom Domains`)') <
+      productSource.indexOf("workers/routes"),
+  );
+  assert.match(productSource, /workers\/routes\/\$\{route\.id\}/);
+  assert.doesNotMatch(productSource, /192\.0\.2\.1|method: "POST"/);
 });
 
 test("legacy app pages redirect to the canonical host", () => {

--- a/tests/runtime-adapter.test.ts
+++ b/tests/runtime-adapter.test.ts
@@ -1830,6 +1830,20 @@ test("runtime adapter terminals use the server-side adapter bearer", async () =>
   assert.match(decorateSource, /routeAvailable/);
 });
 
+test("runtime adapter terminal flow control stays explicit and end-to-end", async () => {
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+
+  assert.match(source, /frame\.type === TerminalMessageType\.Ack/);
+  assert.match(source, /subscription\.outputAcknowledgements/);
+  assert.match(source, /bytes <= subscription\.outputAcknowledgementBytes/);
+  assert.match(source, /acknowledgedBytes <= rightOutputAcknowledgementBytes/);
+  assert.match(source, /TerminalSubscribeFlags\.OutputAcknowledgements/);
+  assert.match(source, /searchParams\.get\("flow"\) === "ack-v1"/);
+  assert.match(source, /JSON\.stringify\(\{ type: "ack", bytes \}\)/);
+  assert.match(source, /terminalOutputAcknowledgement\(forwarded\)/);
+  assert.match(source, /else if \(upstreamConnection\.outputAcknowledgements\)/);
+});
+
 test("runtime adapter terminal bearer stays on the registered origin", () => {
   assert.equal(
     runtimeAdapterTerminalOriginMatches(

--- a/tests/terminal-protocol.test.ts
+++ b/tests/terminal-protocol.test.ts
@@ -3,9 +3,11 @@ import { test } from "node:test";
 import {
   TerminalMessageType,
   TerminalSubscribeFlags,
+  decodeAckPayload,
   decodeResizePayload,
   decodeSubscribePayload,
   decodeTerminalFrame,
+  encodeAckPayload,
   encodeJsonPayload,
   encodeResizePayload,
   encodeSubscribePayload,
@@ -38,13 +40,19 @@ test("terminal decoder rejects truncated and wrong-version frames", () => {
 test("terminal subscribe and resize payloads use stable little-endian fields", () => {
   const subscribe = decodeSubscribePayload(
     encodeSubscribePayload({
-      flags: TerminalSubscribeFlags.Output | TerminalSubscribeFlags.Events,
+      flags:
+        TerminalSubscribeFlags.Output |
+        TerminalSubscribeFlags.Events |
+        TerminalSubscribeFlags.OutputAcknowledgements,
       snapshotMinIntervalMs: 100,
       snapshotMaxIntervalMs: 500,
     }),
   );
   assert.deepEqual(subscribe, {
-    flags: TerminalSubscribeFlags.Output | TerminalSubscribeFlags.Events,
+    flags:
+      TerminalSubscribeFlags.Output |
+      TerminalSubscribeFlags.Events |
+      TerminalSubscribeFlags.OutputAcknowledgements,
     snapshotMinIntervalMs: 100,
     snapshotMaxIntervalMs: 500,
     cols: null,
@@ -52,6 +60,7 @@ test("terminal subscribe and resize payloads use stable little-endian fields", (
   });
 
   assert.deepEqual(decodeResizePayload(encodeResizePayload(132, 43)), { cols: 132, rows: 43 });
+  assert.equal(decodeAckPayload(encodeAckPayload(65_535)), 65_535);
 });
 
 test("terminal subscribe payloads can carry initial PTY size", () => {

--- a/tests/terminal-target.test.ts
+++ b/tests/terminal-target.test.ts
@@ -25,6 +25,7 @@ test("opaque direct terminal URLs pass through the multiplex hub unchanged", asy
   const directEnd = source.indexOf("function sendTerminalJson", directStart);
   const directSource = source.slice(directStart, directEnd);
   assert.match(directSource, /const targetUrl = sizedTerminalTargetUrl\(/);
+  assert.match(directSource, /const targetUrl = sizedTerminalTargetUrl\(\s*target\.url,/);
   assert.match(directSource, /terminalSize\(request, "cols", 120\)/);
   assert.match(directSource, /terminalSize\(request, "rows", 34\)/);
   assert.match(directSource, /upstreamResponse = await fetch\(targetUrl/);

--- a/wrangler.product.jsonc
+++ b/wrangler.product.jsonc
@@ -5,7 +5,7 @@
   "compatibility_date": "2026-06-11",
   "account_id": "91b59577e757131d68d55a471fe32aca",
   "workers_dev": false,
-  // Classic product routes are converged by ensure-cloudflare-domains.mjs.
+  // Product Custom Domains are converged by ensure-cloudflare-domains.mjs.
   // The regular Worker deploy token intentionally has no zone-route access.
   "observability": {
     "enabled": true,


### PR DESCRIPTION
## Summary

- negotiate terminal output acknowledgements end to end while preserving legacy clients and opaque adapter URLs
- bound ACK credit to delivered output in both multiplexed and direct terminal bridges
- deploy the generic product Worker without route permissions, then atomically converge both product Custom Domains before stale-route cleanup

## Verification

- `pnpm check`
- `pnpm test` (142 tests)
- `pnpm build`
- `pnpm exec wrangler deploy --config wrangler.product.jsonc --dry-run`
- structured Codex autoreview: clean
