### PR TITLE
feat: add runtime profile selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add a deployment-configured runtime profile selector with generic labels, targets, capability previews, server-side allowlisting, and CLI/SSH profile overrides.
 - Strip upstream authorization credentials from authenticated trusted-proxy requests before app and terminal routing.
 - Add deployment-neutral trusted reverse-proxy identity with exact-origin and shared-secret proof, existing allowlist authorization, cross-origin mutation rejection, fail-closed assertions, cookie isolation, and downstream credential stripping.
 - Add a native macOS Crabfleet VNC control deck with generic RFB 3.3/3.7/3.8 connections, Metal rendering, six warm desktops, paced previews, fast focus transitions, saved profiles, and stabilized opt-in clipboard synchronization.

--- a/README.md
+++ b/README.md
@@ -235,8 +235,21 @@ The Crabbox namespace cutover intentionally has no old-name compatibility. Exist
 - `CRABFLEET_PREFERRED_REPO` – Optional first/default enabled repo, default `openclaw/crabfleet`
 - `CRABFLEET_DEFAULT_RUNTIME` – Optional interactive runtime default, `container` or `crabbox`; defaults to `container`
 - `CRABFLEET_DEFAULT_PROFILE` – Optional opaque runtime-adapter profile, default `default`
+- `CRABFLEET_RUNTIME_PROFILES_JSON` – Optional bounded JSON array of generic profile descriptors (`id`, `label`, optional `target`, and optional boolean `capabilities`) shown to authenticated users when creating Crabbox sessions; when configured, `CRABFLEET_DEFAULT_PROFILE` must name one entry
 - `CRABFLEET_DEV_LOGIN_ENABLED` – Explicit local-only development identity login gate; disabled unless exactly `true`, and still restricted to literal localhost requests
 - `OPENAI_API_KEY` – Required for built-in Cloudflare Sandbox Codex CLI sessions; injected by the Worker outbound path for Cloudflare Sandbox requests
+
+For example, a deployment can expose two generic desktop profiles without
+teaching Crabfleet about either provider:
+
+```dotenv
+CRABFLEET_DEFAULT_RUNTIME="crabbox"
+CRABFLEET_DEFAULT_PROFILE="linux-desktop"
+CRABFLEET_RUNTIME_PROFILES_JSON='[{"id":"linux-desktop","label":"Linux","target":"linux","capabilities":{"terminal":true,"desktop":true,"vnc":true}},{"id":"macos-desktop","label":"macOS","target":"macos","capabilities":{"terminal":true,"desktop":true,"vnc":true}}]'
+```
+
+The configured lifecycle adapter remains responsible for mapping each opaque
+profile ID to a provider and enforcing its real capabilities.
 
 ### Verify Deployment
 

--- a/cmd/crabbox-ssh-gateway/main.go
+++ b/cmd/crabbox-ssh-gateway/main.go
@@ -108,6 +108,7 @@ type createSessionRequest struct {
 	Repo            string `json:"repo,omitempty"`
 	Branch          string `json:"branch,omitempty"`
 	Runtime         string `json:"runtime,omitempty"`
+	Profile         string `json:"profile,omitempty"`
 	Command         string `json:"command,omitempty"`
 	Prompt          string `json:"prompt,omitempty"`
 	ParentSessionID string `json:"parentSessionId,omitempty"`
@@ -834,6 +835,7 @@ func parseCreate(args []string, client *apiClient, fingerprint string) createArg
 	fs.StringVar(&req.Repo, "repo", "", "repo")
 	fs.StringVar(&req.Branch, "branch", "main", "branch")
 	fs.StringVar(&req.Runtime, "runtime", "", "runtime override; defaults to deployment")
+	fs.StringVar(&req.Profile, "profile", "", "runtime profile override; defaults to deployment")
 	fs.StringVar(&req.Command, "command", "", "command")
 	fs.StringVar(&req.ParentSessionID, "parent", "", "parent session")
 	fs.StringVar(&req.RootSessionID, "root", "", "root session")

--- a/cmd/crabbox-ssh-gateway/main_test.go
+++ b/cmd/crabbox-ssh-gateway/main_test.go
@@ -98,6 +98,17 @@ func TestParseCreateLeavesRuntimeToDeploymentDefault(t *testing.T) {
 	}
 }
 
