### PR TITLE
fix: strip proxy authorization before routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Strip upstream authorization credentials from authenticated trusted-proxy requests before app and terminal routing.
 - Add deployment-neutral trusted reverse-proxy identity with exact-origin and shared-secret proof, existing allowlist authorization, cross-origin mutation rejection, fail-closed assertions, cookie isolation, and downstream credential stripping.
 - Add a native macOS Crabfleet VNC control deck with generic RFB 3.3/3.7/3.8 connections, Metal rendering, six warm desktops, paced previews, fast focus transitions, saved profiles, and stabilized opt-in clipboard synchronization.
 - Redirect `crabfleet.ai`, `www.crabfleet.ai`, and product aliases to the canonical Crabfleet docs while keeping login and app traffic on `crabfleet.openclaw.ai`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1836,6 +1836,7 @@ export default {
       request = sanitizeTrustedProxyRequest(request, env);
       if (trustedProxy.kind === "authenticated") {
         const headers = new Headers(request.headers);
+        if (!usesIndependentServiceAuth(request)) headers.delete("authorization");
         headers.delete("cookie");
         request = new Request(request, { headers });
       }

--- a/tests/trusted-proxy-integration.test.ts
+++ b/tests/trusted-proxy-integration.test.ts
@@ -16,6 +16,10 @@ test("trusted proxy authentication is resolved and sanitized before routing", as
       fetchSource.indexOf("productHostResponse(request)"),
   );
   assert.ok(
+    fetchSource.indexOf('headers.delete("authorization")') <
+      fetchSource.indexOf("api(request, env, context, trustedProxy)"),
+  );
+  assert.ok(
     fetchSource.indexOf('headers.delete("cookie")') <
       fetchSource.indexOf("api(request, env, context, trustedProxy)"),
   );
@@ -52,6 +56,10 @@ test("trusted proxy requests stay sanitized on terminal forwarding paths", async
   const openEnd = source.indexOf("async function ensureSandboxTerminalPrepared", openStart);
   assert.match(source.slice(openStart, openEnd), /terminalSession\.terminal\(request, options\)/);
   assert.match(source, /request = sanitizeTrustedProxyRequest\(request, env\)/);
+  assert.match(
+    source,
+    /trustedProxy\.kind === "authenticated"[\s\S]*headers\.delete\("authorization"\)/,
+  );
 });
 
 test("trusted proxy sign-in cannot pretend that local logout will end the session", async () => {
@@ -71,6 +79,10 @@ test("service-token routes bypass only the mandatory proxy assertion", async () 
   }
   assert.match(source, /requestAuth\.kind === "missing"\) throw unauthorized\(\)/);
   assert.match(source, /trustedProxy\.kind === "rejected"/);
+  assert.match(
+    source,
+    /if \(!usesIndependentServiceAuth\(request\)\) headers\.delete\("authorization"\)/,
+  );
 });
 
 test("split-origin links use the browser-visible proxy origin", async () => {


### PR DESCRIPTION
## Summary

- remove upstream Authorization credentials from authenticated trusted-proxy browser and application requests before routing
- preserve bearer credentials only for the explicitly scoped SSH, agent, OpenClaw, and provision APIs that authenticate independently
- keep cookie and proxy-assertion stripping unchanged

## Why

An authenticating edge may need to forward a short-lived bearer token to an upstream ingress. That credential must terminate before Crabfleet can forward the request to a user-controlled terminal or sandbox.

## Validation

- 170 Node tests
- TypeScript strict typecheck
- oxlint with warnings denied
- oxfmt check
- structured autoreview clean after the service-route exception was added