+func TestParseCreateAcceptsProfileOverride(t *testing.T) {
+	create := parseCreate(
+		[]string{"--repo", "openclaw/crabfleet", "--profile", "desktop-a", "fix it"},
+		nil,
+		"",
+	)
+	if create.request.Profile != "desktop-a" {
+		t.Fatalf("profile = %q, want explicit override", create.request.Profile)
+	}
+}
+
 func TestTerminalCapabilityWithdrawalSuppressesAttach(t *testing.T) {
 	if !terminalCapable(interactiveSession{}) {
 		t.Fatal("legacy session without capabilities should remain attachable")

--- a/cmd/crabfleet/main.go
+++ b/cmd/crabfleet/main.go
@@ -64,6 +64,7 @@ type newCmd struct {
 	Repo    string   `help:"Repository to prepare, owner/repo."`
 	Branch  string   `help:"Git branch to checkout." default:"main"`
 	Runtime *string  `help:"Runtime backend override; omit to use the deployment default." enum:"crabbox,container"`
+	Profile string   `help:"Runtime profile override; omit to use the deployment default."`
 	Command string   `help:"Command to run after checkout." default:"codex --yolo"`
 	Parent  string   `help:"Parent crabbox session id."`
 	Root    string   `help:"Root crabbox session id."`
@@ -202,6 +203,7 @@ type createSessionRequest struct {
 	Repo            string `json:"repo,omitempty"`
 	Branch          string `json:"branch,omitempty"`
 	Runtime         string `json:"runtime,omitempty"`
+	Profile         string `json:"profile,omitempty"`
 	Command         string `json:"command,omitempty"`
 	Prompt          string `json:"prompt,omitempty"`
 	ParentSessionID string `json:"parentSessionId,omitempty"`
@@ -396,6 +398,7 @@ func (cmd newCmd) sessionRequest(app *cli) createSessionRequest {
 		Repo:            cmd.Repo,
 		Branch:          cmd.Branch,
 		Runtime:         runtime,
+		Profile:         cmd.Profile,
 		Command:         cmd.Command,
 		Prompt:          prompt,
 		ParentSessionID: parent,
@@ -409,6 +412,9 @@ func (cmd newCmd) sshCreateArgs(req createSessionRequest) []string {
 	args := []string{"new", "--branch", req.Branch}
 	if req.Runtime != "" {
 		args = append(args, "--runtime", req.Runtime)
+	}
+	if req.Profile != "" {
+		args = append(args, "--profile", req.Profile)
 	}
 	if req.Repo != "" {
 		args = append(args, "--repo", req.Repo)

--- a/cmd/crabfleet/main_test.go
+++ b/cmd/crabfleet/main_test.go
@@ -45,7 +45,7 @@ func TestFirstLineSkipsBlankLines(t *testing.T) {
 	}
 }
 
-func TestNewRuntimeOverrideIsOptional(t *testing.T) {
+func TestNewRuntimeAndProfileOverridesAreOptional(t *testing.T) {
 	t.Setenv("CRABFLEET_ROOT_SESSION_ID", "")
 	parse := func(args ...string) cli {
 		var app cli
@@ -69,12 +69,18 @@ func TestNewRuntimeOverrideIsOptional(t *testing.T) {
 	if req.Runtime != "" {
 		t.Fatalf("runtime = %q, want deployment default", req.Runtime)
 	}
+	if req.Profile != "" {
+		t.Fatalf("profile = %q, want deployment default", req.Profile)
+	}
 	encoded, err := json.Marshal(req)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if bytes.Contains(encoded, []byte(`"runtime"`)) {
 		t.Fatalf("omitted runtime was serialized: %s", encoded)
+	}
+	if bytes.Contains(encoded, []byte(`"profile"`)) {
+		t.Fatalf("omitted profile was serialized: %s", encoded)
 	}
 	for _, arg := range cmd.sshCreateArgs(req) {
 		if arg == "--runtime" {
@@ -96,6 +102,22 @@ func TestNewRuntimeOverrideIsOptional(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("explicit runtime missing from SSH fallback: %q", args)
+	}
+
+	cmd = parse("new", "--profile", "desktop-a").New
+	req = cmd.sessionRequest(&cli{})
+	if req.Profile != "desktop-a" {
+		t.Fatalf("profile = %q, want explicit override", req.Profile)
+	}
+	args = cmd.sshCreateArgs(req)
+	found = false
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == "--profile" && args[index+1] == "desktop-a" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("explicit profile missing from SSH fallback: %q", args)
 	}
 }
 

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -23,6 +23,7 @@ import {
   preferredRepos,
   runCapabilities,
   runtimeCapabilityLabel,
+  runtimeProfileOptionLabel,
   sessionLogsUrl,
   sessionItems,
   statusLabel,
@@ -50,6 +51,7 @@ const defaultDeployment = {
   preferredRepo,
   defaultRuntime: "container",
   defaultProfile: "default",
+  runtimeProfiles: [],
 };
 const loginReturnKey = "crabbox-login-return";
 const skipAutoGithubLoginKey = "crabbox-skip-auto-github-login";
@@ -852,7 +854,11 @@ function App() {
 
   async function createInteractiveSession(form) {
     const data = new FormData(form);
-    const optimistic = optimisticInteractiveSession(data, state.user?.login);
+    const optimistic = optimisticInteractiveSession(
+      data,
+      state.user?.login,
+      state.deployment?.runtimeProfiles,
+    );
     upsertInteractiveSession(optimistic);
     closeDrawer("interactive");
     setFocusedSessionId(optimistic.id);
@@ -1631,6 +1637,11 @@ function CardDrawer({ drawers, closeDrawer, createCard, state }) {
 
 function InteractiveDrawer({ drawers, closeDrawer, createInteractiveSession, state }) {
   const [busy, setBusy] = useState(false);
+  const defaultRuntime = state.deployment?.defaultRuntime || "container";
+  const defaultProfile = state.deployment?.defaultProfile || "default";
+  const runtimeProfiles = state.deployment?.runtimeProfiles || [];
+  const [runtime, setRuntime] = useState(defaultRuntime);
+  useEffect(() => setRuntime(defaultRuntime), [defaultRuntime]);
   return (
     <Drawer
       id="interactive-drawer"
@@ -1641,6 +1652,7 @@ function InteractiveDrawer({ drawers, closeDrawer, createInteractiveSession, sta
       <form
         class="form-grid"
         aria-busy={busy ? "true" : "false"}
+        onReset={() => setRuntime(defaultRuntime)}
         onSubmit={async (event) => {
           event.preventDefault();
           setBusy(true);
@@ -1659,15 +1671,28 @@ function InteractiveDrawer({ drawers, closeDrawer, createInteractiveSession, sta
         <label>
           Runtime
           <select
-            key={state.deployment?.defaultRuntime || "container"}
             name="runtime"
-            defaultValue={state.deployment?.defaultRuntime || "container"}
+            value={runtime}
+            onChange={(event) => setRuntime(event.currentTarget.value)}
           >
             <option value="container">Cloudflare Sandbox</option>
             <option value="crabbox">Crabbox</option>
           </select>
         </label>
-        <input type="hidden" name="profile" value={state.deployment?.defaultProfile || "default"} />
+        {runtime === "crabbox" && runtimeProfiles.length > 0 ? (
+          <label>
+            Profile
+            <select key={defaultProfile} name="profile" defaultValue={defaultProfile}>
+              {runtimeProfiles.map((profile) => (
+                <option key={profile.id} value={profile.id}>
+                  {runtimeProfileOptionLabel(profile)}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <input type="hidden" name="profile" value={defaultProfile} />
+        )}
         <label>
           Command
           <input name="command" defaultValue="codex --yolo" placeholder="codex --yolo" />

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -334,13 +334,17 @@ export function clipboardExtension(mediaType) {
   );
 }
 
-export function optimisticInteractiveSession(data, owner) {
+export function optimisticInteractiveSession(data, owner, runtimeProfiles = []) {
   const now = Date.now();
   const repo = String(data.get("repo") || preferredRepo);
   const branch = String(data.get("branch") || "main");
   const runtime = String(data.get("runtime") || "container");
   const profile = String(data.get("profile") || "default");
   const pendingRuntimeLabel = runtimeLabel(runtime);
+  const configuredCapabilities =
+    runtime === "crabbox"
+      ? runtimeProfiles.find((candidate) => candidate.id === profile)?.capabilities
+      : undefined;
   return {
     id: `LOCAL-${now}`,
     repo,
@@ -354,6 +358,7 @@ export function optimisticInteractiveSession(data, owner) {
       desktop: runtime === "crabbox",
       logs: true,
       artifacts: false,
+      ...configuredCapabilities,
     },
     command: interactiveCommand(data.get("command")),
     prompt: String(data.get("prompt") || ""),
@@ -381,6 +386,23 @@ export function optimisticInteractiveSession(data, owner) {
     logs: [`Requesting ${pendingRuntimeLabel}...`, "Waiting for session id..."],
     title: `${repo} · ${branch}`,
   };
+}
+
+export function runtimeProfileOptionLabel(profile) {
+  const label = String(profile?.label || profile?.id || "Profile");
+  const details = [];
+  if (profile?.target && String(profile.target).toLowerCase() !== label.toLowerCase()) {
+    details.push(String(profile.target));
+  }
+  const capabilities = [
+    ["terminal", "terminal"],
+    ["desktop", "desktop"],
+    ["vnc", "VNC"],
+  ]
+    .filter(([name]) => profile?.capabilities?.[name] === true)
+    .map(([, name]) => name);
+  if (capabilities.length > 0) details.push(capabilities.join(", "));
+  return details.length > 0 ? `${label} — ${details.join(" · ")}` : label;
 }
 
 export function interactiveCommand(value) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,12 @@ import {
   type CredentialPolicyGenerationTombstone,
   type CredentialPolicyLegacyMigration,
 } from "./credential-policy-fence";
+import {
+  parseRuntimeProfiles,
+  runtimeProfileByID,
+  runtimeProfileCapabilities,
+  type RuntimeProfileDescriptor,
+} from "./runtime-profiles";
 
 type Role = "viewer" | "maintainer" | "owner";
 type InteractiveRuntime = "crabbox" | "container" | "github_actions";
@@ -164,6 +170,7 @@ type DeploymentConfig = {
   preferredRepo: string;
   defaultRuntime: "crabbox" | "container";
   defaultProfile: string;
+  runtimeProfiles: RuntimeProfileDescriptor[];
 };
 
 type PublicDeploymentConfig = Pick<
@@ -218,6 +225,7 @@ type RuntimeEnv = Env & {
   CRABFLEET_PREFERRED_REPO?: string;
   CRABFLEET_DEFAULT_RUNTIME?: string;
   CRABFLEET_DEFAULT_PROFILE?: string;
+  CRABFLEET_RUNTIME_PROFILES_JSON?: string;
   CRABFLEET_DEV_LOGIN_ENABLED?: string;
   CRABFLEET_TRUSTED_PROXY_ORIGIN?: string;
   CRABFLEET_TRUSTED_PROXY_PUBLIC_ORIGIN?: string;
@@ -1050,7 +1058,7 @@ const crabboxCapabilities: RuntimeCapabilities = {
 };
 function runtimeAdapterCreateSettings(
   env: RuntimeEnv,
-  runtime: "crabbox" | "container",
+  capabilities: RuntimeCapabilities,
 ): {
   ttlSeconds: number;
   idleTimeoutSeconds: number;
@@ -1059,11 +1067,16 @@ function runtimeAdapterCreateSettings(
   return {
     ttlSeconds: clampedSeconds(env.CRABBOX_RUNTIME_ADAPTER_TTL_SECONDS, 14_400),
     idleTimeoutSeconds: clampedSeconds(env.CRABBOX_RUNTIME_ADAPTER_IDLE_SECONDS, 1_800),
-    capabilities: runtime === "crabbox" ? crabboxCapabilities : containerCapabilities,
+    capabilities,
   };
 }
 
 function deploymentConfig(env: RuntimeEnv): DeploymentConfig {
+  const defaultProfile = clean(env.CRABFLEET_DEFAULT_PROFILE, 120) || "default";
+  const runtimeProfiles = parseRuntimeProfiles(env.CRABFLEET_RUNTIME_PROFILES_JSON);
+  if (runtimeProfiles.length > 0 && !runtimeProfileByID(runtimeProfiles, defaultProfile)) {
+    throw new TypeError("CRABFLEET_DEFAULT_PROFILE must name a configured runtime profile");
+  }
   return {
     label: clean(env.CRABFLEET_LABEL, 80) || "Crabfleet",
     canonicalUrl: configuredHttpOrigin(env.CRABFLEET_CANONICAL_URL, appCanonicalOrigin),
@@ -1075,7 +1088,8 @@ function deploymentConfig(env: RuntimeEnv): DeploymentConfig {
       ["crabbox", "container"] as const,
       "container",
     ),
-    defaultProfile: clean(env.CRABFLEET_DEFAULT_PROFILE, 120) || "default",
+    defaultProfile,
+    runtimeProfiles,
   };
 }
 
@@ -4100,6 +4114,14 @@ async function createInteractiveSessionFromInput(
     | "container";
   requireRuntimeAdapterCreatePreflight(env, runtime);
   const profile = clean(body.profile, 120) || deployment.defaultProfile;
+  const runtimeProfile = runtimeProfileByID(deployment.runtimeProfiles, profile);
+  if (deployment.runtimeProfiles.length > 0 && !runtimeProfile) {
+    throw badRequest("profile is not configured");
+  }
+  const requestedCapabilities = runtimeProfileCapabilities(
+    runtime === "crabbox" ? runtimeProfile : undefined,
+    runtime === "crabbox" ? crabboxCapabilities : containerCapabilities,
+  );
   const command = interactiveCommand(body.command);
   const prompt = clean(body.prompt, 4000);
   const purpose = interactiveSessionPurpose(body.purpose, prompt, repo, branch, command);
@@ -4130,7 +4152,9 @@ async function createInteractiveSessionFromInput(
     const adapterControlPlane = adapterWorkspaceId
       ? configuredRuntimeAdapterControlPlane(env)
       : null;
-    const adapterSettings = adapterWorkspaceId ? runtimeAdapterCreateSettings(env, runtime) : null;
+    const adapterSettings = adapterWorkspaceId
+      ? runtimeAdapterCreateSettings(env, requestedCapabilities)
+      : null;
     const adapterCreatePayload =
       adapterWorkspaceId && adapterSettings
         ? runtimeAdapterCreatePayload(
@@ -4176,9 +4200,7 @@ async function createInteractiveSessionFromInput(
           adapter_workspace_id: adapterWorkspaceId,
           adapter_control_plane: adapterControlPlane,
           provider_resource_id: null,
-          capabilities_json: JSON.stringify(
-            runtime === "crabbox" ? crabboxCapabilities : containerCapabilities,
-          ),
+          capabilities_json: JSON.stringify(requestedCapabilities),
           expires_at: null,
           last_reconciled_at: adapterWorkspaceId ? now : null,
           reconcile_error: adapterWorkspaceId ? "runtime adapter create pending" : null,
@@ -4282,10 +4304,7 @@ async function createInteractiveSessionFromInput(
             profile: provisioned.profile ?? profile,
             adapter_workspace_id: provisioned.adapterWorkspaceId ?? null,
             provider_resource_id: provisioned.providerResourceId ?? null,
-            capabilities_json: JSON.stringify(
-              provisioned.capabilities ??
-                (runtime === "crabbox" ? crabboxCapabilities : containerCapabilities),
-            ),
+            capabilities_json: JSON.stringify(provisioned.capabilities ?? requestedCapabilities),
             expires_at: provisioned.expiresAt ?? null,
             last_reconciled_at: provisioned.reconciledAt ?? null,
             reconcile_error: provisioned.reconcileError ?? null,
@@ -11890,17 +11909,20 @@ async function stageFailedRuntimeAdapterRelease(
 function runtimeAdapterProvisionResult(
   result: AdapterWorkspaceResult,
   session: Pick<InteractiveProvisionRequest, "runtime" | "profile"> & {
+    adapterRequestedCapabilities?: RuntimeCapabilities | null;
     capabilities_json?: string;
   },
   reconciledAt: number,
   adapterWorkspaceId: string,
   initialCreate: boolean,
 ): InteractiveProvisionResult {
-  const defaultCapabilities = session.capabilities_json
-    ? runtimeCapabilities(session.runtime, session.capabilities_json)
-    : session.runtime === "crabbox"
-      ? crabboxCapabilities
-      : containerCapabilities;
+  const defaultCapabilities =
+    session.adapterRequestedCapabilities ??
+    (session.capabilities_json
+      ? runtimeCapabilities(session.runtime, session.capabilities_json)
+      : session.runtime === "crabbox"
+        ? crabboxCapabilities
+        : containerCapabilities);
   const capabilities = effectiveAdapterCapabilities(result, defaultCapabilities, initialCreate);
   return {
     status: result.status,

--- a/src/runtime-profiles.ts
+++ b/src/runtime-profiles.ts
@@ -1,0 +1,114 @@
+export type RuntimeProfileCapabilities = {
+  terminal: boolean;
+  takeover: boolean;
+  vnc: boolean;
+  desktop: boolean;
+  logs: boolean;
+  artifacts: boolean;
+};
+
+export type RuntimeProfileDescriptor = {
+  id: string;
+  label: string;
+  target?: string;
+  capabilities: Partial<RuntimeProfileCapabilities>;
+};
+
+const profileIDPattern = /^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,118}[A-Za-z0-9])?$/;
+const targetPattern = /^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,38}[A-Za-z0-9])?$/;
+const capabilityNames = ["terminal", "takeover", "vnc", "desktop", "logs", "artifacts"] as const;
+const capabilityNameSet = new Set<string>(capabilityNames);
+const descriptorKeys = new Set(["id", "label", "target", "capabilities"]);
+
+export function parseRuntimeProfiles(value: string | undefined): RuntimeProfileDescriptor[] {
+  if (value === undefined || value === "") return [];
+  if (value !== value.trim() || value.length > 32_768) {
+    throw new TypeError("CRABFLEET_RUNTIME_PROFILES_JSON must be bounded JSON without padding");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new TypeError("CRABFLEET_RUNTIME_PROFILES_JSON must be valid JSON");
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0 || parsed.length > 32) {
+    throw new TypeError("CRABFLEET_RUNTIME_PROFILES_JSON must contain 1 to 32 profiles");
+  }
+
+  const seen = new Set<string>();
+  const seenLabels = new Set<string>();
+  return parsed.map((entry, index) => {
+    if (!isRecord(entry) || Object.keys(entry).some((key) => !descriptorKeys.has(key))) {
+      throw new TypeError(`runtime profile ${index + 1} has unsupported fields`);
+    }
+    const id = exactString(entry.id, 120);
+    const label = exactString(entry.label, 80);
+    const target = entry.target === undefined ? undefined : exactString(entry.target, 40);
+    if (!profileIDPattern.test(id)) {
+      throw new TypeError(`runtime profile ${index + 1} has an invalid id`);
+    }
+    if (!label) throw new TypeError(`runtime profile ${index + 1} needs a label`);
+    if (target !== undefined && !targetPattern.test(target)) {
+      throw new TypeError(`runtime profile ${index + 1} has an invalid target`);
+    }
+    if (seen.has(id)) throw new TypeError(`runtime profile ${index + 1} repeats an id`);
+    const normalizedLabel = label.toLowerCase();
+    if (seenLabels.has(normalizedLabel)) {
+      throw new TypeError(`runtime profile ${index + 1} repeats a label`);
+    }
+    seen.add(id);
+    seenLabels.add(normalizedLabel);
+
+    const rawCapabilities = entry.capabilities ?? {};
+    if (
+      !isRecord(rawCapabilities) ||
+      Object.keys(rawCapabilities).some((key) => !capabilityNameSet.has(key))
+    ) {
+      throw new TypeError(`runtime profile ${index + 1} has invalid capabilities`);
+    }
+    const capabilities: Partial<RuntimeProfileCapabilities> = {};
+    for (const name of capabilityNames) {
+      const configured = rawCapabilities[name];
+      if (configured === undefined) continue;
+      if (typeof configured !== "boolean") {
+        throw new TypeError(`runtime profile ${index + 1} has a non-boolean capability`);
+      }
+      capabilities[name] = configured;
+    }
+    return { id, label, ...(target ? { target } : {}), capabilities };
+  });
+}
+
+export function runtimeProfileByID(
+  profiles: RuntimeProfileDescriptor[],
+  id: string,
+): RuntimeProfileDescriptor | undefined {
+  return profiles.find((profile) => profile.id === id);
+}
+
+export function runtimeProfileCapabilities(
+  profile: RuntimeProfileDescriptor | undefined,
+  fallback: RuntimeProfileCapabilities,
+): RuntimeProfileCapabilities {
+  return { ...fallback, ...profile?.capabilities };
+}
+
+function exactString(value: unknown, maximum: number): string {
+  if (
+    typeof value !== "string" ||
+    value !== value.trim() ||
+    value.length > maximum ||
+    [...value].some((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint < 0x20 || codePoint === 0x7f;
+    })
+  ) {
+    return "";
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/tests/app-utils.test.ts
+++ b/tests/app-utils.test.ts
@@ -13,6 +13,7 @@ import {
   optimisticInteractiveSession,
   runCapabilities,
   runtimeCapabilityLabel,
+  runtimeProfileOptionLabel,
   runtimeLabel,
   sessionItems,
   terminalText,
@@ -89,6 +90,47 @@ test("optimistic interactive sessions use runtime-specific pending copy", () => 
   assert.equal(session.runtime, "crabbox");
   assert.equal(session.lastEvent, "Requesting Crabbox...");
   assert.deepEqual(session.logs, ["Requesting Crabbox...", "Waiting for session id..."]);
+});
+
+test("optimistic interactive sessions use configured profile capabilities", () => {
+  const data = new FormData();
+  data.set("repo", "openclaw/crabfleet");
+  data.set("runtime", "crabbox");
+  data.set("profile", "terminal-only");
+
+  const session = optimisticInteractiveSession(data, "operator", [
+    {
+      id: "terminal-only",
+      label: "Terminal only",
+      capabilities: { desktop: false, vnc: false },
+    },
+  ]);
+
+  assert.equal(session.profile, "terminal-only");
+  assert.equal(session.capabilities.terminal, true);
+  assert.equal(session.capabilities.desktop, false);
+  assert.equal(session.capabilities.vnc, false);
+});
+
+test("runtime profile options expose target and enabled capabilities", () => {
+  assert.equal(
+    runtimeProfileOptionLabel({
+      id: "desktop-a",
+      label: "Desktop A",
+      target: "platform-a",
+      capabilities: { terminal: true, desktop: true, vnc: true },
+    }),
+    "Desktop A — platform-a · terminal, desktop, VNC",
+  );
+  assert.equal(
+    runtimeProfileOptionLabel({
+      id: "linux",
+      label: "Linux",
+      target: "linux",
+      capabilities: {},
+    }),
+    "Linux",
+  );
 });
 
 test("interactive command defaults to yolo without sandbox suffix", () => {

--- a/tests/html-dialogs.test.ts
+++ b/tests/html-dialogs.test.ts
@@ -12,7 +12,9 @@ test("app actions use styled HTML dialogs instead of browser prompts", async () 
   assert.match(source, /function Drawer[\s\S]*?previousFocus\?\.focus\?\.\(\)/);
   assert.match(source, /closeAllDrawers\(\);\s*setSignedIn\(false\);/);
   assert.match(source, /async function showSharedLinkError[\s\S]*?closeAllDrawers\(\);/);
-  assert.match(source, /key=\{state\.deployment\?\.defaultRuntime \|\| "container"\}/);
+  assert.match(source, /runtimeProfiles\.map\(\(profile\) =>/);
+  assert.match(source, /runtimeProfileOptionLabel\(profile\)/);
+  assert.match(source, /onReset=\{\(\) => setRuntime\(defaultRuntime\)\}/);
   assert.match(source, /useEffect\(\(\) => setRepo\(preferred\), \[preferred\]\)/);
 });
 

--- a/tests/runtime-adapter.test.ts
+++ b/tests/runtime-adapter.test.ts
@@ -105,6 +105,23 @@ test("adapter create payload matches the strict controller contract", () => {
   );
 });
 
+test("configured profiles fence every adapter runtime and preserve requested capabilities", async () => {
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const createStart = source.indexOf("async function createInteractiveSessionFromInput");
+  const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
+  const createSource = source.slice(createStart, createEnd);
+  const resultStart = source.indexOf("function runtimeAdapterProvisionResult");
+  const resultEnd = source.indexOf(
+    "async function reconcileStoppingRuntimeAdapterWorkspace",
+    resultStart,
+  );
+  const resultSource = source.slice(resultStart, resultEnd);
+
+  assert.match(createSource, /deployment\.runtimeProfiles\.length > 0 && !runtimeProfile/);
+  assert.doesNotMatch(createSource, /runtime === "crabbox" && deployment\.runtimeProfiles/);
+  assert.match(resultSource, /session\.adapterRequestedCapabilities \?\?/);
+});
+
 test("adapter workspace id stays distinct from provider resource id", () => {
   const result = parseAdapterWorkspaceResult({
     id: "fleet-a-is-101",

--- a/tests/runtime-profiles.test.ts
+++ b/tests/runtime-profiles.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import {
+  parseRuntimeProfiles,
+  runtimeProfileByID,
+  runtimeProfileCapabilities,
+} from "../src/runtime-profiles.ts";
+
+test("runtime profile catalog preserves generic labels, targets, and capabilities", () => {
+  const profiles = parseRuntimeProfiles(
+    JSON.stringify([
+      {
+        id: "desktop-a",
+        label: "Desktop A",
+        target: "platform-a",
+        capabilities: { terminal: true, desktop: true, vnc: true },
+      },
+      { id: "terminal-b", label: "Terminal B", capabilities: { desktop: false } },
+    ]),
+  );
+
+  assert.equal(profiles.length, 2);
+  assert.equal(runtimeProfileByID(profiles, "desktop-a")?.target, "platform-a");
+  assert.deepEqual(
+    runtimeProfileCapabilities(runtimeProfileByID(profiles, "terminal-b"), {
+      terminal: true,
+      takeover: false,
+      vnc: true,
+      desktop: true,
+      logs: true,
+      artifacts: false,
+    }),
+    {
+      terminal: true,
+      takeover: false,
+      vnc: true,
+      desktop: false,
+      logs: true,
+      artifacts: false,
+    },
+  );
+});
+
+test("runtime profile catalog fails closed on malformed or ambiguous input", () => {
+  const invalid = [
+    " ",
+    "{}",
+    "[]",
+    '[{"id":"a","label":"A"},{"id":"a","label":"B"}]',
+    '[{"id":"a","label":"Same"},{"id":"b","label":"same"}]',
+    '[{"id":"a","label":" A"}]',
+    '[{"id":"a","label":"A\\nB"}]',
+    '[{"id":"a","label":"A","capabilities":{"desktop":"yes"}}]',
+    '[{"id":"a","label":"A","capabilities":{"unknown":true}}]',
+    '[{"id":"a","label":"A","privateProvider":"hidden"}]',
+  ];
+  for (const value of invalid) {
+    assert.throws(() => parseRuntimeProfiles(value));
+  }
+  assert.deepEqual(parseRuntimeProfiles(undefined), []);
+  assert.deepEqual(parseRuntimeProfiles(""), []);
+});
+
+test("profile allowlisting and capability withdrawals stay enforced at provisioning", async () => {
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const selectionStart = source.indexOf("const profile = clean(body.profile");
+  const selectionEnd = source.indexOf("const command = interactiveCommand", selectionStart);
+  const selection = source.slice(selectionStart, selectionEnd);
+  assert.match(selection, /deployment\.runtimeProfiles\.length > 0 && !runtimeProfile/);
+
+  const resultStart = source.indexOf("function runtimeAdapterProvisionResult");
+  const resultEnd = source.indexOf(
+    "async function reconcileStoppingRuntimeAdapterWorkspace",
+    resultStart,
+  );
+  const result = source.slice(resultStart, resultEnd);
+  assert.match(
+    result,
+    /session\.adapterRequestedCapabilities \?\?[\s\S]*session\.capabilities_json/,
+  );
+});


### PR DESCRIPTION
## Summary

- add a strict deployment-configured runtime profile catalog
- show generic profile, target, and capability choices when creating Crabbox sessions
- enforce configured profile IDs server-side and preserve capability withdrawals through adapter provisioning
- add profile overrides to the CLI and SSH gateway

## Verification

- `node --test --experimental-strip-types tests/runtime-adapter.test.ts tests/runtime-profiles.test.ts tests/app-utils.test.ts tests/html-dialogs.test.ts`
- `go test ./...`
- `oxfmt --check` on changed TypeScript/JavaScript files
- `oxlint .`
- `deno check src/runtime-profiles.ts`
- structured autoreview: clean
