### PR TITLE
feat(api): add room-scoped crabbox supervision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add root-fenced OpenClaw service supervision for Crabbox room trees, including current state, bounded transcript evidence, targeted terminal nudges, audited stop requests, and canonical browser URLs.
+- Allow MultiCodex to use a dedicated service capability without rotating the existing OpenClaw automation token.
 - Add deployment-configured Codex SSH handoffs for ready provider workspaces, with safe alias templating, manager-only session metadata, and copyable local setup commands that keep provider behavior outside Crabfleet.
 - Route generic runtime profiles to distinct versioned adapters through a validated deployment URL template, reject profile-rewriting responses, and preserve immutable lifecycle control-plane fences.
 - Add a deployment-configured runtime profile selector with generic labels, targets, capability previews, server-side allowlisting, and CLI/SSH profile overrides.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add root-fenced OpenClaw service supervision for Crabbox room trees, including current state, bounded transcript evidence, targeted terminal nudges, audited stop requests, and canonical browser URLs.
 - Allow MultiCodex to use a dedicated service capability without rotating the existing OpenClaw automation token.
-- Prepare missing service-requested branches from an explicit base branch before Crabbox provisioning.
+- Safely reserve room capacity and prepare missing service-requested branches from an explicit base branch before Crabbox provisioning.
 - Add deployment-configured Codex SSH handoffs for ready provider workspaces, with safe alias templating, manager-only session metadata, and copyable local setup commands that keep provider behavior outside Crabfleet.
 - Route generic runtime profiles to distinct versioned adapters through a validated deployment URL template, reject profile-rewriting responses, and preserve immutable lifecycle control-plane fences.
 - Add a deployment-configured runtime profile selector with generic labels, targets, capability previews, server-side allowlisting, and CLI/SSH profile overrides.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add root-fenced OpenClaw service supervision for Crabbox room trees, including current state, bounded transcript evidence, targeted terminal nudges, audited stop requests, and canonical browser URLs.
 - Allow MultiCodex to use a dedicated service capability without rotating the existing OpenClaw automation token.
+- Prepare missing service-requested branches from an explicit base branch before Crabbox provisioning.
 - Add deployment-configured Codex SSH handoffs for ready provider workspaces, with safe alias templating, manager-only session metadata, and copyable local setup commands that keep provider behavior outside Crabfleet.
 - Route generic runtime profiles to distinct versioned adapters through a validated deployment URL template, reject profile-rewriting responses, and preserve immutable lifecycle control-plane fences.
 - Add a deployment-configured runtime profile selector with generic labels, targets, capability previews, server-side allowlisting, and CLI/SSH profile overrides.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add root-fenced OpenClaw service supervision for Crabbox room trees, including current state, bounded transcript evidence, targeted terminal nudges, audited stop requests, and canonical browser URLs.
 - Add deployment-configured Codex SSH handoffs for ready provider workspaces, with safe alias templating, manager-only session metadata, and copyable local setup commands that keep provider behavior outside Crabfleet.
 - Route generic runtime profiles to distinct versioned adapters through a validated deployment URL template, reject profile-rewriting responses, and preserve immutable lifecycle control-plane fences.
 - Add a deployment-configured runtime profile selector with generic labels, targets, capability previews, server-side allowlisting, and CLI/SSH profile overrides.

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ The Crabbox namespace cutover intentionally has no old-name compatibility. Exist
 - `CRABBOX_CLAWFLEET_TOKEN` – Optional bearer token sent to ClawFleet
 - `CRABBOX_CLAWFLEET_PUBLIC_URL` – Optional public ClawFleet URL used when building attach/VNC links
 - `CRABBOX_OPENCLAW_TOKEN` – Internal bearer token for OpenClaw service crabbox and GitHub Actions session registration
+- `CRABBOX_MULTICODEX_TOKEN` – Optional dedicated bearer token for MultiCodex room supervision
 - `CRABFLEET_SSH_GATEWAY_TOKEN` / `CRABBOX_SSH_GATEWAY_TOKEN` – Shared bearer token for the Go SSH gateway internal API
 - `CRABFLEET_LOCAL_SANDBOX_BACKUPS` – Optional Cloudflare Sandbox checkpoint mode override; defaults to R2 binding uploads, set `0` for SDK presigned R2 uploads
 - `CRABFLEET_LABEL` – Optional tenant label shown in the app, default `Crabfleet`

--- a/docs/api.md
+++ b/docs/api.md
@@ -542,7 +542,7 @@ Internal automation uses `Authorization: Bearer CRABBOX_OPENCLAW_TOKEN`.
 
 ### POST /api/openclaw/crabboxes
 
-Creates a repo-ready crabbox for an operator, e.g. from a Discord meeting handoff.
+Creates a repo-ready crabbox for an operator, e.g. from a Discord meeting handoff or a MultiCodex room.
 
 ```json
 {
@@ -564,7 +564,45 @@ Response:
     "owner": "@steipete",
     "runtime": "crabbox",
     "vncUrl": "https://..."
-  }
+  },
+  "browserUrl": "https://crabfleet.openclaw.ai/app/sessions/IS-105"
+}
+```
+
+### OpenClaw crabbox supervision
+
+Internal OpenClaw automation can supervise a created room/session tree without
+using browser cookies or an individual session's agent token:
+
+- `GET /api/openclaw/session-roots/:rootSessionId`: list the exact root and its children.
+- `GET /api/openclaw/crabboxes/:id`: read one current crabbox.
+- `GET /api/openclaw/crabboxes/:id/transcript`: read a bounded recent transcript.
+- `POST /api/openclaw/crabboxes/:id/message`: send one terminal message/nudge.
+- `POST /api/openclaw/crabboxes/:id/actions`: request the supported `stop` action.
+
+Every endpoint requires `Authorization: Bearer CRABBOX_OPENCLAW_TOKEN`.
+Per-crabbox reads require `X-Crabfleet-Root-Session-ID`; message and action
+bodies require `rootSessionId`. A session outside that exact root is returned
+as not found. Transcript responses contain at most the newest 240 events and
+64 KiB of UTF-8 text and report whether evidence was truncated. Every message
+and stop request writes an audit event.
+
+Message request:
+
+```json
+{
+  "rootSessionId": "IS-100",
+  "message": "Align the response contract with the frontend lane.",
+  "enter": true
+}
+```
+
+Stop request:
+
+```json
+{
+  "rootSessionId": "IS-100",
+  "action": "stop"
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -585,13 +585,15 @@ existing `CRABBOX_OPENCLAW_TOKEN`, or the dedicated `CRABBOX_MULTICODEX_TOKEN`
 for a MultiCodex deployment. Action-session registration accepts only
 `CRABBOX_OPENCLAW_TOKEN`; the narrower MultiCodex credential cannot register or
 resume GitHub Actions sessions.
-Crabbox creation can include `baseBranch`; when the requested branch is
-missing, Crabfleet creates it from that base with its deployment GitHub
-credential before provisioning the session. If that control-plane credential
-is denied with `403`, Crabfleet defers branch validation to the separately
-credentialed runtime adapter so an existing branch can still launch. A missing
-control-plane credential is also deferrable. A missing or inaccessible branch
-then fails during runtime checkout.
+Crabbox creation can explicitly include `baseBranch`; after request validation,
+when the requested branch is missing, Crabfleet creates it from that base with
+its deployment GitHub credential before provisioning the session. If that
+control-plane credential is denied with `403` or GitHub's masked `404`,
+Crabfleet defers branch validation to the separately credentialed runtime
+adapter so an existing branch can still launch. A missing control-plane
+credential is also deferrable. Without an explicit `baseBranch`, Crabfleet does
+not mutate GitHub. A missing or inaccessible branch then fails during runtime
+checkout.
 Per-crabbox reads require `X-Crabfleet-Root-Session-ID`; message and action
 bodies require `rootSessionId`. A session outside that exact root is returned
 as not found. Transcript responses contain at most the newest 240 events and

--- a/docs/api.md
+++ b/docs/api.md
@@ -585,7 +585,10 @@ Every endpoint requires a configured service capability: the existing
 MultiCodex deployment.
 Crabbox creation can include `baseBranch`; when the requested branch is
 missing, Crabfleet creates it from that base with its deployment GitHub
-credential before provisioning the session.
+credential before provisioning the session. If that control-plane credential
+is denied with `403`, Crabfleet defers branch validation to the separately
+credentialed runtime adapter so an existing branch can still launch. A missing
+or inaccessible branch then fails during runtime checkout.
 Per-crabbox reads require `X-Crabfleet-Root-Session-ID`; message and action
 bodies require `rootSessionId`. A session outside that exact root is returned
 as not found. Transcript responses contain at most the newest 240 events and

--- a/docs/api.md
+++ b/docs/api.md
@@ -580,7 +580,9 @@ using browser cookies or an individual session's agent token:
 - `POST /api/openclaw/crabboxes/:id/message`: send one terminal message/nudge.
 - `POST /api/openclaw/crabboxes/:id/actions`: request the supported `stop` action.
 
-Every endpoint requires `Authorization: Bearer CRABBOX_OPENCLAW_TOKEN`.
+Every endpoint requires a configured service capability: the existing
+`CRABBOX_OPENCLAW_TOKEN`, or the dedicated `CRABBOX_MULTICODEX_TOKEN` for a
+MultiCodex deployment.
 Per-crabbox reads require `X-Crabfleet-Root-Session-ID`; message and action
 bodies require `rootSessionId`. A session outside that exact root is returned
 as not found. Transcript responses contain at most the newest 240 events and

--- a/docs/api.md
+++ b/docs/api.md
@@ -580,15 +580,18 @@ using browser cookies or an individual session's agent token:
 - `POST /api/openclaw/crabboxes/:id/message`: send one terminal message/nudge.
 - `POST /api/openclaw/crabboxes/:id/actions`: request the supported `stop` action.
 
-Every endpoint requires a configured service capability: the existing
-`CRABBOX_OPENCLAW_TOKEN`, or the dedicated `CRABBOX_MULTICODEX_TOKEN` for a
-MultiCodex deployment.
+Room supervision endpoints require a configured service capability: the
+existing `CRABBOX_OPENCLAW_TOKEN`, or the dedicated `CRABBOX_MULTICODEX_TOKEN`
+for a MultiCodex deployment. Action-session registration accepts only
+`CRABBOX_OPENCLAW_TOKEN`; the narrower MultiCodex credential cannot register or
+resume GitHub Actions sessions.
 Crabbox creation can include `baseBranch`; when the requested branch is
 missing, Crabfleet creates it from that base with its deployment GitHub
 credential before provisioning the session. If that control-plane credential
 is denied with `403`, Crabfleet defers branch validation to the separately
 credentialed runtime adapter so an existing branch can still launch. A missing
-or inaccessible branch then fails during runtime checkout.
+control-plane credential is also deferrable. A missing or inaccessible branch
+then fails during runtime checkout.
 Per-crabbox reads require `X-Crabfleet-Root-Session-ID`; message and action
 bodies require `rootSessionId`. A session outside that exact root is returned
 as not found. Transcript responses contain at most the newest 240 events and

--- a/docs/api.md
+++ b/docs/api.md
@@ -574,7 +574,8 @@ Response:
 Internal OpenClaw automation can supervise a created room/session tree without
 using browser cookies or an individual session's agent token:
 
-- `GET /api/openclaw/session-roots/:rootSessionId`: list the exact root and its children.
+- `GET /api/openclaw/session-roots/:rootSessionId`: list the exact root and up to
+  63 children, with logs omitted from each session summary.
 - `GET /api/openclaw/crabboxes/:id`: read one current crabbox.
 - `GET /api/openclaw/crabboxes/:id/transcript`: read a bounded recent transcript.
 - `POST /api/openclaw/crabboxes/:id/message`: send one terminal message/nudge.

--- a/docs/api.md
+++ b/docs/api.md
@@ -575,7 +575,8 @@ Internal OpenClaw automation can supervise a created room/session tree without
 using browser cookies or an individual session's agent token:
 
 - `GET /api/openclaw/session-roots/:rootSessionId`: list the exact root and up to
-  63 children, with logs omitted from each session summary.
+  63 service-created or agent-created descendants, with logs omitted from each
+  session summary.
 - `GET /api/openclaw/crabboxes/:id`: read one current crabbox.
 - `GET /api/openclaw/crabboxes/:id/transcript`: read a bounded recent transcript.
 - `POST /api/openclaw/crabboxes/:id/message`: send one terminal message/nudge.

--- a/docs/api.md
+++ b/docs/api.md
@@ -598,7 +598,9 @@ not mutate GitHub. A missing or inaccessible branch then fails during runtime
 checkout.
 Per-crabbox reads require `X-Crabfleet-Root-Session-ID`; message and action
 bodies require `rootSessionId`. A session outside that exact root is returned
-as not found. Transcript responses contain at most the newest 240 events and
+as not found. Creation rejects a supervised descendant that would exceed the
+64-session room-tree limit before runtime provisioning begins. Transcript
+responses contain at most the newest 240 events and
 64 KiB of UTF-8 text and report whether evidence was truncated. Every message
 and stop request writes an audit event.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -583,6 +583,9 @@ using browser cookies or an individual session's agent token:
 Every endpoint requires a configured service capability: the existing
 `CRABBOX_OPENCLAW_TOKEN`, or the dedicated `CRABBOX_MULTICODEX_TOKEN` for a
 MultiCodex deployment.
+Crabbox creation can include `baseBranch`; when the requested branch is
+missing, Crabfleet creates it from that base with its deployment GitHub
+credential before provisioning the session.
 Per-crabbox reads require `X-Crabfleet-Root-Session-ID`; message and action
 bodies require `rootSessionId`. A session outside that exact root is returned
 as not found. Transcript responses contain at most the newest 240 events and

--- a/migrations/0025_interactive_session_preparation.sql
+++ b/migrations/0025_interactive_session_preparation.sql
@@ -1,0 +1,4 @@
+ALTER TABLE interactive_sessions ADD COLUMN preparation_pending INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_interactive_sessions_preparation
+  ON interactive_sessions(preparation_pending, updated_at);

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ import { readBoundedResponseText } from "./bounded-response";
 import {
   boundedUtf8Tail,
   openClawBranchPreparationCanDefer,
+  openClawGitBranchAllowed,
   openClawGitHubRepoParts,
   openClawRoomMaxSessions,
   openClawRoomRootAllowed,
@@ -3239,6 +3240,10 @@ async function openClawCreateCrabbox(
     baseBranch?: string;
   }>(request);
   const owner = openClawOwner(body.owner);
+  body.branch = openClawServiceBranch(body.branch, "branch", "main");
+  const baseBranch = openClawServiceBranch(body.baseBranch, "baseBranch");
+  if (baseBranch) body.baseBranch = baseBranch;
+  else delete body.baseBranch;
   const serviceUser = openClawServiceUser();
   const result = await createInteractiveSessionFromInput(
     env,
@@ -3920,6 +3925,14 @@ function requireOpenClawServiceToken(
   }
 }
 
+function openClawServiceBranch(value: unknown, name: string, fallback = ""): string {
+  if (value === undefined || value === null || value === "") return fallback;
+  if (typeof value !== "string" || !openClawGitBranchAllowed(value)) {
+    throw badRequest(`${name} must be a valid Git branch of at most 120 characters`);
+  }
+  return value;
+}
+
 async function ensureOpenClawServiceBranch(
   env: RuntimeEnv,
   repoInput: unknown,
@@ -3932,8 +3945,8 @@ async function ensureOpenClawServiceBranch(
   const target = openClawGitHubRepoParts(repo);
   if (!target) throw badRequest("repo must be a GitHub owner/name");
   await requireRepo(env, repo);
-  const branch = clean(branchInput, 120) || "main";
-  const baseBranch = clean(baseBranchInput, 120);
+  const branch = openClawServiceBranch(branchInput, "branch", "main");
+  const baseBranch = openClawServiceBranch(baseBranchInput, "baseBranch");
   if (!baseBranch) return;
   if (branch === baseBranch) return;
   if (!env.GITHUB_TOKEN) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3520,6 +3520,10 @@ async function enforceOpenClawRoomSessionLimitAfterInsert(
   insertedSessionId: string,
   insertedAt: number,
 ): Promise<void> {
+  if (!(await openClawRoomReservationLineageAllowed(env, insertedSessionId, rootSessionId))) {
+    await rollbackInteractiveSessionReservation(env, insertedSessionId, insertedAt);
+    throw badRequest("invalid OpenClaw room lineage");
+  }
   const db = database(env);
   const admission = await sql<{ inserted_rowid: number; position: number }>`
     SELECT inserted.rowid AS inserted_rowid, count(candidate.rowid) AS position
@@ -3542,6 +3546,43 @@ async function enforceOpenClawRoomSessionLimitAfterInsert(
   if (!position) throw serviceUnavailable("session root reservation disappeared");
   await rollbackInteractiveSessionReservation(env, insertedSessionId, insertedAt);
   throw tooManyRequests("session root reached the supervision limit");
+}
+
+async function openClawRoomReservationLineageAllowed(
+  env: RuntimeEnv,
+  insertedSessionId: string,
+  rootSessionId: string,
+): Promise<boolean> {
+  const [session, root] = await Promise.all([
+    readOpenClawLineageSession(env, insertedSessionId, 1),
+    readOpenClawLineageSession(env, rootSessionId, 0),
+  ]);
+  if (!session || !root) return false;
+  const chain = new Map<string, InteractiveSession>([[root.id, root]]);
+  let current = session;
+  for (let depth = 0; depth < openClawRoomMaxSessions && !chain.has(current.id); depth += 1) {
+    chain.set(current.id, current);
+    if (current.id === rootSessionId || !current.parentSessionId) break;
+    if (chain.has(current.parentSessionId)) break;
+    const parent = await readOpenClawLineageSession(env, current.parentSessionId, 0);
+    if (!parent) break;
+    current = parent;
+  }
+  return openClawRoomSessionChainAllowed([...chain.values()], session.id, rootSessionId);
+}
+
+async function readOpenClawLineageSession(
+  env: RuntimeEnv,
+  id: string,
+  preparationPending: 0 | 1,
+): Promise<InteractiveSession | null> {
+  const row = await database(env)
+    .selectFrom("interactive_sessions")
+    .selectAll()
+    .where("id", "=", id)
+    .where("preparation_pending", "=", preparationPending)
+    .executeTakeFirst();
+  return row ? interactiveSession(row, []) : null;
 }
 
 async function rollbackInteractiveSessionReservation(

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ import { readBoundedResponseText } from "./bounded-response";
 import {
   boundedUtf8Tail,
   openClawBranchPreparationCanDefer,
+  openClawRoomMaxSessions,
   openClawRoomRootAllowed,
   openClawRoomSessionAllowed,
   openClawServiceAuthorized,
@@ -3296,11 +3297,25 @@ async function openClawReadSessionRoot(
     .where((expression) =>
       expression.or([expression("root_session_id", "=", root), expression("id", "=", root)]),
     )
+    .where("created_by", "=", "service:openclaw")
+    .where("runtime", "!=", "github_actions")
+    .where("work_key", "is", null)
     .orderBy("created_at", "asc")
+    .limit(openClawRoomMaxSessions + 1)
     .execute();
   if (!rows.length) throw notFound("session root not found");
+  if (rows.length > openClawRoomMaxSessions) {
+    throw serviceUnavailable("session root exceeds the supervision limit");
+  }
   const serviceUser = openClawServiceUser();
-  const sessions = await Promise.all(rows.map((row) => readFreshInteractiveSession(env, row.id)));
+  const sessions: Array<InteractiveSession | null> = Array.from({ length: rows.length }, () => null);
+  await mapWithConcurrency(
+    rows.map((row, index) => ({ row, index })),
+    4,
+    async ({ row, index }) => {
+      sessions[index] = await readFreshInteractiveSession(env, row.id);
+    },
+  );
   return {
     rootSessionId: root,
     crabboxes: sessions
@@ -3311,7 +3326,7 @@ async function openClawReadSessionRoot(
           sessionBelongsToRoot(session.id, session.rootSessionId, root)
         );
       })
-      .map((session) => openClawCrabboxResponse(env, serviceUser, session)),
+      .map((session) => openClawCrabboxSummaryResponse(env, serviceUser, session)),
   };
 }
 
@@ -3322,7 +3337,7 @@ async function openClawReadCrabbox(
 ): Promise<{ session: InteractiveSession; browserUrl: string }> {
   requireOpenClawRoomService(request, env);
   const session = await openClawRootScopedCrabbox(request, env, id);
-  return openClawCrabboxResponse(env, openClawServiceUser(), session);
+  return openClawCrabboxSummaryResponse(env, openClawServiceUser(), session);
 }
 
 async function openClawReadCrabboxTranscript(
@@ -3345,10 +3360,9 @@ async function openClawReadCrabboxTranscript(
   const hasMoreEvents = eventWindow.length > 240;
   const events = hasMoreEvents ? eventWindow.slice(1) : eventWindow;
   const transcript = boundedUtf8Tail(sessionLogTranscript(session, events));
-  const response = openClawCrabboxResponse(env, openClawServiceUser(), session);
+  const response = openClawCrabboxSummaryResponse(env, openClawServiceUser(), session);
   return {
     ...response,
-    session: { ...response.session, logs: [] },
     transcript: transcript.text,
     eventCount,
     truncated: transcript.truncated || hasMoreEvents || eventCount > events.length,
@@ -3405,7 +3419,7 @@ async function openClawMessageCrabbox(
   }
   return {
     delivered: true,
-    ...openClawCrabboxResponse(env, serviceUser, session),
+    ...openClawCrabboxSummaryResponse(env, serviceUser, session),
   };
 }
 
@@ -3421,7 +3435,7 @@ async function openClawMutateCrabbox(
   const serviceUser = openClawServiceUser();
   await audit(env, serviceUser, `openclaw crabbox stop requested ${id}`, Date.now());
   const result = await mutateInteractiveSession(request, env, serviceUser, id, body.action);
-  return openClawCrabboxResponse(env, serviceUser, result.session);
+  return openClawCrabboxSummaryResponse(env, serviceUser, result.session);
 }
 
 async function openClawRootScopedCrabbox(
@@ -3458,6 +3472,15 @@ function openClawCrabboxResponse(
     env,
     decorateInteractiveSession(session, serviceUser, env),
   );
+}
+
+function openClawCrabboxSummaryResponse(
+  env: RuntimeEnv,
+  serviceUser: User,
+  session: InteractiveSession,
+): { session: InteractiveSession; browserUrl: string } {
+  const response = openClawCrabboxResponse(env, serviceUser, session);
+  return { ...response, session: { ...response.session, logs: [] } };
 }
 
 function openClawDecoratedCrabboxResponse(
@@ -5134,6 +5157,7 @@ async function cleanupInteractiveSessions(
         FROM interactive_sessions AS descendant
         WHERE descendant.root_session_id = interactive_sessions.id
           AND descendant.id != interactive_sessions.id
+          AND descendant.status NOT IN ('stopped', 'expired', 'failed')
       )
     `).where(sql<boolean>`
       ${env.SESSION_LOGS ? 1 : 0} = 0
@@ -5201,6 +5225,7 @@ async function deleteFinalizedInteractiveSession(
         FROM interactive_sessions AS descendant
         WHERE descendant.root_session_id = ${row.id}
           AND descendant.id != ${row.id}
+          AND descendant.status NOT IN ('stopped', 'expired', 'failed')
       )
     `).where(sql<boolean>`
       ${archive ? 1 : 0} = 1

--- a/src/index.ts
+++ b/src/index.ts
@@ -1045,6 +1045,7 @@ const runtimeAdapterReconcileIntervalMs = 15_000;
 const runtimeAdapterReconcileLimit = 3;
 const runtimeAdapterReconcileConcurrency = 3;
 const runtimeAdapterReconcileForegroundBudgetMs = 750;
+const openClawPreparationTimeoutMs = 60_000;
 const interactiveSessionPreparationStaleMs = 5 * 60_000;
 const terminalCleanupDeletePending = 2;
 const credentialPolicyCleanupLimit = 8;
@@ -3247,9 +3248,13 @@ async function openClawCreateCrabbox(
       owner,
       createdBy: "service:openclaw",
       afterReserve: async () => {
+        const signal = AbortSignal.timeout(openClawPreparationTimeoutMs);
         try {
-          await ensureOpenClawServiceBranch(env, body.repo, body.branch, body.baseBranch);
+          await ensureOpenClawServiceBranch(env, body.repo, body.branch, body.baseBranch, signal);
         } catch (error) {
+          if (signal.aborted) {
+            throw serviceUnavailable("OpenClaw branch preparation timed out");
+          }
           if (
             !(error instanceof GitHubApiError) ||
             !openClawBranchPreparationCanDefer(error.status)
@@ -3515,25 +3520,25 @@ async function enforceOpenClawRoomSessionLimitAfterInsert(
   insertedAt: number,
 ): Promise<void> {
   const db = database(env);
-  const count = await db
-    .selectFrom("interactive_sessions")
-    .select(({ fn }) => fn.countAll<number>().as("count"))
-    .where((expression) =>
-      expression.or([
-        expression("root_session_id", "=", rootSessionId),
-        expression("id", "=", rootSessionId),
-      ]),
-    )
-    .where((expression) =>
-      expression.or([
-        expression("created_by", "=", "service:openclaw"),
-        expression("created_by", "like", "session:%"),
-      ]),
-    )
-    .where("runtime", "!=", "github_actions")
-    .where("work_key", "is", null)
-    .executeTakeFirst();
-  if (Number(count?.count ?? 0) <= openClawRoomMaxSessions) return;
+  const admission = await sql<{ inserted_rowid: number; position: number }>`
+    SELECT inserted.rowid AS inserted_rowid, count(candidate.rowid) AS position
+    FROM interactive_sessions AS inserted
+    JOIN interactive_sessions AS candidate
+      ON candidate.rowid <= inserted.rowid
+      AND (candidate.root_session_id = ${rootSessionId} OR candidate.id = ${rootSessionId})
+      AND (candidate.created_by = 'service:openclaw' OR candidate.created_by LIKE 'session:%')
+      AND candidate.runtime != 'github_actions'
+      AND candidate.work_key IS NULL
+    WHERE inserted.id = ${insertedSessionId}
+      AND inserted.status = 'provisioning'
+      AND inserted.preparation_pending = 1
+      AND inserted.created_at = ${insertedAt}
+      AND inserted.updated_at = ${insertedAt}
+    GROUP BY inserted.rowid
+  `.execute(db);
+  const position = Number(admission.rows[0]?.position ?? 0);
+  if (position > 0 && position <= openClawRoomMaxSessions) return;
+  if (!position) throw serviceUnavailable("session root reservation disappeared");
   await rollbackInteractiveSessionReservation(env, insertedSessionId, insertedAt);
   throw tooManyRequests("session root reached the supervision limit");
 }
@@ -3878,6 +3883,7 @@ async function ensureOpenClawServiceBranch(
   repoInput: unknown,
   branchInput: unknown,
   baseBranchInput: unknown,
+  signal?: AbortSignal,
 ): Promise<void> {
   const repo = normalizeRepo(repoInput);
   if (!repo) throw badRequest("repo is required");
@@ -3890,7 +3896,7 @@ async function ensureOpenClawServiceBranch(
   const [owner, name] = repo.split("/");
   const refPath = `/repos/${owner}/${name}/git/ref/heads/${encodeURIComponent(branch)}`;
   try {
-    await githubFetch<{ object: { sha: string } }>(refPath, env.GITHUB_TOKEN);
+    await githubFetch<{ object: { sha: string } }>(refPath, env.GITHUB_TOKEN, signal);
     return;
   } catch (error) {
     if (!(error instanceof GitHubApiError) || error.status !== 404) throw error;
@@ -3898,15 +3904,17 @@ async function ensureOpenClawServiceBranch(
   const base = await githubFetch<{ object: { sha: string } }>(
     `/repos/${owner}/${name}/git/ref/heads/${encodeURIComponent(baseBranch)}`,
     env.GITHUB_TOKEN,
+    signal,
   );
   const response = await fetch(`https://api.github.com/repos/${owner}/${name}/git/refs`, {
     method: "POST",
     body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: base.object.sha }),
     headers: { ...githubHeaders(), authorization: `Bearer ${env.GITHUB_TOKEN}` },
+    ...(signal ? { signal } : {}),
   });
   if (response.ok) return;
   if (response.status === 422) {
-    await githubFetch<{ object: { sha: string } }>(refPath, env.GITHUB_TOKEN);
+    await githubFetch<{ object: { sha: string } }>(refPath, env.GITHUB_TOKEN, signal);
     return;
   }
   throw new GitHubApiError(response.status);
@@ -15140,12 +15148,13 @@ function eventInsert(
     .values({ card_id: cardId, actor: actorName, message, created_at: now });
 }
 
-async function githubFetch<T>(path: string, token: string): Promise<T> {
+async function githubFetch<T>(path: string, token: string, signal?: AbortSignal): Promise<T> {
   const response = await fetch(`https://api.github.com${path}`, {
     headers: {
       ...githubHeaders(),
       authorization: `Bearer ${token}`,
     },
+    ...(signal ? { signal } : {}),
   });
   if (!response.ok) throw new GitHubApiError(response.status);
   return response.json<T>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -3236,30 +3236,35 @@ async function openClawCreateCrabbox(
   }>(request);
   const owner = openClawOwner(body.owner);
   const serviceUser = openClawServiceUser();
-  try {
-    await ensureOpenClawServiceBranch(env, body.repo, body.branch, body.baseBranch);
-  } catch (error) {
-    if (
-      !(error instanceof GitHubApiError) ||
-      !openClawBranchPreparationCanDefer(error.status)
-    ) {
-      throw error;
-    }
-    console.warn(
-      JSON.stringify({
-        event: "openclaw_branch_preparation_deferred",
-        repo: normalizeRepo(body.repo),
-        branch: clean(body.branch, 120) || "main",
-        status: error.status,
-      }),
-    );
-  }
   const result = await createInteractiveSessionFromInput(
     env,
     serviceUser,
     body,
     clean(body.githubToken, 4000) || undefined,
-    { owner, createdBy: "service:openclaw" },
+    {
+      owner,
+      createdBy: "service:openclaw",
+      beforeCreate: async () => {
+        try {
+          await ensureOpenClawServiceBranch(env, body.repo, body.branch, body.baseBranch);
+        } catch (error) {
+          if (
+            !(error instanceof GitHubApiError) ||
+            !openClawBranchPreparationCanDefer(error.status)
+          ) {
+            throw error;
+          }
+          console.warn(
+            JSON.stringify({
+              event: "openclaw_branch_preparation_deferred",
+              repo: normalizeRepo(body.repo),
+              branch: clean(body.branch, 120) || "main",
+              status: error.status,
+            }),
+          );
+        }
+      },
+    },
   );
   await audit(
     env,
@@ -3660,7 +3665,8 @@ async function ensureOpenClawServiceBranch(
   if (!repo) throw badRequest("repo is required");
   await requireRepo(env, repo);
   const branch = clean(branchInput, 120) || "main";
-  const baseBranch = clean(baseBranchInput, 120) || "main";
+  const baseBranch = clean(baseBranchInput, 120);
+  if (!baseBranch) return;
   if (branch === baseBranch) return;
   if (!env.GITHUB_TOKEN) return;
   const [owner, name] = repo.split("/");
@@ -4432,6 +4438,7 @@ async function createInteractiveSessionFromInput(
     owner?: string;
     parentSessionId?: string | null;
     rootSessionId?: string | null;
+    beforeCreate?: () => Promise<void>;
   } = {},
 ): Promise<{ session: InteractiveSession }> {
   const repo = normalizeRepo(body.repo);
@@ -4460,6 +4467,7 @@ async function createInteractiveSessionFromInput(
     options.parentSessionId ?? (clean(body.parentSessionId, 120) || null),
     options.rootSessionId ?? (clean(body.rootSessionId, 120) || null),
   );
+  await options.beforeCreate?.();
   const now = Date.now();
   const db = database(env);
   for (let attempt = 0; attempt < 3; attempt += 1) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3513,7 +3513,7 @@ async function openClawSupervisedRootForCreate(
       return lineage.rootSessionId;
     }
   }
-  if (openClawRoomRootAllowed(root)) {
+  if (createdBy === "service:openclaw" || openClawRoomRootAllowed(root)) {
     throw badRequest("invalid OpenClaw room lineage");
   }
   return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,11 @@ import { sizedTerminalTargetUrl } from "./terminal-target";
 import { cachedBooleanGrant } from "./terminal-authorization";
 import { obsoleteSessionArchiveObjectKeys, sessionArchiveAttemptKeys } from "./session-archive";
 import { readBoundedResponseText } from "./bounded-response";
-import { boundedUtf8Tail, sessionBelongsToRoot } from "./openclaw-service";
+import {
+  boundedUtf8Tail,
+  openClawServiceAuthorized,
+  sessionBelongsToRoot,
+} from "./openclaw-service";
 import {
   inspectTrustedProxyAssertion,
   sanitizeTrustedProxyRequest,
@@ -218,6 +222,7 @@ type RuntimeEnv = Env & {
   CRABBOX_SSH_GATEWAY_TOKEN?: string;
   CRABFLEET_SSH_GATEWAY_TOKEN?: string;
   CRABBOX_OPENCLAW_TOKEN?: string;
+  CRABBOX_MULTICODEX_TOKEN?: string;
   CRABBOX_TOKEN_ENCRYPTION_KEY?: string;
   BACKUP_BUCKET_NAME?: string;
   CLOUDFLARE_ACCOUNT_ID?: string;
@@ -3588,10 +3593,11 @@ function openClawServiceUser(): User {
 }
 
 function requireOpenClawService(request: Request, env: RuntimeEnv): void {
-  if (!env.CRABBOX_OPENCLAW_TOKEN) {
+  const tokens = [env.CRABBOX_OPENCLAW_TOKEN, env.CRABBOX_MULTICODEX_TOKEN];
+  if (!tokens.some(Boolean)) {
     throw serviceUnavailable("OpenClaw service token is not configured");
   }
-  if (request.headers.get("authorization") !== `Bearer ${env.CRABBOX_OPENCLAW_TOKEN}`) {
+  if (!openClawServiceAuthorized(request.headers.get("authorization"), tokens)) {
     throw unauthorized();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5177,10 +5177,11 @@ async function cleanupInteractiveSessions(
     `).where(sql<boolean>`
       NOT EXISTS (
         SELECT 1
-        FROM interactive_sessions AS descendant
-        WHERE descendant.root_session_id = interactive_sessions.id
-          AND descendant.id != interactive_sessions.id
-          AND descendant.status NOT IN ('stopped', 'expired', 'failed')
+        FROM interactive_sessions AS active_tree_session
+        WHERE COALESCE(active_tree_session.root_session_id, active_tree_session.id)
+            = COALESCE(interactive_sessions.root_session_id, interactive_sessions.id)
+          AND active_tree_session.id != interactive_sessions.id
+          AND active_tree_session.status NOT IN ('stopped', 'expired', 'failed')
       )
     `).where(sql<boolean>`
       ${env.SESSION_LOGS ? 1 : 0} = 0
@@ -5245,10 +5246,11 @@ async function deleteFinalizedInteractiveSession(
     `).where(sql<boolean>`
       NOT EXISTS (
         SELECT 1
-        FROM interactive_sessions AS descendant
-        WHERE descendant.root_session_id = ${row.id}
-          AND descendant.id != ${row.id}
-          AND descendant.status NOT IN ('stopped', 'expired', 'failed')
+        FROM interactive_sessions AS active_tree_session
+        WHERE COALESCE(active_tree_session.root_session_id, active_tree_session.id)
+            = ${row.root_session_id ?? row.id}
+          AND active_tree_session.id != ${row.id}
+          AND active_tree_session.status NOT IN ('stopped', 'expired', 'failed')
       )
     `).where(sql<boolean>`
       ${archive ? 1 : 0} = 1

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ import { obsoleteSessionArchiveObjectKeys, sessionArchiveAttemptKeys } from "./s
 import { readBoundedResponseText } from "./bounded-response";
 import {
   boundedUtf8Tail,
+  openClawBranchPreparationCanDefer,
   openClawServiceAuthorized,
   sessionBelongsToRoot,
 } from "./openclaw-service";
@@ -3233,7 +3234,24 @@ async function openClawCreateCrabbox(
   }>(request);
   const owner = openClawOwner(body.owner);
   const serviceUser = openClawServiceUser();
-  await ensureOpenClawServiceBranch(env, body.repo, body.branch, body.baseBranch);
+  try {
+    await ensureOpenClawServiceBranch(env, body.repo, body.branch, body.baseBranch);
+  } catch (error) {
+    if (
+      !(error instanceof GitHubApiError) ||
+      !openClawBranchPreparationCanDefer(error.status)
+    ) {
+      throw error;
+    }
+    console.warn(
+      JSON.stringify({
+        event: "openclaw_branch_preparation_deferred",
+        repo: normalizeRepo(body.repo),
+        branch: clean(body.branch, 120) || "main",
+        status: error.status,
+      }),
+    );
+  }
   const result = await createInteractiveSessionFromInput(
     env,
     serviceUser,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3338,16 +3338,18 @@ async function openClawReadCrabboxTranscript(
 }> {
   requireOpenClawRoomService(request, env);
   const session = await openClawRootScopedCrabbox(request, env, id);
-  const [events, eventCount] = await Promise.all([
-    readInteractiveSessionEventRows(env, id, { limit: 240, newest: true }),
+  const [eventWindow, eventCount] = await Promise.all([
+    readInteractiveSessionEventRows(env, id, { limit: 241, newest: true }),
     countInteractiveSessionEvents(env, id),
   ]);
+  const hasMoreEvents = eventWindow.length > 240;
+  const events = hasMoreEvents ? eventWindow.slice(1) : eventWindow;
   const transcript = boundedUtf8Tail(sessionLogTranscript(session, events));
   return {
     ...openClawCrabboxResponse(env, openClawServiceUser(), session),
     transcript: transcript.text,
     eventCount,
-    truncated: transcript.truncated || eventCount > events.length,
+    truncated: transcript.truncated || hasMoreEvents || eventCount > events.length,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ import { readBoundedResponseText } from "./bounded-response";
 import {
   boundedUtf8Tail,
   openClawBranchPreparationCanDefer,
+  openClawGitHubRepoParts,
   openClawRoomMaxSessions,
   openClawRoomRootAllowed,
   openClawRoomSessionChainAllowed,
@@ -3500,7 +3501,7 @@ async function openClawSupervisedRootForCreate(
     readInteractiveSession(env, lineage.parentSessionId),
     readInteractiveSession(env, lineage.rootSessionId),
   ]);
-  if (!parent || !root) return null;
+  if (!parent || !root) throw badRequest("session lineage not found");
   if (createdBy === "service:openclaw" || createdBy === `session:${lineage.parentSessionId}`) {
     const chain = await openClawReadSessionChain(env, parent, root, lineage.rootSessionId);
     if (openClawRoomSessionChainAllowed(chain, parent.id, lineage.rootSessionId)) {
@@ -3887,13 +3888,15 @@ async function ensureOpenClawServiceBranch(
 ): Promise<void> {
   const repo = normalizeRepo(repoInput);
   if (!repo) throw badRequest("repo is required");
+  const target = openClawGitHubRepoParts(repo);
+  if (!target) throw badRequest("repo must be a GitHub owner/name");
   await requireRepo(env, repo);
   const branch = clean(branchInput, 120) || "main";
   const baseBranch = clean(baseBranchInput, 120);
   if (!baseBranch) return;
   if (branch === baseBranch) return;
   if (!env.GITHUB_TOKEN) return;
-  const [owner, name] = repo.split("/");
+  const { owner, name } = target;
   const refPath = `/repos/${owner}/${name}/git/ref/heads/${encodeURIComponent(branch)}`;
   try {
     await githubFetch<{ object: { sha: string } }>(refPath, env.GITHUB_TOKEN, signal);
@@ -13649,6 +13652,7 @@ async function addRepo(
   const body = await readJson<{ repo?: string }>(request);
   const repo = normalizeRepo(body.repo);
   if (!repo) throw badRequest("repo is required");
+  if (!openClawGitHubRepoParts(repo)) throw badRequest("repo must be a GitHub owner/name");
   const now = Date.now();
   await database(env)
     .insertInto("repos")

--- a/src/index.ts
+++ b/src/index.ts
@@ -3345,8 +3345,10 @@ async function openClawReadCrabboxTranscript(
   const hasMoreEvents = eventWindow.length > 240;
   const events = hasMoreEvents ? eventWindow.slice(1) : eventWindow;
   const transcript = boundedUtf8Tail(sessionLogTranscript(session, events));
+  const response = openClawCrabboxResponse(env, openClawServiceUser(), session);
   return {
-    ...openClawCrabboxResponse(env, openClawServiceUser(), session),
+    ...response,
+    session: { ...response.session, logs: [] },
     transcript: transcript.text,
     eventCount,
     truncated: transcript.truncated || hasMoreEvents || eventCount > events.length,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5129,6 +5129,13 @@ async function cleanupInteractiveSessions(
           AND archive.session_updated_at = interactive_sessions.updated_at
       )
     `).where(sql<boolean>`
+      NOT EXISTS (
+        SELECT 1
+        FROM interactive_sessions AS descendant
+        WHERE descendant.root_session_id = interactive_sessions.id
+          AND descendant.id != interactive_sessions.id
+      )
+    `).where(sql<boolean>`
       ${env.SESSION_LOGS ? 1 : 0} = 0
       OR EXISTS (
         SELECT 1
@@ -5187,6 +5194,13 @@ async function deleteFinalizedInteractiveSession(
         SELECT 1
         FROM interactive_session_credential_policies
         WHERE session_id = ${row.id}
+      )
+    `).where(sql<boolean>`
+      NOT EXISTS (
+        SELECT 1
+        FROM interactive_sessions AS descendant
+        WHERE descendant.root_session_id = ${row.id}
+          AND descendant.id != ${row.id}
       )
     `).where(sql<boolean>`
       ${archive ? 1 : 0} = 1

--- a/src/index.ts
+++ b/src/index.ts
@@ -3272,7 +3272,7 @@ async function openClawCreateCrabbox(
     `openclaw crabbox created ${result.session.id} owner=${owner}`,
     Date.now(),
   );
-  return openClawCrabboxResponse(env, serviceUser, result.session);
+  return openClawDecoratedCrabboxResponse(env, result.session);
 }
 
 async function openClawReadSessionRoot(
@@ -3437,8 +3437,18 @@ function openClawCrabboxResponse(
   serviceUser: User,
   session: InteractiveSession,
 ): { session: InteractiveSession; browserUrl: string } {
+  return openClawDecoratedCrabboxResponse(
+    env,
+    decorateInteractiveSession(session, serviceUser, env),
+  );
+}
+
+function openClawDecoratedCrabboxResponse(
+  env: RuntimeEnv,
+  session: InteractiveSession,
+): { session: InteractiveSession; browserUrl: string } {
   return {
-    session: decorateInteractiveSession(session, serviceUser, env),
+    session,
     browserUrl: `${browserAppOrigin(env)}/app/sessions/${encodeURIComponent(session.id)}`,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3483,6 +3483,68 @@ async function openClawReadSessionChain(
   return [...chain.values()];
 }
 
+async function openClawSupervisedRootForCreate(
+  env: RuntimeEnv,
+  createdBy: string,
+  lineage: { parentSessionId: string | null; rootSessionId: string | null },
+): Promise<string | null> {
+  if (!lineage.parentSessionId || !lineage.rootSessionId) return null;
+  if (createdBy !== "service:openclaw" && createdBy !== `session:${lineage.parentSessionId}`) {
+    return null;
+  }
+  const [parent, root] = await Promise.all([
+    readFreshInteractiveSession(env, lineage.parentSessionId),
+    readFreshInteractiveSession(env, lineage.rootSessionId),
+  ]);
+  if (!parent || !root) return null;
+  const chain = await openClawReadSessionChain(env, parent, root, lineage.rootSessionId);
+  return openClawRoomSessionChainAllowed(chain, parent.id, lineage.rootSessionId)
+    ? lineage.rootSessionId
+    : null;
+}
+
+async function enforceOpenClawRoomSessionLimitAfterInsert(
+  env: RuntimeEnv,
+  rootSessionId: string,
+  insertedSessionId: string,
+  insertedAt: number,
+): Promise<void> {
+  const db = database(env);
+  const count = await db
+    .selectFrom("interactive_sessions")
+    .select(({ fn }) => fn.countAll<number>().as("count"))
+    .where((expression) =>
+      expression.or([
+        expression("root_session_id", "=", rootSessionId),
+        expression("id", "=", rootSessionId),
+      ]),
+    )
+    .where((expression) =>
+      expression.or([
+        expression("created_by", "=", "service:openclaw"),
+        expression("created_by", "like", "session:%"),
+      ]),
+    )
+    .where("runtime", "!=", "github_actions")
+    .where("work_key", "is", null)
+    .executeTakeFirst();
+  if (Number(count?.count ?? 0) <= openClawRoomMaxSessions) return;
+  await db
+    .deleteFrom("interactive_sessions")
+    .where("id", "=", insertedSessionId)
+    .where("status", "=", "provisioning")
+    .where("created_at", "=", insertedAt)
+    .where("updated_at", "=", insertedAt)
+    .execute();
+  const current = await db
+    .selectFrom("interactive_sessions")
+    .select("id")
+    .where("id", "=", insertedSessionId)
+    .executeTakeFirst();
+  if (current) throw serviceUnavailable("session root capacity rollback failed");
+  throw tooManyRequests("session root reached the supervision limit");
+}
+
 function openClawCrabboxResponse(
   env: RuntimeEnv,
   serviceUser: User,
@@ -4538,6 +4600,7 @@ async function createInteractiveSessionFromInput(
     options.rootSessionId ?? (clean(body.rootSessionId, 120) || null),
   );
   await options.beforeCreate?.();
+  const supervisedRootSessionId = await openClawSupervisedRootForCreate(env, createdBy, lineage);
   const now = Date.now();
   const db = database(env);
   for (let attempt = 0; attempt < 3; attempt += 1) {
@@ -4653,6 +4716,14 @@ async function createInteractiveSessionFromInput(
           completion_reason: null,
         })
         .execute();
+      if (supervisedRootSessionId) {
+        await enforceOpenClawRoomSessionLimitAfterInsert(
+          env,
+          supervisedRootSessionId,
+          id,
+          now,
+        );
+      }
       await appendInteractiveSessionEvent(env, id, user, "interactive workspace requested", now);
       const provisioned = await provisionInteractiveSession(
         env,
@@ -5176,12 +5247,20 @@ async function cleanupInteractiveSessions(
       )
     `).where(sql<boolean>`
       NOT EXISTS (
+        WITH RECURSIVE active_ancestor(id) AS (
+          SELECT parent_session_id
+          FROM interactive_sessions
+          WHERE status NOT IN ('stopped', 'expired', 'failed')
+            AND parent_session_id IS NOT NULL
+          UNION
+          SELECT session.parent_session_id
+          FROM interactive_sessions AS session
+          JOIN active_ancestor ON session.id = active_ancestor.id
+          WHERE session.parent_session_id IS NOT NULL
+        )
         SELECT 1
-        FROM interactive_sessions AS active_tree_session
-        WHERE COALESCE(active_tree_session.root_session_id, active_tree_session.id)
-            = COALESCE(interactive_sessions.root_session_id, interactive_sessions.id)
-          AND active_tree_session.id != interactive_sessions.id
-          AND active_tree_session.status NOT IN ('stopped', 'expired', 'failed')
+        FROM active_ancestor
+        WHERE id = interactive_sessions.id
       )
     `).where(sql<boolean>`
       ${env.SESSION_LOGS ? 1 : 0} = 0
@@ -5245,12 +5324,20 @@ async function deleteFinalizedInteractiveSession(
       )
     `).where(sql<boolean>`
       NOT EXISTS (
+        WITH RECURSIVE active_ancestor(id) AS (
+          SELECT parent_session_id
+          FROM interactive_sessions
+          WHERE status NOT IN ('stopped', 'expired', 'failed')
+            AND parent_session_id IS NOT NULL
+          UNION
+          SELECT session.parent_session_id
+          FROM interactive_sessions AS session
+          JOIN active_ancestor ON session.id = active_ancestor.id
+          WHERE session.parent_session_id IS NOT NULL
+        )
         SELECT 1
-        FROM interactive_sessions AS active_tree_session
-        WHERE COALESCE(active_tree_session.root_session_id, active_tree_session.id)
-            = ${row.root_session_id ?? row.id}
-          AND active_tree_session.id != ${row.id}
-          AND active_tree_session.status NOT IN ('stopped', 'expired', 'failed')
+        FROM active_ancestor
+        WHERE id = ${row.id}
       )
     `).where(sql<boolean>`
       ${archive ? 1 : 0} = 1

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,7 @@ import { sizedTerminalTargetUrl } from "./terminal-target";
 import { cachedBooleanGrant } from "./terminal-authorization";
 import { obsoleteSessionArchiveObjectKeys, sessionArchiveAttemptKeys } from "./session-archive";
 import { readBoundedResponseText } from "./bounded-response";
+import { boundedUtf8Tail, sessionBelongsToRoot } from "./openclaw-service";
 import {
   inspectTrustedProxyAssertion,
   sanitizeTrustedProxyRequest,
@@ -2270,6 +2271,67 @@ async function api(
     return json(await openClawCreateCrabbox(request, env), { status: 201 });
   }
 
+  const openClawSessionRootMatch = url.pathname.match(/^\/api\/openclaw\/session-roots\/([^/]+)$/);
+  if (request.method === "GET" && openClawSessionRootMatch) {
+    return json(
+      await openClawReadSessionRoot(
+        request,
+        env,
+        decodeURIComponent(openClawSessionRootMatch[1] ?? ""),
+      ),
+    );
+  }
+
+  const openClawCrabboxTranscriptMatch = url.pathname.match(
+    /^\/api\/openclaw\/crabboxes\/([^/]+)\/transcript$/,
+  );
+  if (request.method === "GET" && openClawCrabboxTranscriptMatch) {
+    return json(
+      await openClawReadCrabboxTranscript(
+        request,
+        env,
+        decodeURIComponent(openClawCrabboxTranscriptMatch[1] ?? ""),
+      ),
+    );
+  }
+
+  const openClawCrabboxMessageMatch = url.pathname.match(
+    /^\/api\/openclaw\/crabboxes\/([^/]+)\/message$/,
+  );
+  if (request.method === "POST" && openClawCrabboxMessageMatch) {
+    return json(
+      await openClawMessageCrabbox(
+        request,
+        env,
+        decodeURIComponent(openClawCrabboxMessageMatch[1] ?? ""),
+      ),
+    );
+  }
+
+  const openClawCrabboxActionMatch = url.pathname.match(
+    /^\/api\/openclaw\/crabboxes\/([^/]+)\/actions$/,
+  );
+  if (request.method === "POST" && openClawCrabboxActionMatch) {
+    return json(
+      await openClawMutateCrabbox(
+        request,
+        env,
+        decodeURIComponent(openClawCrabboxActionMatch[1] ?? ""),
+      ),
+    );
+  }
+
+  const openClawCrabboxReadMatch = url.pathname.match(/^\/api\/openclaw\/crabboxes\/([^/]+)$/);
+  if (request.method === "GET" && openClawCrabboxReadMatch) {
+    return json(
+      await openClawReadCrabbox(
+        request,
+        env,
+        decodeURIComponent(openClawCrabboxReadMatch[1] ?? ""),
+      ),
+    );
+  }
+
   const sshInteractivePtyMatch = url.pathname.match(
     /^\/api\/ssh\/interactive-sessions\/([^/]+)\/pty$/,
   );
@@ -3147,7 +3209,7 @@ async function agentCreateInteractiveSession(
 async function openClawCreateCrabbox(
   request: Request,
   env: RuntimeEnv,
-): Promise<{ session: InteractiveSession }> {
+): Promise<{ session: InteractiveSession; browserUrl: string }> {
   requireOpenClawService(request, env);
   const body = await readJson<{
     repo?: string;
@@ -3178,7 +3240,159 @@ async function openClawCreateCrabbox(
     `openclaw crabbox created ${result.session.id} owner=${owner}`,
     Date.now(),
   );
-  return result;
+  return openClawCrabboxResponse(env, serviceUser, result.session);
+}
+
+async function openClawReadSessionRoot(
+  request: Request,
+  env: RuntimeEnv,
+  rootSessionId: string,
+): Promise<{
+  rootSessionId: string;
+  crabboxes: Array<{ session: InteractiveSession; browserUrl: string }>;
+}> {
+  requireOpenClawService(request, env);
+  const root = clean(rootSessionId, 120);
+  if (!root) throw badRequest("root session id is required");
+  const rows = await database(env)
+    .selectFrom("interactive_sessions")
+    .select("id")
+    .where((expression) =>
+      expression.or([expression("root_session_id", "=", root), expression("id", "=", root)]),
+    )
+    .orderBy("created_at", "asc")
+    .execute();
+  if (!rows.length) throw notFound("session root not found");
+  const serviceUser = openClawServiceUser();
+  const sessions = await Promise.all(rows.map((row) => readFreshInteractiveSession(env, row.id)));
+  return {
+    rootSessionId: root,
+    crabboxes: sessions
+      .filter((session): session is InteractiveSession => Boolean(session))
+      .map((session) => openClawCrabboxResponse(env, serviceUser, session)),
+  };
+}
+
+async function openClawReadCrabbox(
+  request: Request,
+  env: RuntimeEnv,
+  id: string,
+): Promise<{ session: InteractiveSession; browserUrl: string }> {
+  requireOpenClawService(request, env);
+  const session = await openClawRootScopedCrabbox(request, env, id);
+  return openClawCrabboxResponse(env, openClawServiceUser(), session);
+}
+
+async function openClawReadCrabboxTranscript(
+  request: Request,
+  env: RuntimeEnv,
+  id: string,
+): Promise<{
+  session: InteractiveSession;
+  browserUrl: string;
+  transcript: string;
+  eventCount: number;
+  truncated: boolean;
+}> {
+  requireOpenClawService(request, env);
+  const session = await openClawRootScopedCrabbox(request, env, id);
+  const [events, eventCount] = await Promise.all([
+    readInteractiveSessionEventRows(env, id, { limit: 240, newest: true }),
+    countInteractiveSessionEvents(env, id),
+  ]);
+  const transcript = boundedUtf8Tail(sessionLogTranscript(session, events));
+  return {
+    ...openClawCrabboxResponse(env, openClawServiceUser(), session),
+    transcript: transcript.text,
+    eventCount,
+    truncated: transcript.truncated || eventCount > events.length,
+  };
+}
+
+async function openClawMessageCrabbox(
+  request: Request,
+  env: RuntimeEnv,
+  id: string,
+): Promise<{ delivered: true; session: InteractiveSession; browserUrl: string }> {
+  requireOpenClawService(request, env);
+  const body = await readJson<{ rootSessionId?: string; message?: string; enter?: boolean }>(request);
+  const session = await openClawRootScopedCrabbox(request, env, id, body.rootSessionId);
+  if (["stopping", "stopped", "expired", "failed"].includes(session.status)) {
+    throw badRequest(`session is ${session.status}`);
+  }
+  if (!session.capabilities.terminal) {
+    throw badRequest("session does not advertise terminal access");
+  }
+  const message = clean(body.message, 4000);
+  if (!message) throw badRequest("message is required");
+  const serviceUser = openClawServiceUser();
+  const terminalRequest = new Request(request.url, { headers: { upgrade: "websocket" } });
+  const upstream = await openInteractiveTerminalUpstream(
+    terminalRequest,
+    env,
+    serviceUser,
+    session,
+    120,
+    34,
+  );
+  await upstream.markConnected();
+  upstream.socket.send(encoder.encode(`${message}${body.enter === false ? "" : "\r"}`));
+  upstream.socket.close(1000, "OpenClaw service nudge sent");
+  const now = Date.now();
+  await appendInteractiveSessionEvent(env, id, serviceUser, "OpenClaw service nudge sent", now);
+  await audit(env, serviceUser, `openclaw crabbox message sent ${id}`, now);
+  return {
+    delivered: true,
+    ...openClawCrabboxResponse(
+      env,
+      serviceUser,
+      (await readInteractiveSession(env, id)) as InteractiveSession,
+    ),
+  };
+}
+
+async function openClawMutateCrabbox(
+  request: Request,
+  env: RuntimeEnv,
+  id: string,
+): Promise<{ session: InteractiveSession; browserUrl: string }> {
+  requireOpenClawService(request, env);
+  const body = await readJson<{ rootSessionId?: string; action?: string }>(request);
+  await openClawRootScopedCrabbox(request, env, id, body.rootSessionId);
+  if (body.action !== "stop") throw badRequest("only stop is supported");
+  const serviceUser = openClawServiceUser();
+  const result = await mutateInteractiveSession(request, env, serviceUser, id, body.action);
+  await audit(env, serviceUser, `openclaw crabbox stop requested ${id}`, Date.now());
+  return openClawCrabboxResponse(env, serviceUser, result.session);
+}
+
+async function openClawRootScopedCrabbox(
+  request: Request,
+  env: RuntimeEnv,
+  id: string,
+  bodyRootSessionId?: string,
+): Promise<InteractiveSession> {
+  const rootSessionId = clean(
+    bodyRootSessionId ?? request.headers.get("x-crabfleet-root-session-id"),
+    120,
+  );
+  if (!rootSessionId) throw badRequest("root session id is required");
+  const session = await readFreshInteractiveSession(env, id);
+  if (!session || !sessionBelongsToRoot(session.id, session.rootSessionId, rootSessionId)) {
+    throw notFound("interactive session not found");
+  }
+  return session;
+}
+
+function openClawCrabboxResponse(
+  env: RuntimeEnv,
+  serviceUser: User,
+  session: InteractiveSession,
+): { session: InteractiveSession; browserUrl: string } {
+  return {
+    session: decorateInteractiveSession(session, serviceUser, env),
+    browserUrl: `${browserAppOrigin(env)}/app/sessions/${encodeURIComponent(session.id)}`,
+  };
 }
 
 async function openClawRegisterActionSession(

--- a/src/index.ts
+++ b/src/index.ts
@@ -3229,9 +3229,11 @@ async function openClawCreateCrabbox(
     purpose?: string;
     summary?: string;
     githubToken?: string;
+    baseBranch?: string;
   }>(request);
   const owner = openClawOwner(body.owner);
   const serviceUser = openClawServiceUser();
+  await ensureOpenClawServiceBranch(env, body.repo, body.branch, body.baseBranch);
   const result = await createInteractiveSessionFromInput(
     env,
     serviceUser,
@@ -3600,6 +3602,46 @@ function requireOpenClawService(request: Request, env: RuntimeEnv): void {
   if (!openClawServiceAuthorized(request.headers.get("authorization"), tokens)) {
     throw unauthorized();
   }
+}
+
+async function ensureOpenClawServiceBranch(
+  env: RuntimeEnv,
+  repoInput: unknown,
+  branchInput: unknown,
+  baseBranchInput: unknown,
+): Promise<void> {
+  const repo = normalizeRepo(repoInput);
+  if (!repo) throw badRequest("repo is required");
+  await requireRepo(env, repo);
+  const branch = clean(branchInput, 120) || "main";
+  const baseBranch = clean(baseBranchInput, 120) || "main";
+  if (branch === baseBranch) return;
+  if (!env.GITHUB_TOKEN) {
+    throw serviceUnavailable("GitHub token is not configured for service branch creation");
+  }
+  const [owner, name] = repo.split("/");
+  const refPath = `/repos/${owner}/${name}/git/ref/heads/${encodeURIComponent(branch)}`;
+  try {
+    await githubFetch<{ object: { sha: string } }>(refPath, env.GITHUB_TOKEN);
+    return;
+  } catch (error) {
+    if (!(error instanceof GitHubApiError) || error.status !== 404) throw error;
+  }
+  const base = await githubFetch<{ object: { sha: string } }>(
+    `/repos/${owner}/${name}/git/ref/heads/${encodeURIComponent(baseBranch)}`,
+    env.GITHUB_TOKEN,
+  );
+  const response = await fetch(`https://api.github.com/repos/${owner}/${name}/git/refs`, {
+    method: "POST",
+    body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: base.object.sha }),
+    headers: { ...githubHeaders(), authorization: `Bearer ${env.GITHUB_TOKEN}` },
+  });
+  if (response.ok) return;
+  if (response.status === 422) {
+    await githubFetch<{ object: { sha: string } }>(refPath, env.GITHUB_TOKEN);
+    return;
+  }
+  throw new GitHubApiError(response.status);
 }
 
 function actionWorkIdentifier(value: unknown, name: string, max: number): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,9 +137,8 @@ import {
   openClawBranchPreparationCanDefer,
   openClawRoomMaxSessions,
   openClawRoomRootAllowed,
-  openClawRoomSessionAllowed,
+  openClawRoomSessionChainAllowed,
   openClawServiceAuthorized,
-  sessionBelongsToRoot,
 } from "./openclaw-service";
 import {
   inspectTrustedProxyAssertion,
@@ -3321,16 +3320,13 @@ async function openClawReadSessionRoot(
       sessions[index] = await readFreshInteractiveSession(env, row.id);
     },
   );
+  const validSessions = sessions.filter(
+    (session): session is InteractiveSession => Boolean(session),
+  );
   return {
     rootSessionId: root,
-    crabboxes: sessions
-      .filter((session): session is InteractiveSession => {
-        if (!session) return false;
-        return (
-          openClawRoomSessionAllowed(session) &&
-          sessionBelongsToRoot(session.id, session.rootSessionId, root)
-        );
-      })
+    crabboxes: validSessions
+      .filter((session) => openClawRoomSessionChainAllowed(validSessions, session.id, root))
       .map((session) => openClawCrabboxSummaryResponse(env, serviceUser, session)),
   };
 }
@@ -3456,16 +3452,35 @@ async function openClawRootScopedCrabbox(
   if (!rootSessionId) throw badRequest("root session id is required");
   const session = await readFreshInteractiveSession(env, id);
   const root = await readFreshInteractiveSession(env, rootSessionId);
+  const chain =
+    session && root ? await openClawReadSessionChain(env, session, root, rootSessionId) : [];
   if (
     !session ||
     !root ||
-    !openClawRoomRootAllowed(root) ||
-    !openClawRoomSessionAllowed(session) ||
-    !sessionBelongsToRoot(session.id, session.rootSessionId, rootSessionId)
+    !openClawRoomSessionChainAllowed(chain, session.id, rootSessionId)
   ) {
     throw notFound("interactive session not found");
   }
   return session;
+}
+
+async function openClawReadSessionChain(
+  env: RuntimeEnv,
+  session: InteractiveSession,
+  root: InteractiveSession,
+  rootSessionId: string,
+): Promise<InteractiveSession[]> {
+  const chain = new Map<string, InteractiveSession>([[root.id, root]]);
+  let current = session;
+  for (let depth = 0; depth < openClawRoomMaxSessions && !chain.has(current.id); depth += 1) {
+    chain.set(current.id, current);
+    if (current.id === rootSessionId || !current.parentSessionId) break;
+    if (chain.has(current.parentSessionId)) break;
+    const parent = await readFreshInteractiveSession(env, current.parentSessionId);
+    if (!parent) break;
+    current = parent;
+  }
+  return [...chain.values()];
 }
 
 function openClawCrabboxResponse(
@@ -5082,7 +5097,10 @@ async function resolveInteractiveSessionLineage(
 ): Promise<{ parentSessionId: string | null; rootSessionId: string | null }> {
   const parentId = clean(parentSessionId, 120) || null;
   const rootId = clean(rootSessionId, 120) || null;
-  if (!parentId) return { parentSessionId: null, rootSessionId: rootId };
+  if (!parentId) {
+    if (rootId) throw badRequest("root session id requires a parent session id");
+    return { parentSessionId: null, rootSessionId: null };
+  }
 
   const parent = await readInteractiveSession(env, parentId);
   if (!parent) throw badRequest("parent session not found");

--- a/src/index.ts
+++ b/src/index.ts
@@ -4689,7 +4689,7 @@ async function createInteractiveSessionFromInput(
     options.rootSessionId ?? (clean(body.rootSessionId, 120) || null),
   );
   const supervisedRootSessionId = await openClawSupervisedRootForCreate(env, createdBy, lineage);
-  const sideEffectReservation = Boolean(options.afterReserve);
+  const preparationReservation = Boolean(options.afterReserve || supervisedRootSessionId);
   const now = Date.now();
   const db = database(env);
   for (let attempt = 0; attempt < 3; attempt += 1) {
@@ -4751,16 +4751,16 @@ async function createInteractiveSessionFromInput(
           repo,
           branch,
           runtime,
-          adapter: adapterWorkspaceId && !sideEffectReservation ? runtimeAdapterName : null,
+          adapter: adapterWorkspaceId && !preparationReservation ? runtimeAdapterName : null,
           profile,
           adapter_workspace_id: adapterWorkspaceId,
           adapter_control_plane: adapterControlPlane,
           provider_resource_id: null,
           capabilities_json: JSON.stringify(requestedCapabilities),
           expires_at: null,
-          last_reconciled_at: adapterWorkspaceId && !sideEffectReservation ? now : null,
+          last_reconciled_at: adapterWorkspaceId && !preparationReservation ? now : null,
           reconcile_error:
-            adapterWorkspaceId && !sideEffectReservation ? "runtime adapter create pending" : null,
+            adapterWorkspaceId && !preparationReservation ? "runtime adapter create pending" : null,
           terminal_status: null,
           adapter_ttl_seconds: adapterSettings?.ttlSeconds ?? null,
           adapter_idle_timeout_seconds: adapterSettings?.idleTimeoutSeconds ?? null,
@@ -4768,8 +4768,8 @@ async function createInteractiveSessionFromInput(
             ? JSON.stringify(adapterSettings.capabilities)
             : null,
           adapter_create_payload_json: adapterCreatePayloadJson,
-          adapter_create_pending: adapterWorkspaceId && !sideEffectReservation ? 1 : 0,
-          preparation_pending: sideEffectReservation ? 1 : 0,
+          adapter_create_pending: adapterWorkspaceId && !preparationReservation ? 1 : 0,
+          preparation_pending: preparationReservation ? 1 : 0,
           command,
           prompt,
           purpose,
@@ -4821,7 +4821,7 @@ async function createInteractiveSessionFromInput(
         await rollbackInteractiveSessionReservation(env, id, now);
         throw error;
       }
-      if (sideEffectReservation) {
+      if (preparationReservation) {
         await activateInteractiveSessionReservation(env, id, now, adapterWorkspaceId);
       }
       await appendInteractiveSessionEvent(env, id, user, "interactive workspace requested", now);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3244,7 +3244,7 @@ async function openClawCreateCrabbox(
     {
       owner,
       createdBy: "service:openclaw",
-      beforeCreate: async () => {
+      afterReserve: async () => {
         try {
           await ensureOpenClawServiceBranch(env, body.repo, body.branch, body.baseBranch);
         } catch (error) {
@@ -3529,6 +3529,16 @@ async function enforceOpenClawRoomSessionLimitAfterInsert(
     .where("work_key", "is", null)
     .executeTakeFirst();
   if (Number(count?.count ?? 0) <= openClawRoomMaxSessions) return;
+  await rollbackInteractiveSessionReservation(env, insertedSessionId, insertedAt);
+  throw tooManyRequests("session root reached the supervision limit");
+}
+
+async function rollbackInteractiveSessionReservation(
+  env: RuntimeEnv,
+  insertedSessionId: string,
+  insertedAt: number,
+): Promise<void> {
+  const db = database(env);
   await db
     .deleteFrom("interactive_sessions")
     .where("id", "=", insertedSessionId)
@@ -3541,8 +3551,7 @@ async function enforceOpenClawRoomSessionLimitAfterInsert(
     .select("id")
     .where("id", "=", insertedSessionId)
     .executeTakeFirst();
-  if (current) throw serviceUnavailable("session root capacity rollback failed");
-  throw tooManyRequests("session root reached the supervision limit");
+  if (current) throw serviceUnavailable("interactive session reservation rollback failed");
 }
 
 function openClawCrabboxResponse(
@@ -4570,7 +4579,7 @@ async function createInteractiveSessionFromInput(
     owner?: string;
     parentSessionId?: string | null;
     rootSessionId?: string | null;
-    beforeCreate?: () => Promise<void>;
+    afterReserve?: () => Promise<void>;
   } = {},
 ): Promise<{ session: InteractiveSession }> {
   const repo = normalizeRepo(body.repo);
@@ -4599,7 +4608,6 @@ async function createInteractiveSessionFromInput(
     options.parentSessionId ?? (clean(body.parentSessionId, 120) || null),
     options.rootSessionId ?? (clean(body.rootSessionId, 120) || null),
   );
-  await options.beforeCreate?.();
   const supervisedRootSessionId = await openClawSupervisedRootForCreate(env, createdBy, lineage);
   const now = Date.now();
   const db = database(env);
@@ -4723,6 +4731,12 @@ async function createInteractiveSessionFromInput(
           id,
           now,
         );
+      }
+      try {
+        await options.afterReserve?.();
+      } catch (error) {
+        await rollbackInteractiveSessionReservation(env, id, now);
+        throw error;
       }
       await appendInteractiveSessionEvent(env, id, user, "interactive workspace requested", now);
       const provisioned = await provisionInteractiveSession(

--- a/src/index.ts
+++ b/src/index.ts
@@ -3297,7 +3297,12 @@ async function openClawReadSessionRoot(
     .where((expression) =>
       expression.or([expression("root_session_id", "=", root), expression("id", "=", root)]),
     )
-    .where("created_by", "=", "service:openclaw")
+    .where((expression) =>
+      expression.or([
+        expression("created_by", "=", "service:openclaw"),
+        expression("created_by", "like", "session:%"),
+      ]),
+    )
     .where("runtime", "!=", "github_actions")
     .where("work_key", "is", null)
     .orderBy("created_at", "asc")

--- a/src/index.ts
+++ b/src/index.ts
@@ -3288,13 +3288,20 @@ async function openClawReadSessionRoot(
   requireOpenClawRoomService(request, env);
   const root = clean(rootSessionId, 120);
   if (!root) throw badRequest("root session id is required");
-  const rootSession = await readFreshInteractiveSession(env, root);
+  const db = database(env);
+  const rootRow = await db
+    .selectFrom("interactive_sessions")
+    .selectAll()
+    .where("id", "=", root)
+    .where("preparation_pending", "=", 0)
+    .executeTakeFirst();
+  const rootSession = rootRow ? interactiveSession(rootRow, []) : null;
   if (!rootSession || !openClawRoomRootAllowed(rootSession)) {
     throw notFound("session root not found");
   }
-  const rows = await database(env)
+  const rows = await db
     .selectFrom("interactive_sessions")
-    .select("id")
+    .selectAll()
     .where((expression) =>
       expression.or([expression("root_session_id", "=", root), expression("id", "=", root)]),
     )
@@ -3315,21 +3322,11 @@ async function openClawReadSessionRoot(
     throw serviceUnavailable("session root exceeds the supervision limit");
   }
   const serviceUser = openClawServiceUser();
-  const sessions: Array<InteractiveSession | null> = Array.from({ length: rows.length }, () => null);
-  await mapWithConcurrency(
-    rows.map((row, index) => ({ row, index })),
-    4,
-    async ({ row, index }) => {
-      sessions[index] = await readFreshInteractiveSession(env, row.id);
-    },
-  );
-  const validSessions = sessions.filter(
-    (session): session is InteractiveSession => Boolean(session),
-  );
+  const sessions = rows.map((row) => interactiveSession(row, []));
   return {
     rootSessionId: root,
-    crabboxes: validSessions
-      .filter((session) => openClawRoomSessionChainAllowed(validSessions, session.id, root))
+    crabboxes: sessions
+      .filter((session) => openClawRoomSessionChainAllowed(sessions, session.id, root))
       .map((session) => openClawCrabboxSummaryResponse(env, serviceUser, session)),
   };
 }
@@ -3453,8 +3450,8 @@ async function openClawRootScopedCrabbox(
     120,
   );
   if (!rootSessionId) throw badRequest("root session id is required");
-  const session = await readFreshInteractiveSession(env, id);
-  const root = await readFreshInteractiveSession(env, rootSessionId);
+  const session = await readInteractiveSession(env, id);
+  const root = await readInteractiveSession(env, rootSessionId);
   const chain =
     session && root ? await openClawReadSessionChain(env, session, root, rootSessionId) : [];
   if (
@@ -3464,7 +3461,9 @@ async function openClawRootScopedCrabbox(
   ) {
     throw notFound("interactive session not found");
   }
-  return session;
+  const refreshed = await readFreshInteractiveSession(env, id);
+  if (!refreshed) throw notFound("interactive session not found");
+  return refreshed;
 }
 
 async function openClawReadSessionChain(
@@ -3479,7 +3478,7 @@ async function openClawReadSessionChain(
     chain.set(current.id, current);
     if (current.id === rootSessionId || !current.parentSessionId) break;
     if (chain.has(current.parentSessionId)) break;
-    const parent = await readFreshInteractiveSession(env, current.parentSessionId);
+    const parent = await readInteractiveSession(env, current.parentSessionId);
     if (!parent) break;
     current = parent;
   }
@@ -3493,8 +3492,8 @@ async function openClawSupervisedRootForCreate(
 ): Promise<string | null> {
   if (!lineage.parentSessionId || !lineage.rootSessionId) return null;
   const [parent, root] = await Promise.all([
-    readFreshInteractiveSession(env, lineage.parentSessionId),
-    readFreshInteractiveSession(env, lineage.rootSessionId),
+    readInteractiveSession(env, lineage.parentSessionId),
+    readInteractiveSession(env, lineage.rootSessionId),
   ]);
   if (!parent || !root) return null;
   if (createdBy === "service:openclaw" || createdBy === `session:${lineage.parentSessionId}`) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9433,6 +9433,9 @@ async function provisionInteractiveEndpoint(
     .selectAll()
     .where("id", "=", payload.id)
     .executeTakeFirst();
+  if (managed && managed.preparation_pending !== 0) {
+    return failedProvision("interactive provision failed: managed session preparation is pending");
+  }
   if (managed) {
     if (payload.runtime !== "container" || !env.SANDBOX) {
       return failedProvision(
@@ -9481,6 +9484,7 @@ async function provisionManagedSandboxEndpoint(
   if (
     !managedSandboxProvisionPayloadMatches(payload, session) ||
     !["provisioning", "pending_adapter"].includes(session.status) ||
+    session.preparation_pending !== 0 ||
     session.adapter === runtimeAdapterName ||
     session.credential_cleanup_terminal_status !== null
   ) {
@@ -9514,6 +9518,7 @@ async function provisionManagedSandboxEndpoint(
     .where("id", "=", session.id)
     .where("updated_at", "=", session.updated_at)
     .where("status", "in", ["provisioning", "pending_adapter"])
+    .where("preparation_pending", "=", 0)
     .where(sql<boolean>`parent_session_id IS ${payload.parentSessionId}`)
     .where(sql<boolean>`COALESCE(root_session_id, id) = ${payload.rootSessionId}`)
     .where("runtime", "=", payload.runtime)

--- a/src/index.ts
+++ b/src/index.ts
@@ -828,6 +828,7 @@ type InteractiveSessionTable = {
   adapter_requested_capabilities_json: string | null;
   adapter_create_payload_json: string | null;
   adapter_create_pending: number;
+  preparation_pending: Generated<number>;
   terminal_finalize_pending: Generated<number>;
   credential_cleanup_terminal_status: Generated<"stopped" | "expired" | "failed" | null>;
   sandbox_refresh_sandbox_id: Generated<string | null>;
@@ -1044,6 +1045,7 @@ const runtimeAdapterReconcileIntervalMs = 15_000;
 const runtimeAdapterReconcileLimit = 3;
 const runtimeAdapterReconcileConcurrency = 3;
 const runtimeAdapterReconcileForegroundBudgetMs = 750;
+const interactiveSessionPreparationStaleMs = 5 * 60_000;
 const terminalCleanupDeletePending = 2;
 const credentialPolicyCleanupLimit = 8;
 const credentialPolicyScanLimit = 32;
@@ -3304,6 +3306,7 @@ async function openClawReadSessionRoot(
     )
     .where("runtime", "!=", "github_actions")
     .where("work_key", "is", null)
+    .where("preparation_pending", "=", 0)
     .orderBy("created_at", "asc")
     .limit(openClawRoomMaxSessions + 1)
     .execute();
@@ -3489,18 +3492,21 @@ async function openClawSupervisedRootForCreate(
   lineage: { parentSessionId: string | null; rootSessionId: string | null },
 ): Promise<string | null> {
   if (!lineage.parentSessionId || !lineage.rootSessionId) return null;
-  if (createdBy !== "service:openclaw" && createdBy !== `session:${lineage.parentSessionId}`) {
-    return null;
-  }
   const [parent, root] = await Promise.all([
     readFreshInteractiveSession(env, lineage.parentSessionId),
     readFreshInteractiveSession(env, lineage.rootSessionId),
   ]);
   if (!parent || !root) return null;
-  const chain = await openClawReadSessionChain(env, parent, root, lineage.rootSessionId);
-  return openClawRoomSessionChainAllowed(chain, parent.id, lineage.rootSessionId)
-    ? lineage.rootSessionId
-    : null;
+  if (createdBy === "service:openclaw" || createdBy === `session:${lineage.parentSessionId}`) {
+    const chain = await openClawReadSessionChain(env, parent, root, lineage.rootSessionId);
+    if (openClawRoomSessionChainAllowed(chain, parent.id, lineage.rootSessionId)) {
+      return lineage.rootSessionId;
+    }
+  }
+  if (openClawRoomRootAllowed(root)) {
+    throw badRequest("invalid OpenClaw room lineage");
+  }
+  return null;
 }
 
 async function enforceOpenClawRoomSessionLimitAfterInsert(
@@ -3539,13 +3545,32 @@ async function rollbackInteractiveSessionReservation(
   insertedAt: number,
 ): Promise<void> {
   const db = database(env);
-  await db
-    .deleteFrom("interactive_sessions")
-    .where("id", "=", insertedSessionId)
-    .where("status", "=", "provisioning")
-    .where("created_at", "=", insertedAt)
-    .where("updated_at", "=", insertedAt)
-    .execute();
+  const ownsReservation = sql<boolean>`EXISTS (
+    SELECT 1
+    FROM interactive_sessions
+    WHERE id = ${insertedSessionId}
+      AND status = 'provisioning'
+      AND preparation_pending = 1
+      AND created_at = ${insertedAt}
+      AND updated_at = ${insertedAt}
+  )`;
+  await executeBatch(env, [
+    db
+      .deleteFrom("interactive_session_events")
+      .where("session_id", "=", insertedSessionId)
+      .where(ownsReservation),
+    db
+      .deleteFrom("interactive_session_log_archives")
+      .where("session_id", "=", insertedSessionId)
+      .where(ownsReservation),
+    db
+      .deleteFrom("interactive_sessions")
+      .where("id", "=", insertedSessionId)
+      .where("status", "=", "provisioning")
+      .where("preparation_pending", "=", 1)
+      .where("created_at", "=", insertedAt)
+      .where("updated_at", "=", insertedAt),
+  ]);
   const current = await db
     .selectFrom("interactive_sessions")
     .select("id")
@@ -3554,24 +3579,50 @@ async function rollbackInteractiveSessionReservation(
   if (current) throw serviceUnavailable("interactive session reservation rollback failed");
 }
 
-async function activateRuntimeAdapterReservation(
+async function cleanupAbandonedInteractiveSessionPreparations(
+  env: RuntimeEnv,
+  now: number,
+): Promise<void> {
+  const rows = await database(env)
+    .selectFrom("interactive_sessions")
+    .select(["id", "created_at"])
+    .where("status", "=", "provisioning")
+    .where("preparation_pending", "=", 1)
+    .where("updated_at", "<=", now - interactiveSessionPreparationStaleMs)
+    .orderBy("updated_at", "asc")
+    .limit(runtimeAdapterReconcileLimit)
+    .execute();
+  await mapWithConcurrency(rows, runtimeAdapterReconcileConcurrency, async (row) => {
+    await rollbackInteractiveSessionReservation(env, row.id, row.created_at).catch((error) => {
+      console.error(`interactive session preparation cleanup failed for ${row.id}`, error);
+    });
+  });
+}
+
+async function activateInteractiveSessionReservation(
   env: RuntimeEnv,
   insertedSessionId: string,
   insertedAt: number,
-  adapterWorkspaceId: string,
+  adapterWorkspaceId: string | null,
 ): Promise<void> {
   const activated = await database(env)
     .updateTable("interactive_sessions")
     .set({
-      adapter: runtimeAdapterName,
-      adapter_create_pending: 1,
-      last_reconciled_at: insertedAt,
-      reconcile_error: "runtime adapter create pending",
+      preparation_pending: 0,
+      ...(adapterWorkspaceId
+        ? {
+            adapter: runtimeAdapterName,
+            adapter_create_pending: 1,
+            last_reconciled_at: insertedAt,
+            reconcile_error: "runtime adapter create pending",
+          }
+        : {}),
     })
     .where("id", "=", insertedSessionId)
     .where("status", "=", "provisioning")
+    .where("preparation_pending", "=", 1)
     .where("adapter", "is", null)
-    .where("adapter_workspace_id", "=", adapterWorkspaceId)
+    .where(sql<boolean>`adapter_workspace_id IS ${adapterWorkspaceId}`)
     .where("adapter_create_pending", "=", 0)
     .where("created_at", "=", insertedAt)
     .where("updated_at", "=", insertedAt)
@@ -3922,6 +3973,7 @@ async function requireAgentSession(
     .selectFrom("interactive_sessions")
     .selectAll()
     .where("id", "=", id)
+    .where("preparation_pending", "=", 0)
     .executeTakeFirst();
   if (!row?.agent_token_hash || row.agent_token_hash !== (await sha256(token))) {
     throw unauthorized();
@@ -4092,6 +4144,7 @@ async function reconcileInteractiveSessionLifecycleBatch(
   env: RuntimeEnv,
   now: number,
 ): Promise<void> {
+  await cleanupAbandonedInteractiveSessionPreparations(env, now);
   await reconcileCredentialPolicyCleanupBatch(env, now);
   await reconcileLegacyStoppingInteractiveSessionBatch(env, now);
   await reconcileExternalInteractiveSessionBatch(env, now);
@@ -4716,6 +4769,7 @@ async function createInteractiveSessionFromInput(
             : null,
           adapter_create_payload_json: adapterCreatePayloadJson,
           adapter_create_pending: adapterWorkspaceId && !sideEffectReservation ? 1 : 0,
+          preparation_pending: sideEffectReservation ? 1 : 0,
           command,
           prompt,
           purpose,
@@ -4767,8 +4821,8 @@ async function createInteractiveSessionFromInput(
         await rollbackInteractiveSessionReservation(env, id, now);
         throw error;
       }
-      if (adapterWorkspaceId && sideEffectReservation) {
-        await activateRuntimeAdapterReservation(env, id, now, adapterWorkspaceId);
+      if (sideEffectReservation) {
+        await activateInteractiveSessionReservation(env, id, now, adapterWorkspaceId);
       }
       await appendInteractiveSessionEvent(env, id, user, "interactive workspace requested", now);
       const provisioned = await provisionInteractiveSession(
@@ -14023,6 +14077,7 @@ async function readInteractiveSessions(env: RuntimeEnv, user: User): Promise<Int
   const rows = await database(env)
     .selectFrom("interactive_sessions")
     .selectAll()
+    .where("preparation_pending", "=", 0)
     .orderBy("updated_at", "desc")
     .limit(80)
     .execute();
@@ -14052,6 +14107,7 @@ async function readInteractiveSession(
     .selectFrom("interactive_sessions")
     .selectAll()
     .where("id", "=", id)
+    .where("preparation_pending", "=", 0)
     .executeTakeFirst();
   if (!row) return null;
   const logs = await readInteractiveSessionLogs(env, [id]);
@@ -14078,6 +14134,7 @@ async function readSharedInteractiveSession(
     .selectFrom("interactive_sessions")
     .selectAll()
     .where("id", "=", id)
+    .where("preparation_pending", "=", 0)
     .where("share_mode", "=", "link_read")
     .executeTakeFirst();
   if (!row || !row.share_token_hash || !token) throw notFound("shared session not found");

--- a/src/index.ts
+++ b/src/index.ts
@@ -3554,6 +3554,33 @@ async function rollbackInteractiveSessionReservation(
   if (current) throw serviceUnavailable("interactive session reservation rollback failed");
 }
 
+async function activateRuntimeAdapterReservation(
+  env: RuntimeEnv,
+  insertedSessionId: string,
+  insertedAt: number,
+  adapterWorkspaceId: string,
+): Promise<void> {
+  const activated = await database(env)
+    .updateTable("interactive_sessions")
+    .set({
+      adapter: runtimeAdapterName,
+      adapter_create_pending: 1,
+      last_reconciled_at: insertedAt,
+      reconcile_error: "runtime adapter create pending",
+    })
+    .where("id", "=", insertedSessionId)
+    .where("status", "=", "provisioning")
+    .where("adapter", "is", null)
+    .where("adapter_workspace_id", "=", adapterWorkspaceId)
+    .where("adapter_create_pending", "=", 0)
+    .where("created_at", "=", insertedAt)
+    .where("updated_at", "=", insertedAt)
+    .executeTakeFirst();
+  if ((activated.numUpdatedRows ?? 0n) > 0n) return;
+  await rollbackInteractiveSessionReservation(env, insertedSessionId, insertedAt);
+  throw serviceUnavailable("interactive session reservation activation failed");
+}
+
 function openClawCrabboxResponse(
   env: RuntimeEnv,
   serviceUser: User,
@@ -4609,6 +4636,7 @@ async function createInteractiveSessionFromInput(
     options.rootSessionId ?? (clean(body.rootSessionId, 120) || null),
   );
   const supervisedRootSessionId = await openClawSupervisedRootForCreate(env, createdBy, lineage);
+  const sideEffectReservation = Boolean(options.afterReserve);
   const now = Date.now();
   const db = database(env);
   for (let attempt = 0; attempt < 3; attempt += 1) {
@@ -4670,15 +4698,16 @@ async function createInteractiveSessionFromInput(
           repo,
           branch,
           runtime,
-          adapter: adapterWorkspaceId ? runtimeAdapterName : null,
+          adapter: adapterWorkspaceId && !sideEffectReservation ? runtimeAdapterName : null,
           profile,
           adapter_workspace_id: adapterWorkspaceId,
           adapter_control_plane: adapterControlPlane,
           provider_resource_id: null,
           capabilities_json: JSON.stringify(requestedCapabilities),
           expires_at: null,
-          last_reconciled_at: adapterWorkspaceId ? now : null,
-          reconcile_error: adapterWorkspaceId ? "runtime adapter create pending" : null,
+          last_reconciled_at: adapterWorkspaceId && !sideEffectReservation ? now : null,
+          reconcile_error:
+            adapterWorkspaceId && !sideEffectReservation ? "runtime adapter create pending" : null,
           terminal_status: null,
           adapter_ttl_seconds: adapterSettings?.ttlSeconds ?? null,
           adapter_idle_timeout_seconds: adapterSettings?.idleTimeoutSeconds ?? null,
@@ -4686,7 +4715,7 @@ async function createInteractiveSessionFromInput(
             ? JSON.stringify(adapterSettings.capabilities)
             : null,
           adapter_create_payload_json: adapterCreatePayloadJson,
-          adapter_create_pending: adapterWorkspaceId ? 1 : 0,
+          adapter_create_pending: adapterWorkspaceId && !sideEffectReservation ? 1 : 0,
           command,
           prompt,
           purpose,
@@ -4737,6 +4766,9 @@ async function createInteractiveSessionFromInput(
       } catch (error) {
         await rollbackInteractiveSessionReservation(env, id, now);
         throw error;
+      }
+      if (adapterWorkspaceId && sideEffectReservation) {
+        await activateRuntimeAdapterReservation(env, id, now, adapterWorkspaceId);
       }
       await appendInteractiveSessionEvent(env, id, user, "interactive workspace requested", now);
       const provisioned = await provisionInteractiveSession(

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,8 @@ import { readBoundedResponseText } from "./bounded-response";
 import {
   boundedUtf8Tail,
   openClawBranchPreparationCanDefer,
+  openClawRoomRootAllowed,
+  openClawRoomSessionAllowed,
   openClawServiceAuthorized,
   sessionBelongsToRoot,
 } from "./openclaw-service";
@@ -3216,7 +3218,7 @@ async function openClawCreateCrabbox(
   request: Request,
   env: RuntimeEnv,
 ): Promise<{ session: InteractiveSession; browserUrl: string }> {
-  requireOpenClawService(request, env);
+  requireOpenClawRoomService(request, env);
   const body = await readJson<{
     repo?: string;
     branch?: string;
@@ -3276,9 +3278,13 @@ async function openClawReadSessionRoot(
   rootSessionId: string;
   crabboxes: Array<{ session: InteractiveSession; browserUrl: string }>;
 }> {
-  requireOpenClawService(request, env);
+  requireOpenClawRoomService(request, env);
   const root = clean(rootSessionId, 120);
   if (!root) throw badRequest("root session id is required");
+  const rootSession = await readFreshInteractiveSession(env, root);
+  if (!rootSession || !openClawRoomRootAllowed(rootSession)) {
+    throw notFound("session root not found");
+  }
   const rows = await database(env)
     .selectFrom("interactive_sessions")
     .select("id")
@@ -3293,7 +3299,13 @@ async function openClawReadSessionRoot(
   return {
     rootSessionId: root,
     crabboxes: sessions
-      .filter((session): session is InteractiveSession => Boolean(session))
+      .filter((session): session is InteractiveSession => {
+        if (!session) return false;
+        return (
+          openClawRoomSessionAllowed(session) &&
+          sessionBelongsToRoot(session.id, session.rootSessionId, root)
+        );
+      })
       .map((session) => openClawCrabboxResponse(env, serviceUser, session)),
   };
 }
@@ -3303,7 +3315,7 @@ async function openClawReadCrabbox(
   env: RuntimeEnv,
   id: string,
 ): Promise<{ session: InteractiveSession; browserUrl: string }> {
-  requireOpenClawService(request, env);
+  requireOpenClawRoomService(request, env);
   const session = await openClawRootScopedCrabbox(request, env, id);
   return openClawCrabboxResponse(env, openClawServiceUser(), session);
 }
@@ -3319,7 +3331,7 @@ async function openClawReadCrabboxTranscript(
   eventCount: number;
   truncated: boolean;
 }> {
-  requireOpenClawService(request, env);
+  requireOpenClawRoomService(request, env);
   const session = await openClawRootScopedCrabbox(request, env, id);
   const [events, eventCount] = await Promise.all([
     readInteractiveSessionEventRows(env, id, { limit: 240, newest: true }),
@@ -3339,7 +3351,7 @@ async function openClawMessageCrabbox(
   env: RuntimeEnv,
   id: string,
 ): Promise<{ delivered: true; session: InteractiveSession; browserUrl: string }> {
-  requireOpenClawService(request, env);
+  requireOpenClawRoomService(request, env);
   const body = await readJson<{ rootSessionId?: string; message?: string; enter?: boolean }>(request);
   const session = await openClawRootScopedCrabbox(request, env, id, body.rootSessionId);
   if (["stopping", "stopped", "expired", "failed"].includes(session.status)) {
@@ -3360,7 +3372,6 @@ async function openClawMessageCrabbox(
     120,
     34,
   );
-  await upstream.markConnected();
   upstream.socket.send(encoder.encode(`${message}${body.enter === false ? "" : "\r"}`));
   upstream.socket.close(1000, "OpenClaw service nudge sent");
   const now = Date.now();
@@ -3381,7 +3392,7 @@ async function openClawMutateCrabbox(
   env: RuntimeEnv,
   id: string,
 ): Promise<{ session: InteractiveSession; browserUrl: string }> {
-  requireOpenClawService(request, env);
+  requireOpenClawRoomService(request, env);
   const body = await readJson<{ rootSessionId?: string; action?: string }>(request);
   await openClawRootScopedCrabbox(request, env, id, body.rootSessionId);
   if (body.action !== "stop") throw badRequest("only stop is supported");
@@ -3403,7 +3414,14 @@ async function openClawRootScopedCrabbox(
   );
   if (!rootSessionId) throw badRequest("root session id is required");
   const session = await readFreshInteractiveSession(env, id);
-  if (!session || !sessionBelongsToRoot(session.id, session.rootSessionId, rootSessionId)) {
+  const root = await readFreshInteractiveSession(env, rootSessionId);
+  if (
+    !session ||
+    !root ||
+    !openClawRoomRootAllowed(root) ||
+    !openClawRoomSessionAllowed(session) ||
+    !sessionBelongsToRoot(session.id, session.rootSessionId, rootSessionId)
+  ) {
     throw notFound("interactive session not found");
   }
   return session;
@@ -3429,7 +3447,7 @@ async function openClawRegisterActionSession(
   runnerPtyUrl: string;
   browserUrl: string;
 }> {
-  requireOpenClawService(request, env);
+  requireOpenClawAutomationService(request, env);
   const body = await readJson<{
     workKey?: string;
     workKind?: string;
@@ -3612,8 +3630,18 @@ function openClawServiceUser(): User {
   };
 }
 
-function requireOpenClawService(request: Request, env: RuntimeEnv): void {
-  const tokens = [env.CRABBOX_OPENCLAW_TOKEN, env.CRABBOX_MULTICODEX_TOKEN];
+function requireOpenClawAutomationService(request: Request, env: RuntimeEnv): void {
+  requireOpenClawServiceToken(request, [env.CRABBOX_OPENCLAW_TOKEN]);
+}
+
+function requireOpenClawRoomService(request: Request, env: RuntimeEnv): void {
+  requireOpenClawServiceToken(request, [env.CRABBOX_OPENCLAW_TOKEN, env.CRABBOX_MULTICODEX_TOKEN]);
+}
+
+function requireOpenClawServiceToken(
+  request: Request,
+  tokens: Array<string | null | undefined>,
+): void {
   if (!tokens.some(Boolean)) {
     throw serviceUnavailable("OpenClaw service token is not configured");
   }
@@ -3634,9 +3662,7 @@ async function ensureOpenClawServiceBranch(
   const branch = clean(branchInput, 120) || "main";
   const baseBranch = clean(baseBranchInput, 120) || "main";
   if (branch === baseBranch) return;
-  if (!env.GITHUB_TOKEN) {
-    throw serviceUnavailable("GitHub token is not configured for service branch creation");
-  }
+  if (!env.GITHUB_TOKEN) return;
   const [owner, name] = repo.split("/");
   const refPath = `/repos/${owner}/${name}/git/ref/heads/${encodeURIComponent(branch)}`;
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3368,6 +3368,9 @@ async function openClawMessageCrabbox(
   const message = clean(body.message, 4000);
   if (!message) throw badRequest("message is required");
   const serviceUser = openClawServiceUser();
+  const now = Date.now();
+  await appendInteractiveSessionEvent(env, id, serviceUser, "OpenClaw service nudge requested", now);
+  await audit(env, serviceUser, `openclaw crabbox message requested ${id}`, now);
   const terminalRequest = new Request(request.url, { headers: { upgrade: "websocket" } });
   const upstream = await openInteractiveTerminalUpstream(
     terminalRequest,
@@ -3378,17 +3381,27 @@ async function openClawMessageCrabbox(
     34,
   );
   upstream.socket.send(encoder.encode(`${message}${body.enter === false ? "" : "\r"}`));
-  upstream.socket.close(1000, "OpenClaw service nudge sent");
-  const now = Date.now();
-  await appendInteractiveSessionEvent(env, id, serviceUser, "OpenClaw service nudge sent", now);
-  await audit(env, serviceUser, `openclaw crabbox message sent ${id}`, now);
+  try {
+    upstream.socket.close(1000, "OpenClaw service nudge sent");
+  } catch {
+    console.warn(JSON.stringify({ event: "openclaw_message_socket_close_failed", sessionId: id }));
+  }
+  const deliveredAt = Date.now();
+  const deliveryRecords = await Promise.allSettled([
+    appendInteractiveSessionEvent(env, id, serviceUser, "OpenClaw service nudge sent", deliveredAt),
+    audit(env, serviceUser, `openclaw crabbox message sent ${id}`, deliveredAt),
+  ]);
+  if (deliveryRecords.some((record) => record.status === "rejected")) {
+    console.warn(
+      JSON.stringify({
+        event: "openclaw_message_delivery_record_failed",
+        sessionId: id,
+      }),
+    );
+  }
   return {
     delivered: true,
-    ...openClawCrabboxResponse(
-      env,
-      serviceUser,
-      (await readInteractiveSession(env, id)) as InteractiveSession,
-    ),
+    ...openClawCrabboxResponse(env, serviceUser, session),
   };
 }
 
@@ -3402,8 +3415,8 @@ async function openClawMutateCrabbox(
   await openClawRootScopedCrabbox(request, env, id, body.rootSessionId);
   if (body.action !== "stop") throw badRequest("only stop is supported");
   const serviceUser = openClawServiceUser();
-  const result = await mutateInteractiveSession(request, env, serviceUser, id, body.action);
   await audit(env, serviceUser, `openclaw crabbox stop requested ${id}`, Date.now());
+  const result = await mutateInteractiveSession(request, env, serviceUser, id, body.action);
   return openClawCrabboxResponse(env, serviceUser, result.session);
 }
 

--- a/src/openclaw-service.ts
+++ b/src/openclaw-service.ts
@@ -2,6 +2,7 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 export const openClawTranscriptMaxBytes = 64 * 1024;
+export const openClawRoomMaxSessions = 64;
 
 type OpenClawSessionFence = {
 	id: string;

--- a/src/openclaw-service.ts
+++ b/src/openclaw-service.ts
@@ -1,0 +1,22 @@
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export const openClawTranscriptMaxBytes = 64 * 1024;
+
+export function sessionBelongsToRoot(
+	sessionId: string,
+	sessionRootId: string | null,
+	expectedRootId: string,
+): boolean {
+	return Boolean(expectedRootId) && (sessionRootId || sessionId) === expectedRootId;
+}
+
+export function boundedUtf8Tail(
+	value: string,
+	maxBytes = openClawTranscriptMaxBytes,
+): { text: string; truncated: boolean } {
+	const bytes = encoder.encode(value);
+	if (bytes.byteLength <= maxBytes) return { text: value, truncated: false };
+	const tail = decoder.decode(bytes.slice(bytes.byteLength - maxBytes)).replace(/^\uFFFD/, "");
+	return { text: tail, truncated: true };
+}

--- a/src/openclaw-service.ts
+++ b/src/openclaw-service.ts
@@ -18,6 +18,10 @@ export function sessionBelongsToRoot(
 	return Boolean(expectedRootId) && (sessionRootId || sessionId) === expectedRootId;
 }
 
+export function openClawBranchPreparationCanDefer(status: number): boolean {
+	return status === 403;
+}
+
 export function boundedUtf8Tail(
 	value: string,
 	maxBytes = openClawTranscriptMaxBytes,

--- a/src/openclaw-service.ts
+++ b/src/openclaw-service.ts
@@ -3,6 +3,14 @@ const decoder = new TextDecoder();
 
 export const openClawTranscriptMaxBytes = 64 * 1024;
 
+type OpenClawSessionFence = {
+	id: string;
+	rootSessionId: string | null;
+	runtime: string;
+	createdBy: string;
+	workKey: string | null;
+};
+
 export function openClawServiceAuthorized(
 	authorization: string | null,
 	tokens: Array<string | null | undefined>,
@@ -18,6 +26,20 @@ export function sessionBelongsToRoot(
 	return Boolean(expectedRootId) && (sessionRootId || sessionId) === expectedRootId;
 }
 
+export function openClawRoomSessionAllowed(session: OpenClawSessionFence): boolean {
+	return (
+		session.createdBy === "service:openclaw" &&
+		session.runtime !== "github_actions" &&
+		!session.workKey
+	);
+}
+
+export function openClawRoomRootAllowed(session: OpenClawSessionFence): boolean {
+	return (
+		openClawRoomSessionAllowed(session) && (session.rootSessionId || session.id) === session.id
+	);
+}
+
 export function openClawBranchPreparationCanDefer(status: number): boolean {
 	return status === 403;
 }
@@ -28,6 +50,8 @@ export function boundedUtf8Tail(
 ): { text: string; truncated: boolean } {
 	const bytes = encoder.encode(value);
 	if (bytes.byteLength <= maxBytes) return { text: value, truncated: false };
-	const tail = decoder.decode(bytes.slice(bytes.byteLength - maxBytes)).replace(/^\uFFFD/, "");
+	let start = bytes.byteLength - maxBytes;
+	while (start < bytes.byteLength && (bytes[start]! & 0xc0) === 0x80) start += 1;
+	const tail = decoder.decode(bytes.slice(start));
 	return { text: tail, truncated: true };
 }

--- a/src/openclaw-service.ts
+++ b/src/openclaw-service.ts
@@ -3,6 +3,13 @@ const decoder = new TextDecoder();
 
 export const openClawTranscriptMaxBytes = 64 * 1024;
 
+export function openClawServiceAuthorized(
+	authorization: string | null,
+	tokens: Array<string | null | undefined>,
+): boolean {
+	return tokens.some((token) => Boolean(token) && authorization === `Bearer ${token}`);
+}
+
 export function sessionBelongsToRoot(
 	sessionId: string,
 	sessionRootId: string | null,

--- a/src/openclaw-service.ts
+++ b/src/openclaw-service.ts
@@ -75,6 +75,21 @@ export function openClawBranchPreparationCanDefer(status: number): boolean {
 	return status === 403 || status === 404;
 }
 
+export function openClawGitHubRepoParts(repo: string): { owner: string; name: string } | null {
+	const parts = repo.split("/");
+	if (parts.length !== 2) return null;
+	const [owner, name] = parts;
+	if (
+		!owner ||
+		!name ||
+		!/^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/i.test(owner) ||
+		!/^[a-z0-9._-]{1,100}$/i.test(name)
+	) {
+		return null;
+	}
+	return { owner, name };
+}
+
 export function boundedUtf8Tail(
 	value: string,
 	maxBytes = openClawTranscriptMaxBytes,

--- a/src/openclaw-service.ts
+++ b/src/openclaw-service.ts
@@ -75,6 +75,35 @@ export function openClawBranchPreparationCanDefer(status: number): boolean {
 	return status === 403 || status === 404;
 }
 
+export function openClawGitBranchAllowed(branch: string): boolean {
+	if (!branch || branch.length > 120 || branch !== branch.trim()) return false;
+	if (
+		branch === "@" ||
+		branch.startsWith("-") ||
+		branch.startsWith("/") ||
+		branch.endsWith("/") ||
+		branch.endsWith(".") ||
+		branch.includes("..") ||
+		branch.includes("@{") ||
+		branch.includes("//")
+	) {
+		return false;
+	}
+	if (
+		[...branch].some(
+			(character) =>
+				character.charCodeAt(0) <= 32 ||
+				character.charCodeAt(0) === 127 ||
+				"~^:?*[\\".includes(character),
+		)
+	) {
+		return false;
+	}
+	return branch
+		.split("/")
+		.every((part) => Boolean(part) && !part.startsWith(".") && !part.endsWith(".lock"));
+}
+
 export function openClawGitHubRepoParts(repo: string): { owner: string; name: string } | null {
 	const parts = repo.split("/");
 	if (parts.length !== 2) return null;

--- a/src/openclaw-service.ts
+++ b/src/openclaw-service.ts
@@ -29,7 +29,7 @@ export function sessionBelongsToRoot(
 
 export function openClawRoomSessionAllowed(session: OpenClawSessionFence): boolean {
 	return (
-		session.createdBy === "service:openclaw" &&
+		(session.createdBy === "service:openclaw" || session.createdBy.startsWith("session:")) &&
 		session.runtime !== "github_actions" &&
 		!session.workKey
 	);
@@ -37,7 +37,9 @@ export function openClawRoomSessionAllowed(session: OpenClawSessionFence): boole
 
 export function openClawRoomRootAllowed(session: OpenClawSessionFence): boolean {
 	return (
-		openClawRoomSessionAllowed(session) && (session.rootSessionId || session.id) === session.id
+		session.createdBy === "service:openclaw" &&
+		openClawRoomSessionAllowed(session) &&
+		(session.rootSessionId || session.id) === session.id
 	);
 }
 

--- a/src/openclaw-service.ts
+++ b/src/openclaw-service.ts
@@ -41,7 +41,7 @@ export function openClawRoomRootAllowed(session: OpenClawSessionFence): boolean 
 }
 
 export function openClawBranchPreparationCanDefer(status: number): boolean {
-	return status === 403;
+	return status === 403 || status === 404;
 }
 
 export function boundedUtf8Tail(

--- a/src/openclaw-service.ts
+++ b/src/openclaw-service.ts
@@ -6,6 +6,7 @@ export const openClawRoomMaxSessions = 64;
 
 type OpenClawSessionFence = {
 	id: string;
+	parentSessionId: string | null;
 	rootSessionId: string | null;
 	runtime: string;
 	createdBy: string;
@@ -29,7 +30,9 @@ export function sessionBelongsToRoot(
 
 export function openClawRoomSessionAllowed(session: OpenClawSessionFence): boolean {
 	return (
-		(session.createdBy === "service:openclaw" || session.createdBy.startsWith("session:")) &&
+		(session.createdBy === "service:openclaw" ||
+			(Boolean(session.parentSessionId) &&
+				session.createdBy === `session:${session.parentSessionId}`)) &&
 		session.runtime !== "github_actions" &&
 		!session.workKey
 	);
@@ -41,6 +44,31 @@ export function openClawRoomRootAllowed(session: OpenClawSessionFence): boolean 
 		openClawRoomSessionAllowed(session) &&
 		(session.rootSessionId || session.id) === session.id
 	);
+}
+
+export function openClawRoomSessionChainAllowed(
+	sessions: OpenClawSessionFence[],
+	sessionId: string,
+	expectedRootId: string,
+): boolean {
+	const byId = new Map(sessions.map((session) => [session.id, session]));
+	const root = byId.get(expectedRootId);
+	if (!root || !openClawRoomRootAllowed(root)) return false;
+	let current = byId.get(sessionId);
+	const visited = new Set<string>();
+	while (current && !visited.has(current.id)) {
+		visited.add(current.id);
+		if (
+			!openClawRoomSessionAllowed(current) ||
+			!sessionBelongsToRoot(current.id, current.rootSessionId, expectedRootId)
+		) {
+			return false;
+		}
+		if (current.id === expectedRootId) return true;
+		if (!current.parentSessionId) return false;
+		current = byId.get(current.parentSessionId);
+	}
+	return false;
 }
 
 export function openClawBranchPreparationCanDefer(status: number): boolean {

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	boundedUtf8Tail,
+	openClawTranscriptMaxBytes,
+	sessionBelongsToRoot,
+} from "../src/openclaw-service.ts";
+
+test("session root fences accept the root and every child only for the exact root", () => {
+	assert.equal(sessionBelongsToRoot("IS-10", "IS-10", "IS-10"), true);
+	assert.equal(sessionBelongsToRoot("IS-11", "IS-10", "IS-10"), true);
+	assert.equal(sessionBelongsToRoot("IS-11", "IS-10", "IS-99"), false);
+	assert.equal(sessionBelongsToRoot("IS-10", null, "IS-10"), true);
+	assert.equal(sessionBelongsToRoot("IS-10", null, ""), false);
+});
+
+test("bounded transcript tails remain valid UTF-8 and report truncation", () => {
+	assert.deepEqual(boundedUtf8Tail("hello", 5), { text: "hello", truncated: false });
+	assert.deepEqual(boundedUtf8Tail("hello", 4), { text: "ello", truncated: true });
+	assert.deepEqual(boundedUtf8Tail("a\u00E9b", 2), { text: "b", truncated: true });
+	assert.equal(openClawTranscriptMaxBytes, 64 * 1024);
+});

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -177,3 +177,28 @@ test("interactive lineage rejects caller-claimed roots without a parent", async 
 		/if \(rootId\) throw badRequest\("root session id requires a parent session id"\)/,
 	);
 });
+
+test("OpenClaw room capacity rolls back before event recording or provisioning", async () => {
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const capacityStart = source.indexOf("async function enforceOpenClawRoomSessionLimitAfterInsert");
+	const capacityEnd = source.indexOf("function openClawCrabboxResponse", capacityStart);
+	const capacitySource = source.slice(capacityStart, capacityEnd);
+	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
+	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
+	const createSource = source.slice(createStart, createEnd);
+
+	assert.match(capacitySource, /fn\.countAll<number>\(\)/);
+	assert.match(capacitySource, /deleteFrom\("interactive_sessions"\)/);
+	assert.match(
+		capacitySource,
+		/throw tooManyRequests\("session root reached the supervision limit"\)/,
+	);
+	assert.ok(
+		createSource.indexOf("enforceOpenClawRoomSessionLimitAfterInsert") <
+			createSource.indexOf("appendInteractiveSessionEvent"),
+	);
+	assert.ok(
+		createSource.indexOf("enforceOpenClawRoomSessionLimitAfterInsert") <
+			createSource.indexOf("provisionInteractiveSession"),
+	);
+});

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -108,6 +108,9 @@ test("OpenClaw create preserves the already-decorated interactive session", asyn
 	assert.match(createSource, /return openClawDecoratedCrabboxResponse\(env, result\.session\)/);
 	assert.doesNotMatch(createSource, /openClawCrabboxResponse\(env, serviceUser, result\.session\)/);
 	assert.doesNotMatch(responseSource, /decorateInteractiveSession/);
+	assert.match(createSource, /AbortSignal\.timeout\(openClawPreparationTimeoutMs\)/);
+	assert.match(createSource, /ensureOpenClawServiceBranch\([\s\S]*signal\)/);
+	assert.match(createSource, /if \(signal\.aborted\)/);
 });
 
 test("OpenClaw mutations persist request evidence before consequential work", async () => {
@@ -221,7 +224,9 @@ test("OpenClaw room reservation precedes branch mutation, event recording, and p
 	const readSource = source.slice(readStart, readEnd);
 
 	assert.match(migration, /ADD COLUMN preparation_pending INTEGER NOT NULL DEFAULT 0/);
-	assert.match(capacitySource, /fn\.countAll<number>\(\)/);
+	assert.match(capacitySource, /inserted\.rowid AS inserted_rowid/);
+	assert.match(capacitySource, /candidate\.rowid <= inserted\.rowid/);
+	assert.match(capacitySource, /GROUP BY inserted\.rowid/);
 	assert.match(capacitySource, /deleteFrom\("interactive_sessions"\)/);
 	assert.match(
 		capacitySource,

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -159,6 +159,7 @@ test("OpenClaw root reads are filtered, capped, concurrent, and log-free", async
 	assert.match(readSource, /expression\("created_by", "like", "session:%"\)/);
 	assert.match(readSource, /\.where\("runtime", "!=", "github_actions"\)/);
 	assert.match(readSource, /\.where\("work_key", "is", null\)/);
+	assert.match(readSource, /\.where\("preparation_pending", "=", 0\)/);
 	assert.match(readSource, /\.limit\(openClawRoomMaxSessions \+ 1\)/);
 	assert.match(readSource, /mapWithConcurrency\(/);
 	assert.match(readSource, /openClawRoomSessionChainAllowed/);
@@ -180,16 +181,27 @@ test("interactive lineage rejects caller-claimed roots without a parent", async 
 
 test("OpenClaw room reservation precedes branch mutation, event recording, and provisioning", async () => {
 	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const migration = await readFile(
+		new URL("../migrations/0025_interactive_session_preparation.sql", import.meta.url),
+		"utf8",
+	);
 	const capacityStart = source.indexOf("async function enforceOpenClawRoomSessionLimitAfterInsert");
 	const capacityEnd = source.indexOf("function openClawCrabboxResponse", capacityStart);
 	const capacitySource = source.slice(capacityStart, capacityEnd);
-	const activationStart = source.indexOf("async function activateRuntimeAdapterReservation");
+	const activationStart = source.indexOf("async function activateInteractiveSessionReservation");
 	const activationEnd = source.indexOf("function openClawCrabboxResponse", activationStart);
 	const activationSource = source.slice(activationStart, activationEnd);
+	const rollbackStart = source.indexOf("async function rollbackInteractiveSessionReservation");
+	const rollbackEnd = source.indexOf("async function activateInteractiveSessionReservation");
+	const rollbackSource = source.slice(rollbackStart, rollbackEnd);
 	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
 	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
 	const createSource = source.slice(createStart, createEnd);
+	const readStart = source.indexOf("async function readInteractiveSessions");
+	const readEnd = source.indexOf("async function readSharedInteractiveSession", readStart);
+	const readSource = source.slice(readStart, readEnd);
 
+	assert.match(migration, /ADD COLUMN preparation_pending INTEGER NOT NULL DEFAULT 0/);
 	assert.match(capacitySource, /fn\.countAll<number>\(\)/);
 	assert.match(capacitySource, /deleteFrom\("interactive_sessions"\)/);
 	assert.match(
@@ -198,8 +210,16 @@ test("OpenClaw room reservation precedes branch mutation, event recording, and p
 	);
 	assert.match(activationSource, /adapter: runtimeAdapterName/);
 	assert.match(activationSource, /adapter_create_pending: 1/);
+	assert.match(activationSource, /preparation_pending: 0/);
+	assert.match(activationSource, /\.where\("preparation_pending", "=", 1\)/);
 	assert.match(activationSource, /\.where\("adapter", "is", null\)/);
 	assert.match(activationSource, /\.where\("adapter_create_pending", "=", 0\)/);
+	assert.match(rollbackSource, /executeBatch\(env,/);
+	assert.match(rollbackSource, /deleteFrom\("interactive_session_events"\)/);
+	assert.match(rollbackSource, /deleteFrom\("interactive_session_log_archives"\)/);
+	assert.match(capacitySource, /cleanupAbandonedInteractiveSessionPreparations/);
+	assert.match(capacitySource, /interactiveSessionPreparationStaleMs/);
+	assert.match(readSource, /\.where\("preparation_pending", "=", 0\)/);
 	assert.match(
 		createSource,
 		/adapter: adapterWorkspaceId && !sideEffectReservation \? runtimeAdapterName : null/,
@@ -208,16 +228,17 @@ test("OpenClaw room reservation precedes branch mutation, event recording, and p
 		createSource,
 		/adapter_create_pending: adapterWorkspaceId && !sideEffectReservation \? 1 : 0/,
 	);
+	assert.match(createSource, /preparation_pending: sideEffectReservation \? 1 : 0/);
 	assert.ok(
 		createSource.indexOf("enforceOpenClawRoomSessionLimitAfterInsert") <
 			createSource.indexOf("await options.afterReserve"),
 	);
 	assert.ok(
 		createSource.indexOf("await options.afterReserve") <
-			createSource.indexOf("activateRuntimeAdapterReservation"),
+			createSource.indexOf("activateInteractiveSessionReservation"),
 	);
 	assert.ok(
-		createSource.indexOf("activateRuntimeAdapterReservation") <
+		createSource.indexOf("activateInteractiveSessionReservation") <
 			createSource.indexOf("appendInteractiveSessionEvent"),
 	);
 	assert.ok(
@@ -228,4 +249,17 @@ test("OpenClaw room reservation precedes branch mutation, event recording, and p
 		createSource,
 		/catch \(error\) \{\s+await rollbackInteractiveSessionReservation\(env, id, now\);\s+throw error;/,
 	);
+});
+
+test("invalid descendants below an OpenClaw root fail closed before insertion", async () => {
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const lineageStart = source.indexOf("async function openClawSupervisedRootForCreate");
+	const lineageEnd = source.indexOf(
+		"async function enforceOpenClawRoomSessionLimitAfterInsert",
+		lineageStart,
+	);
+	const lineageSource = source.slice(lineageStart, lineageEnd);
+
+	assert.match(lineageSource, /if \(openClawRoomRootAllowed\(root\)\)/);
+	assert.match(lineageSource, /throw badRequest\("invalid OpenClaw room lineage"\)/);
 });

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -18,10 +18,10 @@ test("OpenClaw service authorization accepts dedicated scoped consumers", () => 
 	assert.equal(openClawServiceAuthorized(null, [undefined, null]), false);
 });
 
-test("OpenClaw branch preparation defers only control-plane permission failures", () => {
+test("OpenClaw branch preparation defers masked control-plane permission failures", () => {
 	assert.equal(openClawBranchPreparationCanDefer(403), true);
+	assert.equal(openClawBranchPreparationCanDefer(404), true);
 	assert.equal(openClawBranchPreparationCanDefer(401), false);
-	assert.equal(openClawBranchPreparationCanDefer(404), false);
 	assert.equal(openClawBranchPreparationCanDefer(500), false);
 });
 

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
 	boundedUtf8Tail,
 	openClawBranchPreparationCanDefer,
+	openClawRoomMaxSessions,
 	openClawRoomRootAllowed,
 	openClawRoomSessionAllowed,
 	openClawServiceAuthorized,
@@ -62,6 +63,7 @@ test("bounded transcript tails remain valid UTF-8 and report truncation", () => 
 		new TextEncoder().encode(boundedUtf8Tail("\u{1F600}\u{1F600}", 5).text).byteLength <= 5,
 	);
 	assert.equal(openClawTranscriptMaxBytes, 64 * 1024);
+	assert.equal(openClawRoomMaxSessions, 64);
 });
 
 test("OpenClaw create preserves the already-decorated interactive session", async () => {
@@ -107,9 +109,27 @@ test("OpenClaw transcript reads a sentinel event before reporting completeness",
 	assert.match(transcriptSource, /limit: 241, newest: true/);
 	assert.match(transcriptSource, /const hasMoreEvents = eventWindow\.length > 240/);
 	assert.match(transcriptSource, /eventWindow\.slice\(1\)/);
-	assert.match(transcriptSource, /session: \{ \.\.\.response\.session, logs: \[\] \}/);
+	assert.match(transcriptSource, /openClawCrabboxSummaryResponse/);
 	assert.match(
 		transcriptSource,
 		/transcript\.truncated \|\| hasMoreEvents \|\| eventCount > events\.length/,
 	);
+});
+
+test("OpenClaw root reads are filtered, capped, concurrent, and log-free", async () => {
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const readStart = source.indexOf("async function openClawReadSessionRoot");
+	const readEnd = source.indexOf("async function openClawReadCrabbox", readStart);
+	const readSource = source.slice(readStart, readEnd);
+	const summaryStart = source.indexOf("function openClawCrabboxSummaryResponse");
+	const summaryEnd = source.indexOf("function openClawDecoratedCrabboxResponse", summaryStart);
+	const summarySource = source.slice(summaryStart, summaryEnd);
+
+	assert.match(readSource, /\.where\("created_by", "=", "service:openclaw"\)/);
+	assert.match(readSource, /\.where\("runtime", "!=", "github_actions"\)/);
+	assert.match(readSource, /\.where\("work_key", "is", null\)/);
+	assert.match(readSource, /\.limit\(openClawRoomMaxSessions \+ 1\)/);
+	assert.match(readSource, /mapWithConcurrency\(/);
+	assert.match(readSource, /openClawCrabboxSummaryResponse/);
+	assert.match(summarySource, /session: \{ \.\.\.response\.session, logs: \[\] \}/);
 });

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
 	boundedUtf8Tail,
 	openClawBranchPreparationCanDefer,
+	openClawGitHubRepoParts,
 	openClawRoomMaxSessions,
 	openClawRoomRootAllowed,
 	openClawRoomSessionChainAllowed,
@@ -26,6 +27,17 @@ test("OpenClaw branch preparation defers masked control-plane permission failure
 	assert.equal(openClawBranchPreparationCanDefer(404), true);
 	assert.equal(openClawBranchPreparationCanDefer(401), false);
 	assert.equal(openClawBranchPreparationCanDefer(500), false);
+});
+
+test("OpenClaw GitHub writes require one exact owner/name pair", () => {
+	assert.deepEqual(openClawGitHubRepoParts("openclaw/crabfleet"), {
+		owner: "openclaw",
+		name: "crabfleet",
+	});
+	assert.equal(openClawGitHubRepoParts("openclaw/crabfleet/extra"), null);
+	assert.equal(openClawGitHubRepoParts("openclaw/crabfleet?ref=main"), null);
+	assert.equal(openClawGitHubRepoParts("open_claw/crabfleet"), null);
+	assert.equal(openClawGitHubRepoParts("openclaw/"), null);
 });
 
 test("session root fences accept the root and every child only for the exact root", () => {
@@ -289,5 +301,9 @@ test("invalid descendants below an OpenClaw root fail closed before insertion", 
 	const lineageSource = source.slice(lineageStart, lineageEnd);
 
 	assert.match(lineageSource, /if \(openClawRoomRootAllowed\(root\)\)/);
+	assert.match(
+		lineageSource,
+		/if \(!parent \|\| !root\) throw badRequest\("session lineage not found"\)/,
+	);
 	assert.match(lineageSource, /throw badRequest\("invalid OpenClaw room lineage"\)/);
 });

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -4,6 +4,8 @@ import test from "node:test";
 import {
 	boundedUtf8Tail,
 	openClawBranchPreparationCanDefer,
+	openClawRoomRootAllowed,
+	openClawRoomSessionAllowed,
 	openClawServiceAuthorized,
 	openClawTranscriptMaxBytes,
 	sessionBelongsToRoot,
@@ -31,9 +33,32 @@ test("session root fences accept the root and every child only for the exact roo
 	assert.equal(sessionBelongsToRoot("IS-10", null, ""), false);
 });
 
+test("room supervision accepts only service-created non-action trees", () => {
+	const root = {
+		id: "IS-10",
+		rootSessionId: "IS-10",
+		runtime: "container",
+		createdBy: "service:openclaw",
+		workKey: null,
+	};
+	assert.equal(openClawRoomSessionAllowed(root), true);
+	assert.equal(openClawRoomRootAllowed(root), true);
+	assert.equal(openClawRoomRootAllowed({ ...root, id: "IS-11" }), false);
+	assert.equal(openClawRoomSessionAllowed({ ...root, runtime: "github_actions" }), false);
+	assert.equal(openClawRoomSessionAllowed({ ...root, createdBy: "github:123" }), false);
+	assert.equal(openClawRoomSessionAllowed({ ...root, workKey: "repo:pr:1" }), false);
+});
+
 test("bounded transcript tails remain valid UTF-8 and report truncation", () => {
 	assert.deepEqual(boundedUtf8Tail("hello", 5), { text: "hello", truncated: false });
 	assert.deepEqual(boundedUtf8Tail("hello", 4), { text: "ello", truncated: true });
 	assert.deepEqual(boundedUtf8Tail("a\u00E9b", 2), { text: "b", truncated: true });
+	assert.deepEqual(boundedUtf8Tail("\u{1F600}\u{1F600}", 5), {
+		text: "\u{1F600}",
+		truncated: true,
+	});
+	assert.ok(
+		new TextEncoder().encode(boundedUtf8Tail("\u{1F600}\u{1F600}", 5).text).byteLength <= 5,
+	);
 	assert.equal(openClawTranscriptMaxBytes, 64 * 1024);
 });

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -3,9 +3,17 @@ import test from "node:test";
 
 import {
 	boundedUtf8Tail,
+	openClawServiceAuthorized,
 	openClawTranscriptMaxBytes,
 	sessionBelongsToRoot,
 } from "../src/openclaw-service.ts";
+
+test("OpenClaw service authorization accepts dedicated scoped consumers", () => {
+	assert.equal(openClawServiceAuthorized("Bearer openclaw", ["openclaw", "multicodex"]), true);
+	assert.equal(openClawServiceAuthorized("Bearer multicodex", ["openclaw", "multicodex"]), true);
+	assert.equal(openClawServiceAuthorized("Bearer public", ["openclaw", "multicodex"]), false);
+	assert.equal(openClawServiceAuthorized(null, [undefined, null]), false);
+});
 
 test("session root fences accept the root and every child only for the exact root", () => {
 	assert.equal(sessionBelongsToRoot("IS-10", "IS-10", "IS-10"), true);

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -97,3 +97,18 @@ test("OpenClaw mutations persist request evidence before consequential work", as
 			stopSource.indexOf("mutateInteractiveSession"),
 	);
 });
+
+test("OpenClaw transcript reads a sentinel event before reporting completeness", async () => {
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const transcriptStart = source.indexOf("async function openClawReadCrabboxTranscript");
+	const transcriptEnd = source.indexOf("async function openClawMessageCrabbox", transcriptStart);
+	const transcriptSource = source.slice(transcriptStart, transcriptEnd);
+
+	assert.match(transcriptSource, /limit: 241, newest: true/);
+	assert.match(transcriptSource, /const hasMoreEvents = eventWindow\.length > 240/);
+	assert.match(transcriptSource, /eventWindow\.slice\(1\)/);
+	assert.match(
+		transcriptSource,
+		/transcript\.truncated \|\| hasMoreEvents \|\| eventCount > events\.length/,
+	);
+});

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -7,6 +7,7 @@ import {
 	openClawBranchPreparationCanDefer,
 	openClawRoomMaxSessions,
 	openClawRoomRootAllowed,
+	openClawRoomSessionChainAllowed,
 	openClawRoomSessionAllowed,
 	openClawServiceAuthorized,
 	openClawTranscriptMaxBytes,
@@ -38,6 +39,7 @@ test("session root fences accept the root and every child only for the exact roo
 test("room supervision accepts service roots and their agent-created non-action descendants", () => {
 	const root = {
 		id: "IS-10",
+		parentSessionId: null,
 		rootSessionId: "IS-10",
 		runtime: "container",
 		createdBy: "service:openclaw",
@@ -47,13 +49,36 @@ test("room supervision accepts service roots and their agent-created non-action 
 	assert.equal(openClawRoomRootAllowed(root), true);
 	assert.equal(openClawRoomRootAllowed({ ...root, id: "IS-11" }), false);
 	assert.equal(
-		openClawRoomSessionAllowed({ ...root, id: "IS-11", createdBy: "session:IS-10" }),
+		openClawRoomSessionAllowed({
+			...root,
+			id: "IS-11",
+			parentSessionId: "IS-10",
+			createdBy: "session:IS-10",
+		}),
 		true,
 	);
 	assert.equal(openClawRoomRootAllowed({ ...root, createdBy: "session:IS-10" }), false);
 	assert.equal(openClawRoomSessionAllowed({ ...root, runtime: "github_actions" }), false);
 	assert.equal(openClawRoomSessionAllowed({ ...root, createdBy: "github:123" }), false);
 	assert.equal(openClawRoomSessionAllowed({ ...root, workKey: "repo:pr:1" }), false);
+
+	const child = { ...root, id: "IS-11", parentSessionId: "IS-10" };
+	const agent = {
+		...root,
+		id: "IS-12",
+		parentSessionId: "IS-11",
+		createdBy: "session:IS-11",
+	};
+	assert.equal(openClawRoomSessionChainAllowed([root, child, agent], agent.id, root.id), true);
+	assert.equal(openClawRoomSessionChainAllowed([root, agent], agent.id, root.id), false);
+	assert.equal(
+		openClawRoomSessionChainAllowed(
+			[root, { ...child, createdBy: "github:123" }, agent],
+			agent.id,
+			root.id,
+		),
+		false,
+	);
 });
 
 test("bounded transcript tails remain valid UTF-8 and report truncation", () => {
@@ -136,6 +161,19 @@ test("OpenClaw root reads are filtered, capped, concurrent, and log-free", async
 	assert.match(readSource, /\.where\("work_key", "is", null\)/);
 	assert.match(readSource, /\.limit\(openClawRoomMaxSessions \+ 1\)/);
 	assert.match(readSource, /mapWithConcurrency\(/);
+	assert.match(readSource, /openClawRoomSessionChainAllowed/);
 	assert.match(readSource, /openClawCrabboxSummaryResponse/);
 	assert.match(summarySource, /session: \{ \.\.\.response\.session, logs: \[\] \}/);
+});
+
+test("interactive lineage rejects caller-claimed roots without a parent", async () => {
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const start = source.indexOf("async function resolveInteractiveSessionLineage");
+	const end = source.indexOf("function interactiveSessionPurpose", start);
+	const lineageSource = source.slice(start, end);
+
+	assert.match(
+		lineageSource,
+		/if \(rootId\) throw badRequest\("root session id requires a parent session id"\)/,
+	);
 });

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
 	boundedUtf8Tail,
+	openClawBranchPreparationCanDefer,
 	openClawServiceAuthorized,
 	openClawTranscriptMaxBytes,
 	sessionBelongsToRoot,
@@ -13,6 +14,13 @@ test("OpenClaw service authorization accepts dedicated scoped consumers", () => 
 	assert.equal(openClawServiceAuthorized("Bearer multicodex", ["openclaw", "multicodex"]), true);
 	assert.equal(openClawServiceAuthorized("Bearer public", ["openclaw", "multicodex"]), false);
 	assert.equal(openClawServiceAuthorized(null, [undefined, null]), false);
+});
+
+test("OpenClaw branch preparation defers only control-plane permission failures", () => {
+	assert.equal(openClawBranchPreparationCanDefer(403), true);
+	assert.equal(openClawBranchPreparationCanDefer(401), false);
+	assert.equal(openClawBranchPreparationCanDefer(404), false);
+	assert.equal(openClawBranchPreparationCanDefer(500), false);
 });
 
 test("session root fences accept the root and every child only for the exact root", () => {

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -35,7 +35,7 @@ test("session root fences accept the root and every child only for the exact roo
 	assert.equal(sessionBelongsToRoot("IS-10", null, ""), false);
 });
 
-test("room supervision accepts only service-created non-action trees", () => {
+test("room supervision accepts service roots and their agent-created non-action descendants", () => {
 	const root = {
 		id: "IS-10",
 		rootSessionId: "IS-10",
@@ -46,6 +46,11 @@ test("room supervision accepts only service-created non-action trees", () => {
 	assert.equal(openClawRoomSessionAllowed(root), true);
 	assert.equal(openClawRoomRootAllowed(root), true);
 	assert.equal(openClawRoomRootAllowed({ ...root, id: "IS-11" }), false);
+	assert.equal(
+		openClawRoomSessionAllowed({ ...root, id: "IS-11", createdBy: "session:IS-10" }),
+		true,
+	);
+	assert.equal(openClawRoomRootAllowed({ ...root, createdBy: "session:IS-10" }), false);
 	assert.equal(openClawRoomSessionAllowed({ ...root, runtime: "github_actions" }), false);
 	assert.equal(openClawRoomSessionAllowed({ ...root, createdBy: "github:123" }), false);
 	assert.equal(openClawRoomSessionAllowed({ ...root, workKey: "repo:pr:1" }), false);
@@ -125,7 +130,8 @@ test("OpenClaw root reads are filtered, capped, concurrent, and log-free", async
 	const summaryEnd = source.indexOf("function openClawDecoratedCrabboxResponse", summaryStart);
 	const summarySource = source.slice(summaryStart, summaryEnd);
 
-	assert.match(readSource, /\.where\("created_by", "=", "service:openclaw"\)/);
+	assert.match(readSource, /expression\("created_by", "=", "service:openclaw"\)/);
+	assert.match(readSource, /expression\("created_by", "like", "session:%"\)/);
 	assert.match(readSource, /\.where\("runtime", "!=", "github_actions"\)/);
 	assert.match(readSource, /\.where\("work_key", "is", null\)/);
 	assert.match(readSource, /\.limit\(openClawRoomMaxSessions \+ 1\)/);

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -222,13 +222,17 @@ test("OpenClaw room reservation precedes branch mutation, event recording, and p
 	assert.match(readSource, /\.where\("preparation_pending", "=", 0\)/);
 	assert.match(
 		createSource,
-		/adapter: adapterWorkspaceId && !sideEffectReservation \? runtimeAdapterName : null/,
+		/adapter: adapterWorkspaceId && !preparationReservation \? runtimeAdapterName : null/,
 	);
 	assert.match(
 		createSource,
-		/adapter_create_pending: adapterWorkspaceId && !sideEffectReservation \? 1 : 0/,
+		/adapter_create_pending: adapterWorkspaceId && !preparationReservation \? 1 : 0/,
 	);
-	assert.match(createSource, /preparation_pending: sideEffectReservation \? 1 : 0/);
+	assert.match(
+		createSource,
+		/const preparationReservation = Boolean\(options\.afterReserve \|\| supervisedRootSessionId\)/,
+	);
+	assert.match(createSource, /preparation_pending: preparationReservation \? 1 : 0/);
 	assert.ok(
 		createSource.indexOf("enforceOpenClawRoomSessionLimitAfterInsert") <
 			createSource.indexOf("await options.afterReserve"),

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -178,7 +178,7 @@ test("interactive lineage rejects caller-claimed roots without a parent", async 
 	);
 });
 
-test("OpenClaw room capacity rolls back before event recording or provisioning", async () => {
+test("OpenClaw room reservation precedes branch mutation, event recording, and provisioning", async () => {
 	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
 	const capacityStart = source.indexOf("async function enforceOpenClawRoomSessionLimitAfterInsert");
 	const capacityEnd = source.indexOf("function openClawCrabboxResponse", capacityStart);
@@ -195,10 +195,18 @@ test("OpenClaw room capacity rolls back before event recording or provisioning",
 	);
 	assert.ok(
 		createSource.indexOf("enforceOpenClawRoomSessionLimitAfterInsert") <
+			createSource.indexOf("options.afterReserve"),
+	);
+	assert.ok(
+		createSource.indexOf("options.afterReserve") <
 			createSource.indexOf("appendInteractiveSessionEvent"),
 	);
 	assert.ok(
-		createSource.indexOf("enforceOpenClawRoomSessionLimitAfterInsert") <
+		createSource.indexOf("options.afterReserve") <
 			createSource.indexOf("provisionInteractiveSession"),
+	);
+	assert.match(
+		createSource,
+		/catch \(error\) \{\s+await rollbackInteractiveSessionReservation\(env, id, now\);\s+throw error;/,
 	);
 });

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -183,6 +183,9 @@ test("OpenClaw room reservation precedes branch mutation, event recording, and p
 	const capacityStart = source.indexOf("async function enforceOpenClawRoomSessionLimitAfterInsert");
 	const capacityEnd = source.indexOf("function openClawCrabboxResponse", capacityStart);
 	const capacitySource = source.slice(capacityStart, capacityEnd);
+	const activationStart = source.indexOf("async function activateRuntimeAdapterReservation");
+	const activationEnd = source.indexOf("function openClawCrabboxResponse", activationStart);
+	const activationSource = source.slice(activationStart, activationEnd);
 	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
 	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
 	const createSource = source.slice(createStart, createEnd);
@@ -193,16 +196,32 @@ test("OpenClaw room reservation precedes branch mutation, event recording, and p
 		capacitySource,
 		/throw tooManyRequests\("session root reached the supervision limit"\)/,
 	);
-	assert.ok(
-		createSource.indexOf("enforceOpenClawRoomSessionLimitAfterInsert") <
-			createSource.indexOf("options.afterReserve"),
+	assert.match(activationSource, /adapter: runtimeAdapterName/);
+	assert.match(activationSource, /adapter_create_pending: 1/);
+	assert.match(activationSource, /\.where\("adapter", "is", null\)/);
+	assert.match(activationSource, /\.where\("adapter_create_pending", "=", 0\)/);
+	assert.match(
+		createSource,
+		/adapter: adapterWorkspaceId && !sideEffectReservation \? runtimeAdapterName : null/,
+	);
+	assert.match(
+		createSource,
+		/adapter_create_pending: adapterWorkspaceId && !sideEffectReservation \? 1 : 0/,
 	);
 	assert.ok(
-		createSource.indexOf("options.afterReserve") <
+		createSource.indexOf("enforceOpenClawRoomSessionLimitAfterInsert") <
+			createSource.indexOf("await options.afterReserve"),
+	);
+	assert.ok(
+		createSource.indexOf("await options.afterReserve") <
+			createSource.indexOf("activateRuntimeAdapterReservation"),
+	);
+	assert.ok(
+		createSource.indexOf("activateRuntimeAdapterReservation") <
 			createSource.indexOf("appendInteractiveSessionEvent"),
 	);
 	assert.ok(
-		createSource.indexOf("options.afterReserve") <
+		createSource.indexOf("await options.afterReserve") <
 			createSource.indexOf("provisionInteractiveSession"),
 	);
 	assert.match(

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -107,6 +107,7 @@ test("OpenClaw transcript reads a sentinel event before reporting completeness",
 	assert.match(transcriptSource, /limit: 241, newest: true/);
 	assert.match(transcriptSource, /const hasMoreEvents = eventWindow\.length > 240/);
 	assert.match(transcriptSource, /eventWindow\.slice\(1\)/);
+	assert.match(transcriptSource, /session: \{ \.\.\.response\.session, logs: \[\] \}/);
 	assert.match(
 		transcriptSource,
 		/transcript\.truncated \|\| hasMoreEvents \|\| eventCount > events\.length/,

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -239,6 +239,13 @@ test("OpenClaw room reservation precedes branch mutation, event recording, and p
 	assert.match(capacitySource, /inserted\.rowid AS inserted_rowid/);
 	assert.match(capacitySource, /candidate\.rowid <= inserted\.rowid/);
 	assert.match(capacitySource, /GROUP BY inserted\.rowid/);
+	assert.match(capacitySource, /openClawRoomReservationLineageAllowed/);
+	assert.match(capacitySource, /readOpenClawLineageSession\(env, insertedSessionId, 1\)/);
+	assert.match(capacitySource, /readOpenClawLineageSession\(env, rootSessionId, 0\)/);
+	assert.ok(
+		capacitySource.indexOf("openClawRoomReservationLineageAllowed") <
+			capacitySource.indexOf("inserted.rowid AS inserted_rowid"),
+	);
 	assert.match(capacitySource, /deleteFrom\("interactive_sessions"\)/);
 	assert.match(
 		capacitySource,

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
@@ -61,4 +62,18 @@ test("bounded transcript tails remain valid UTF-8 and report truncation", () => 
 		new TextEncoder().encode(boundedUtf8Tail("\u{1F600}\u{1F600}", 5).text).byteLength <= 5,
 	);
 	assert.equal(openClawTranscriptMaxBytes, 64 * 1024);
+});
+
+test("OpenClaw create preserves the already-decorated interactive session", async () => {
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const createStart = source.indexOf("async function openClawCreateCrabbox");
+	const createEnd = source.indexOf("async function openClawReadSessionRoot", createStart);
+	const createSource = source.slice(createStart, createEnd);
+	const responseStart = source.indexOf("function openClawDecoratedCrabboxResponse");
+	const responseEnd = source.indexOf("async function openClawRegisterActionSession", responseStart);
+	const responseSource = source.slice(responseStart, responseEnd);
+
+	assert.match(createSource, /return openClawDecoratedCrabboxResponse\(env, result\.session\)/);
+	assert.doesNotMatch(createSource, /openClawCrabboxResponse\(env, serviceUser, result\.session\)/);
+	assert.doesNotMatch(responseSource, /decorateInteractiveSession/);
 });

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -327,10 +327,13 @@ test("invalid descendants below an OpenClaw root fail closed before insertion", 
 	);
 	const lineageSource = source.slice(lineageStart, lineageEnd);
 
-	assert.match(lineageSource, /if \(openClawRoomRootAllowed\(root\)\)/);
 	assert.match(
 		lineageSource,
 		/if \(!parent \|\| !root\) throw badRequest\("session lineage not found"\)/,
+	);
+	assert.match(
+		lineageSource,
+		/if \(createdBy === "service:openclaw" \|\| openClawRoomRootAllowed\(root\)\)/,
 	);
 	assert.match(lineageSource, /throw badRequest\("invalid OpenClaw room lineage"\)/);
 });

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -146,7 +146,7 @@ test("OpenClaw transcript reads a sentinel event before reporting completeness",
 	);
 });
 
-test("OpenClaw root reads are filtered, capped, concurrent, and log-free", async () => {
+test("OpenClaw root reads are filtered, capped, D1-only, and log-free", async () => {
 	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
 	const readStart = source.indexOf("async function openClawReadSessionRoot");
 	const readEnd = source.indexOf("async function openClawReadCrabbox", readStart);
@@ -161,10 +161,29 @@ test("OpenClaw root reads are filtered, capped, concurrent, and log-free", async
 	assert.match(readSource, /\.where\("work_key", "is", null\)/);
 	assert.match(readSource, /\.where\("preparation_pending", "=", 0\)/);
 	assert.match(readSource, /\.limit\(openClawRoomMaxSessions \+ 1\)/);
-	assert.match(readSource, /mapWithConcurrency\(/);
+	assert.doesNotMatch(readSource, /readFreshInteractiveSession/);
+	assert.doesNotMatch(readSource, /mapWithConcurrency\(/);
 	assert.match(readSource, /openClawRoomSessionChainAllowed/);
 	assert.match(readSource, /openClawCrabboxSummaryResponse/);
 	assert.match(summarySource, /session: \{ \.\.\.response\.session, logs: \[\] \}/);
+});
+
+test("OpenClaw target authorization precedes targeted reconciliation", async () => {
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const scopedStart = source.indexOf("async function openClawRootScopedCrabbox");
+	const scopedEnd = source.indexOf("async function openClawReadSessionChain", scopedStart);
+	const scopedSource = source.slice(scopedStart, scopedEnd);
+	const chainStart = scopedEnd;
+	const chainEnd = source.indexOf("async function openClawSupervisedRootForCreate", chainStart);
+	const chainSource = source.slice(chainStart, chainEnd);
+
+	assert.ok(
+		scopedSource.indexOf("openClawRoomSessionChainAllowed") <
+			scopedSource.indexOf("readFreshInteractiveSession"),
+	);
+	assert.match(scopedSource, /const session = await readInteractiveSession/);
+	assert.match(scopedSource, /const root = await readInteractiveSession/);
+	assert.doesNotMatch(chainSource, /readFreshInteractiveSession/);
 });
 
 test("interactive lineage rejects caller-claimed roots without a parent", async () => {

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
 	boundedUtf8Tail,
 	openClawBranchPreparationCanDefer,
+	openClawGitBranchAllowed,
 	openClawGitHubRepoParts,
 	openClawRoomMaxSessions,
 	openClawRoomRootAllowed,
@@ -27,6 +28,17 @@ test("OpenClaw branch preparation defers masked control-plane permission failure
 	assert.equal(openClawBranchPreparationCanDefer(404), true);
 	assert.equal(openClawBranchPreparationCanDefer(401), false);
 	assert.equal(openClawBranchPreparationCanDefer(500), false);
+});
+
+test("OpenClaw GitHub branch writes reject lossy or invalid refs", () => {
+	assert.equal(openClawGitBranchAllowed("main"), true);
+	assert.equal(openClawGitBranchAllowed("feature/team-room"), true);
+	assert.equal(openClawGitBranchAllowed("x".repeat(120)), true);
+	assert.equal(openClawGitBranchAllowed("x".repeat(121)), false);
+	assert.equal(openClawGitBranchAllowed("feature/team-room "), false);
+	assert.equal(openClawGitBranchAllowed("feature//team-room"), false);
+	assert.equal(openClawGitBranchAllowed("feature/../team-room"), false);
+	assert.equal(openClawGitBranchAllowed("feature/team-room.lock"), false);
 });
 
 test("OpenClaw GitHub writes require one exact owner/name pair", () => {
@@ -123,6 +135,14 @@ test("OpenClaw create preserves the already-decorated interactive session", asyn
 	assert.match(createSource, /AbortSignal\.timeout\(openClawPreparationTimeoutMs\)/);
 	assert.match(createSource, /ensureOpenClawServiceBranch\([\s\S]*signal\)/);
 	assert.match(createSource, /if \(signal\.aborted\)/);
+	assert.match(createSource, /openClawServiceBranch\(body\.branch, "branch", "main"\)/);
+
+	const branchStart = source.indexOf("async function ensureOpenClawServiceBranch");
+	const branchEnd = source.indexOf("function actionWorkIdentifier", branchStart);
+	const branchSource = source.slice(branchStart, branchEnd);
+	assert.match(branchSource, /openClawServiceBranch\(branchInput, "branch", "main"\)/);
+	assert.match(branchSource, /openClawServiceBranch\(baseBranchInput, "baseBranch"\)/);
+	assert.doesNotMatch(branchSource, /clean\(branch/);
 });
 
 test("OpenClaw mutations persist request evidence before consequential work", async () => {

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -77,3 +77,23 @@ test("OpenClaw create preserves the already-decorated interactive session", asyn
 	assert.doesNotMatch(createSource, /openClawCrabboxResponse\(env, serviceUser, result\.session\)/);
 	assert.doesNotMatch(responseSource, /decorateInteractiveSession/);
 });
+
+test("OpenClaw mutations persist request evidence before consequential work", async () => {
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const messageStart = source.indexOf("async function openClawMessageCrabbox");
+	const messageEnd = source.indexOf("async function openClawMutateCrabbox", messageStart);
+	const messageSource = source.slice(messageStart, messageEnd);
+	const stopStart = messageEnd;
+	const stopEnd = source.indexOf("async function openClawRootScopedCrabbox", stopStart);
+	const stopSource = source.slice(stopStart, stopEnd);
+
+	assert.ok(
+		messageSource.indexOf("OpenClaw service nudge requested") <
+			messageSource.indexOf("openInteractiveTerminalUpstream"),
+	);
+	assert.match(messageSource, /Promise\.allSettled/);
+	assert.ok(
+		stopSource.indexOf("openclaw crabbox stop requested") <
+			stopSource.indexOf("mutateInteractiveSession"),
+	);
+});

--- a/tests/runtime-adapter.test.ts
+++ b/tests/runtime-adapter.test.ts
@@ -3,2294 +3,2297 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
-	adapterFailureReleaseState,
-	adapterWorkspaceIdMatches,
-	clearedAdapterCapabilities,
-	createOnlyAdapterStatus,
-	definitiveRuntimeAdapterCreateFailure,
-	effectiveAdapterCapabilities,
-	currentAdapterDesktopConnection,
-	legacyLeaseIdForAdapter,
-	namespacedAdapterWorkspaceId,
-	normalizeAdapterNamespace,
-	normalizeAdapterWorkspaceId,
-	parseAdapterDesktopConnection,
-	parseAdapterWorkspaceResult,
-	redactedAdapterMessage,
-	redactedAdapterResponseMessage,
-	runtimeAdapterControlPlaneForProfile,
-	runtimeAdapterControlPlaneIdentity,
-	runtimeAdapterCreatePayload,
-	runtimeAdapterBrowserVncUrl,
-	runtimeAdapterDesktopUrl,
-	runtimeAdapterReplayRequest,
-	retainedRuntimeAdapterFailureMessage,
-	runtimeAdapterStopOutcome,
-	runtimeAdapterTerminalFailureStatus,
-	runtimeAdapterTerminalOriginMatches,
-	runtimeAdapterWorkspaceIdConflict,
-	runtimeAdapterWorkspaceUrl,
-	resolveCreateAfterStopRace,
-	safeDesktopUrl,
-	safeWebSocketUrl,
-	shouldReplayRuntimeAdapterCreate,
-	validatedRuntimeAdapterCreatePayloadJson,
+  adapterFailureReleaseState,
+  adapterWorkspaceIdMatches,
+  clearedAdapterCapabilities,
+  createOnlyAdapterStatus,
+  definitiveRuntimeAdapterCreateFailure,
+  effectiveAdapterCapabilities,
+  currentAdapterDesktopConnection,
+  legacyLeaseIdForAdapter,
+  namespacedAdapterWorkspaceId,
+  normalizeAdapterNamespace,
+  normalizeAdapterWorkspaceId,
+  parseAdapterDesktopConnection,
+  parseAdapterWorkspaceResult,
+  redactedAdapterMessage,
+  redactedAdapterResponseMessage,
+  runtimeAdapterControlPlaneForProfile,
+  runtimeAdapterControlPlaneIdentity,
+  runtimeAdapterCreatePayload,
+  runtimeAdapterBrowserVncUrl,
+  runtimeAdapterDesktopUrl,
+  runtimeAdapterReplayRequest,
+  retainedRuntimeAdapterFailureMessage,
+  runtimeAdapterStopOutcome,
+  runtimeAdapterTerminalFailureStatus,
+  runtimeAdapterTerminalOriginMatches,
+  runtimeAdapterWorkspaceIdConflict,
+  runtimeAdapterWorkspaceUrl,
+  resolveCreateAfterStopRace,
+  safeDesktopUrl,
+  safeWebSocketUrl,
+  shouldReplayRuntimeAdapterCreate,
+  validatedRuntimeAdapterCreatePayloadJson,
 } from "../src/runtime-adapter.ts";
 
 test("adapter create payload matches the strict controller contract", () => {
-	const payload = runtimeAdapterCreatePayload({
-		namespace: "fleet-a",
-		id: "IS-101",
-		parentSessionId: null,
-		rootSessionId: "IS-101",
-		repo: "example/project",
-		branch: "main",
-		runtime: "crabbox",
-		profile: "default",
-		command: "codex --yolo",
-		prompt: "investigate the failure",
-		purpose: "investigate",
-		summary: "starting",
-		owner: "operator",
-		createdBy: "operator",
-		ttlSeconds: 14_400,
-		idleTimeoutSeconds: 1_800,
-		desktop: true,
-	});
+  const payload = runtimeAdapterCreatePayload({
+    namespace: "fleet-a",
+    id: "IS-101",
+    parentSessionId: null,
+    rootSessionId: "IS-101",
+    repo: "example/project",
+    branch: "main",
+    runtime: "crabbox",
+    profile: "default",
+    command: "codex --yolo",
+    prompt: "investigate the failure",
+    purpose: "investigate",
+    summary: "starting",
+    owner: "operator",
+    createdBy: "operator",
+    ttlSeconds: 14_400,
+    idleTimeoutSeconds: 1_800,
+    desktop: true,
+  });
 
-	assert.deepEqual(payload, {
-		id: "fleet-a-is-101",
-		parentSessionId: null,
-		rootSessionId: "IS-101",
-		repo: "example/project",
-		branch: "main",
-		runtime: "crabbox",
-		profile: "default",
-		command: "codex --yolo",
-		prompt: "investigate the failure",
-		purpose: "investigate",
-		summary: "starting",
-		owner: "operator",
-		createdBy: "operator",
-		ttlSeconds: 14_400,
-		idleTimeoutSeconds: 1_800,
-		capabilities: { desktop: true },
-	});
-	assert.equal("apiVersion" in (payload ?? {}), false);
-	assert.equal("sessionId" in (payload ?? {}), false);
-	assert.equal("idempotencyKey" in (payload ?? {}), false);
-	assert.equal(
-		runtimeAdapterCreatePayload(
-			{
-				namespace: "different-config",
-				id: "IS-101",
-				parentSessionId: null,
-				rootSessionId: "IS-101",
-				repo: "example/project",
-				branch: "main",
-				runtime: "crabbox",
-				profile: "default",
-				command: "codex --yolo",
-				prompt: "investigate the failure",
-				purpose: "investigate",
-				summary: "starting",
-				owner: "operator",
-				createdBy: "operator",
-				ttlSeconds: 14_400,
-				idleTimeoutSeconds: 1_800,
-				desktop: true,
-			},
-			"fleet-a-is-101",
-		)?.id,
-		"fleet-a-is-101",
-	);
+  assert.deepEqual(payload, {
+    id: "fleet-a-is-101",
+    parentSessionId: null,
+    rootSessionId: "IS-101",
+    repo: "example/project",
+    branch: "main",
+    runtime: "crabbox",
+    profile: "default",
+    command: "codex --yolo",
+    prompt: "investigate the failure",
+    purpose: "investigate",
+    summary: "starting",
+    owner: "operator",
+    createdBy: "operator",
+    ttlSeconds: 14_400,
+    idleTimeoutSeconds: 1_800,
+    capabilities: { desktop: true },
+  });
+  assert.equal("apiVersion" in (payload ?? {}), false);
+  assert.equal("sessionId" in (payload ?? {}), false);
+  assert.equal("idempotencyKey" in (payload ?? {}), false);
+  assert.equal(
+    runtimeAdapterCreatePayload(
+      {
+        namespace: "different-config",
+        id: "IS-101",
+        parentSessionId: null,
+        rootSessionId: "IS-101",
+        repo: "example/project",
+        branch: "main",
+        runtime: "crabbox",
+        profile: "default",
+        command: "codex --yolo",
+        prompt: "investigate the failure",
+        purpose: "investigate",
+        summary: "starting",
+        owner: "operator",
+        createdBy: "operator",
+        ttlSeconds: 14_400,
+        idleTimeoutSeconds: 1_800,
+        desktop: true,
+      },
+      "fleet-a-is-101",
+    )?.id,
+    "fleet-a-is-101",
+  );
 });
 
 test("configured profiles fence every adapter runtime and preserve requested capabilities", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
-	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
-	const createSource = source.slice(createStart, createEnd);
-	const profileStart = source.indexOf("function selectedRuntimeProfile");
-	const profileEnd = source.indexOf("function publicDeploymentConfig", profileStart);
-	const profileSource = source.slice(profileStart, profileEnd);
-	const resultStart = source.indexOf("function runtimeAdapterProvisionResult");
-	const resultEnd = source.indexOf(
-		"async function reconcileStoppingRuntimeAdapterWorkspace",
-		resultStart,
-	);
-	const resultSource = source.slice(resultStart, resultEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const createStart = source.indexOf("async function createInteractiveSessionFromInput");
+  const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
+  const createSource = source.slice(createStart, createEnd);
+  const profileStart = source.indexOf("function selectedRuntimeProfile");
+  const profileEnd = source.indexOf("function publicDeploymentConfig", profileStart);
+  const profileSource = source.slice(profileStart, profileEnd);
+  const resultStart = source.indexOf("function runtimeAdapterProvisionResult");
+  const resultEnd = source.indexOf(
+    "async function reconcileStoppingRuntimeAdapterWorkspace",
+    resultStart,
+  );
+  const resultSource = source.slice(resultStart, resultEnd);
 
-	assert.match(createSource, /selectedRuntimeProfile\(deployment, body\.profile\)/);
-	assert.match(profileSource, /deployment\.runtimeProfiles\.length > 0 && !descriptor/);
-	assert.match(resultSource, /session\.adapterRequestedCapabilities \?\?/);
-	assert.match(resultSource, /profile: session\.profile/);
-	assert.doesNotMatch(resultSource, /profile: result\.profile/);
+  assert.match(createSource, /selectedRuntimeProfile\(deployment, body\.profile\)/);
+  assert.match(profileSource, /deployment\.runtimeProfiles\.length > 0 && !descriptor/);
+  assert.match(resultSource, /session\.adapterRequestedCapabilities \?\?/);
+  assert.match(resultSource, /profile: session\.profile/);
+  assert.doesNotMatch(resultSource, /profile: result\.profile/);
 });
 
 test("profile-routed adapter responses cannot rewrite their lifecycle route", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const createStart = source.indexOf("async function provisionWithRuntimeAdapter");
-	const createEnd = source.indexOf("function persistedRuntimeAdapterSeconds", createStart);
-	const createSource = source.slice(createStart, createEnd);
-	const inspectStart = source.indexOf("async function inspectRuntimeAdapterWorkspace");
-	const inspectEnd = source.indexOf(
-		"async function reconcileStoppingRuntimeAdapterWorkspace",
-		inspectStart,
-	);
-	const inspectSource = source.slice(inspectStart, inspectEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const createStart = source.indexOf("async function provisionWithRuntimeAdapter");
+  const createEnd = source.indexOf("function persistedRuntimeAdapterSeconds", createStart);
+  const createSource = source.slice(createStart, createEnd);
+  const inspectStart = source.indexOf("async function inspectRuntimeAdapterWorkspace");
+  const inspectEnd = source.indexOf(
+    "async function reconcileStoppingRuntimeAdapterWorkspace",
+    inspectStart,
+  );
+  const inspectSource = source.slice(inspectStart, inspectEnd);
 
-	assert.match(createSource, /parsed\.profile !== session\.profile/);
-	assert.match(createSource, /workspace profile mismatch/);
-	assert.match(inspectSource, /parsed\.profile !== session\.profile/);
-	assert.match(inspectSource, /different workspace profile/);
+  assert.match(createSource, /parsed\.profile !== session\.profile/);
+  assert.match(createSource, /workspace profile mismatch/);
+  assert.match(inspectSource, /parsed\.profile !== session\.profile/);
+  assert.match(inspectSource, /different workspace profile/);
 });
 
 test("adapter workspace id stays distinct from provider resource id", () => {
-	const result = parseAdapterWorkspaceResult({
-		id: "fleet-a-is-101",
-		providerResourceId: "cloud/project/box-42",
-		status: "ready",
-		attachUrl: "wss://controller.example/terminal/is-101",
-		capabilities: {
-			terminal: true,
-			takeover: false,
-			vnc: true,
-			desktop: true,
-			logs: false,
-			artifacts: false,
-			browser: true,
-			code: true,
-		},
-		expiresAt: "2026-06-12T12:00:00Z",
-		message: "cloud/project/box-42 is ready as fleet-a-is-101",
-	});
+  const result = parseAdapterWorkspaceResult({
+    id: "fleet-a-is-101",
+    providerResourceId: "cloud/project/box-42",
+    status: "ready",
+    attachUrl: "wss://controller.example/terminal/is-101",
+    capabilities: {
+      terminal: true,
+      takeover: false,
+      vnc: true,
+      desktop: true,
+      logs: false,
+      artifacts: false,
+      browser: true,
+      code: true,
+    },
+    expiresAt: "2026-06-12T12:00:00Z",
+    message: "cloud/project/box-42 is ready as fleet-a-is-101",
+  });
 
-	assert.equal(result?.workspaceId, "fleet-a-is-101");
-	assert.equal(result?.providerResourceId, "cloud/project/box-42");
-	assert.equal(result?.terminalUrl, "wss://controller.example/terminal/is-101");
-	assert.equal(result?.terminalUrlPresent, true);
-	assert.equal(result?.capabilities?.terminal, true);
-	assert.equal(result?.capabilities?.desktop, true);
-	assert.equal(result?.capabilities?.vnc, true);
-	assert.equal(result?.terminalCapabilityInferred, false);
-	assert.equal(result?.message, "[workspace] is ready as [workspace]");
-	assert.deepEqual(
-		effectiveAdapterCapabilities(
-			result!,
-			{
-				...clearedAdapterCapabilities,
-				takeover: true,
-				logs: true,
-				artifacts: true,
-			},
-			false,
-		),
-		{
-			terminal: true,
-			takeover: false,
-			vnc: true,
-			desktop: true,
-			logs: false,
-			artifacts: false,
-		},
-	);
+  assert.equal(result?.workspaceId, "fleet-a-is-101");
+  assert.equal(result?.providerResourceId, "cloud/project/box-42");
+  assert.equal(result?.terminalUrl, "wss://controller.example/terminal/is-101");
+  assert.equal(result?.terminalUrlPresent, true);
+  assert.equal(result?.capabilities?.terminal, true);
+  assert.equal(result?.capabilities?.desktop, true);
+  assert.equal(result?.capabilities?.vnc, true);
+  assert.equal(result?.terminalCapabilityInferred, false);
+  assert.equal(result?.message, "[workspace] is ready as [workspace]");
+  assert.deepEqual(
+    effectiveAdapterCapabilities(
+      result!,
+      {
+        ...clearedAdapterCapabilities,
+        takeover: true,
+        logs: true,
+        artifacts: true,
+      },
+      false,
+    ),
+    {
+      terminal: true,
+      takeover: false,
+      vnc: true,
+      desktop: true,
+      logs: false,
+      artifacts: false,
+    },
+  );
 
-	const explicitlyDisabled = parseAdapterWorkspaceResult({
-		id: "fleet-a-is-102",
-		status: "ready",
-		attachUrl: "wss://controller.example/terminal/is-102",
-		capabilities: { terminal: false, desktop: true },
-	});
-	assert.equal(explicitlyDisabled?.capabilities?.terminal, false);
-	assert.equal(explicitlyDisabled?.terminalCapabilityInferred, false);
-	assert.equal(
-		effectiveAdapterCapabilities(
-			explicitlyDisabled!,
-			{ ...clearedAdapterCapabilities, terminal: true, takeover: true, artifacts: true },
-			true,
-		)?.terminal,
-		false,
-	);
+  const explicitlyDisabled = parseAdapterWorkspaceResult({
+    id: "fleet-a-is-102",
+    status: "ready",
+    attachUrl: "wss://controller.example/terminal/is-102",
+    capabilities: { terminal: false, desktop: true },
+  });
+  assert.equal(explicitlyDisabled?.capabilities?.terminal, false);
+  assert.equal(explicitlyDisabled?.terminalCapabilityInferred, false);
+  assert.equal(
+    effectiveAdapterCapabilities(
+      explicitlyDisabled!,
+      { ...clearedAdapterCapabilities, terminal: true, takeover: true, artifacts: true },
+      true,
+    )?.terminal,
+    false,
+  );
 
-	const explicitlyNull = parseAdapterWorkspaceResult({
-		id: "fleet-a-is-102-null",
-		status: "ready",
-		attachUrl: "wss://controller.example/terminal/is-102-null",
-		capabilities: { terminal: null, desktop: true },
-	});
-	assert.equal(explicitlyNull?.capabilities?.terminal, false);
-	assert.equal(explicitlyNull?.terminalCapabilityInferred, false);
-	assert.equal(
-		effectiveAdapterCapabilities(
-			explicitlyNull!,
-			{ ...clearedAdapterCapabilities, terminal: true, artifacts: true },
-			false,
-		)?.terminal,
-		false,
-	);
+  const explicitlyNull = parseAdapterWorkspaceResult({
+    id: "fleet-a-is-102-null",
+    status: "ready",
+    attachUrl: "wss://controller.example/terminal/is-102-null",
+    capabilities: { terminal: null, desktop: true },
+  });
+  assert.equal(explicitlyNull?.capabilities?.terminal, false);
+  assert.equal(explicitlyNull?.terminalCapabilityInferred, false);
+  assert.equal(
+    effectiveAdapterCapabilities(
+      explicitlyNull!,
+      { ...clearedAdapterCapabilities, terminal: true, artifacts: true },
+      false,
+    )?.terminal,
+    false,
+  );
 
-	const authoritativeList = parseAdapterWorkspaceResult({
-		id: "fleet-a-is-103",
-		status: "ready",
-		attachUrl: "wss://controller.example/terminal/is-103",
-		capabilities: ["desktop"],
-	});
-	assert.equal(authoritativeList?.capabilities?.terminal, false);
-	assert.equal(authoritativeList?.terminalCapabilityInferred, false);
+  const authoritativeList = parseAdapterWorkspaceResult({
+    id: "fleet-a-is-103",
+    status: "ready",
+    attachUrl: "wss://controller.example/terminal/is-103",
+    capabilities: ["desktop"],
+  });
+  assert.equal(authoritativeList?.capabilities?.terminal, false);
+  assert.equal(authoritativeList?.terminalCapabilityInferred, false);
 
-	const omittedCapabilities = parseAdapterWorkspaceResult({
-		id: "fleet-a-is-104",
-		status: "ready",
-		attachUrl: "wss://controller.example/terminal/is-104",
-	});
-	assert.equal(omittedCapabilities?.capabilitiesPresent, false);
-	assert.equal(omittedCapabilities?.terminalCapabilityInferred, true);
-	assert.equal(omittedCapabilities?.capabilities, null);
-	assert.deepEqual(
-		effectiveAdapterCapabilities(
-			omittedCapabilities!,
-			{ ...clearedAdapterCapabilities, desktop: true, vnc: true, logs: true, artifacts: true },
-			false,
-		),
-		{
-			...clearedAdapterCapabilities,
-			terminal: true,
-			desktop: true,
-			vnc: true,
-			logs: true,
-			artifacts: true,
-		},
-	);
+  const omittedCapabilities = parseAdapterWorkspaceResult({
+    id: "fleet-a-is-104",
+    status: "ready",
+    attachUrl: "wss://controller.example/terminal/is-104",
+  });
+  assert.equal(omittedCapabilities?.capabilitiesPresent, false);
+  assert.equal(omittedCapabilities?.terminalCapabilityInferred, true);
+  assert.equal(omittedCapabilities?.capabilities, null);
+  assert.deepEqual(
+    effectiveAdapterCapabilities(
+      omittedCapabilities!,
+      { ...clearedAdapterCapabilities, desktop: true, vnc: true, logs: true, artifacts: true },
+      false,
+    ),
+    {
+      ...clearedAdapterCapabilities,
+      terminal: true,
+      desktop: true,
+      vnc: true,
+      logs: true,
+      artifacts: true,
+    },
+  );
 
-	const overlapping = parseAdapterWorkspaceResult({
-		id: "fleet-a-is-101",
-		providerResourceId: "fleet-a-is-101-provider-suffix",
-		status: "ready",
-		message: "fleet-a-is-101-provider-suffix is ready for fleet-a-is-101",
-	});
-	assert.equal(overlapping?.message, "[workspace] is ready for [workspace]");
+  const overlapping = parseAdapterWorkspaceResult({
+    id: "fleet-a-is-101",
+    providerResourceId: "fleet-a-is-101-provider-suffix",
+    status: "ready",
+    message: "fleet-a-is-101-provider-suffix is ready for fleet-a-is-101",
+  });
+  assert.equal(overlapping?.message, "[workspace] is ready for [workspace]");
 });
 
 test("adapter workspace identity is namespaced, bounded, and exact", () => {
-	assert.equal(normalizeAdapterNamespace("Fleet-A"), "fleet-a");
-	assert.equal(normalizeAdapterNamespace("fleet_a"), null);
-	assert.equal(namespacedAdapterWorkspaceId("Fleet-A", "IS-101"), "fleet-a-is-101");
-	assert.equal(namespacedAdapterWorkspaceId("a".repeat(32), "b".repeat(31)), null);
+  assert.equal(normalizeAdapterNamespace("Fleet-A"), "fleet-a");
+  assert.equal(normalizeAdapterNamespace("fleet_a"), null);
+  assert.equal(namespacedAdapterWorkspaceId("Fleet-A", "IS-101"), "fleet-a-is-101");
+  assert.equal(namespacedAdapterWorkspaceId("a".repeat(32), "b".repeat(31)), null);
 
-	const exact = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "ready" });
-	const wrong = parseAdapterWorkspaceResult({ id: "fleet-b-is-101", status: "ready" });
-	const missing = parseAdapterWorkspaceResult(
-		{ status: "ready" },
-		{ workspaceId: "fleet-a-is-101" },
-	);
-	assert.equal(adapterWorkspaceIdMatches(exact!, "fleet-a-is-101"), true);
-	assert.equal(adapterWorkspaceIdMatches(wrong!, "fleet-a-is-101"), false);
-	assert.equal(adapterWorkspaceIdMatches(missing!, "fleet-a-is-101"), false);
-	assert.equal(exact?.providerResourceId, null);
-	assert.equal(parseAdapterWorkspaceResult({ id: " fleet-a-is-101", status: "ready" }), null);
-	assert.equal(parseAdapterWorkspaceResult({ id: "Fleet-A-Is-101", status: "ready" }), null);
-	assert.equal(
-		parseAdapterWorkspaceResult({
-			id: "fleet-a-is-101",
-			workspaceId: "fleet-a-is-102",
-			status: "ready",
-		}),
-		null,
-	);
+  const exact = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "ready" });
+  const wrong = parseAdapterWorkspaceResult({ id: "fleet-b-is-101", status: "ready" });
+  const missing = parseAdapterWorkspaceResult(
+    { status: "ready" },
+    { workspaceId: "fleet-a-is-101" },
+  );
+  assert.equal(adapterWorkspaceIdMatches(exact!, "fleet-a-is-101"), true);
+  assert.equal(adapterWorkspaceIdMatches(wrong!, "fleet-a-is-101"), false);
+  assert.equal(adapterWorkspaceIdMatches(missing!, "fleet-a-is-101"), false);
+  assert.equal(exact?.providerResourceId, null);
+  assert.equal(parseAdapterWorkspaceResult({ id: " fleet-a-is-101", status: "ready" }), null);
+  assert.equal(parseAdapterWorkspaceResult({ id: "Fleet-A-Is-101", status: "ready" }), null);
+  assert.equal(
+    parseAdapterWorkspaceResult({
+      id: "fleet-a-is-101",
+      workspaceId: "fleet-a-is-102",
+      status: "ready",
+    }),
+    null,
+  );
 });
 
 test("create-only adapters cannot return an unowned stopping lifecycle", () => {
-	assert.equal(createOnlyAdapterStatus("ready"), "ready");
-	assert.equal(createOnlyAdapterStatus("failed"), "failed");
-	assert.equal(createOnlyAdapterStatus("stopping"), null);
-	assert.equal(createOnlyAdapterStatus(" ready "), null);
+  assert.equal(createOnlyAdapterStatus("ready"), "ready");
+  assert.equal(createOnlyAdapterStatus("failed"), "failed");
+  assert.equal(createOnlyAdapterStatus("stopping"), null);
+  assert.equal(createOnlyAdapterStatus(" ready "), null);
 });
 
 test("status-only inspect preserves omitted capability and expiry fields", () => {
-	const omitted = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "ready" });
-	assert.equal(omitted?.capabilitiesPresent, false);
-	assert.equal(omitted?.capabilities, null);
-	assert.equal(omitted?.expiresAtPresent, false);
-	assert.equal(omitted?.expiresAt, null);
-	assert.equal(omitted?.terminalUrlPresent, false);
+  const omitted = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "ready" });
+  assert.equal(omitted?.capabilitiesPresent, false);
+  assert.equal(omitted?.capabilities, null);
+  assert.equal(omitted?.expiresAtPresent, false);
+  assert.equal(omitted?.expiresAt, null);
+  assert.equal(omitted?.terminalUrlPresent, false);
 
-	const cleared = parseAdapterWorkspaceResult({
-		id: "fleet-a-is-101",
-		status: "ready",
-		capabilities: null,
-		expiresAt: null,
-		attachUrl: null,
-	});
-	assert.equal(cleared?.capabilitiesPresent, true);
-	assert.equal(cleared?.capabilities, null);
-	assert.equal(cleared?.expiresAtPresent, true);
-	assert.equal(cleared?.expiresAt, null);
-	assert.equal(cleared?.terminalUrlPresent, true);
-	assert.equal(cleared?.terminalUrl, null);
-	assert.equal(
-		parseAdapterWorkspaceResult({
-			id: "fleet-a-is-101",
-			status: "ready",
-			expiresAt: "not-a-date",
-		}),
-		null,
-	);
-	assert.equal(
-		parseAdapterWorkspaceResult({
-			id: "fleet-a-is-101",
-			status: "ready",
-			expiresAt: "",
-		}),
-		null,
-	);
-	assert.deepEqual(clearedAdapterCapabilities, {
-		terminal: false,
-		takeover: false,
-		vnc: false,
-		desktop: false,
-		logs: false,
-		artifacts: false,
-	});
-	assert.deepEqual(
-		effectiveAdapterCapabilities(
-			cleared!,
-			{ ...clearedAdapterCapabilities, vnc: true, desktop: true },
-			true,
-		),
-		clearedAdapterCapabilities,
-	);
-	assert.equal(
-		effectiveAdapterCapabilities(omitted!, clearedAdapterCapabilities, false),
-		undefined,
-	);
+  const cleared = parseAdapterWorkspaceResult({
+    id: "fleet-a-is-101",
+    status: "ready",
+    capabilities: null,
+    expiresAt: null,
+    attachUrl: null,
+  });
+  assert.equal(cleared?.capabilitiesPresent, true);
+  assert.equal(cleared?.capabilities, null);
+  assert.equal(cleared?.expiresAtPresent, true);
+  assert.equal(cleared?.expiresAt, null);
+  assert.equal(cleared?.terminalUrlPresent, true);
+  assert.equal(cleared?.terminalUrl, null);
+  assert.equal(
+    parseAdapterWorkspaceResult({
+      id: "fleet-a-is-101",
+      status: "ready",
+      expiresAt: "not-a-date",
+    }),
+    null,
+  );
+  assert.equal(
+    parseAdapterWorkspaceResult({
+      id: "fleet-a-is-101",
+      status: "ready",
+      expiresAt: "",
+    }),
+    null,
+  );
+  assert.deepEqual(clearedAdapterCapabilities, {
+    terminal: false,
+    takeover: false,
+    vnc: false,
+    desktop: false,
+    logs: false,
+    artifacts: false,
+  });
+  assert.deepEqual(
+    effectiveAdapterCapabilities(
+      cleared!,
+      { ...clearedAdapterCapabilities, vnc: true, desktop: true },
+      true,
+    ),
+    clearedAdapterCapabilities,
+  );
+  assert.equal(
+    effectiveAdapterCapabilities(omitted!, clearedAdapterCapabilities, false),
+    undefined,
+  );
 });
 
 test("missing ambiguous workspaces replay the complete persisted request", () => {
-	const createPayloadJson = JSON.stringify({
-		id: "fleet-a-is-101",
-		purpose: "immutable original purpose",
-		summary: "immutable original summary",
-		profile: "desktop-large",
-		ttlSeconds: 14_400,
-		idleTimeoutSeconds: 1_800,
-		capabilities: { desktop: true },
-	});
-	const request = runtimeAdapterReplayRequest({
-		id: "IS-101",
-		adapter_workspace_id: "fleet-a-is-101",
-		adapter_control_plane: "https://controller.example/api",
-		parent_session_id: "IS-100",
-		root_session_id: "IS-99",
-		repo: "example/project",
-		branch: "feature/retry",
-		runtime: "crabbox",
-		profile: "desktop-large",
-		command: "codex --yolo",
-		prompt: "continue after timeout",
-		purpose: "repair create",
-		summary: "create outcome unknown",
-		owner: "operator",
-		created_by: "service",
-		adapter_ttl_seconds: 14_400,
-		adapter_idle_timeout_seconds: 1_800,
-		adapter_requested_capabilities_json: JSON.stringify({
-			terminal: true,
-			takeover: true,
-			vnc: true,
-			desktop: true,
-			logs: true,
-			artifacts: true,
-		}),
-		adapter_create_payload_json: createPayloadJson,
-	});
+  const createPayloadJson = JSON.stringify({
+    id: "fleet-a-is-101",
+    purpose: "immutable original purpose",
+    summary: "immutable original summary",
+    profile: "desktop-large",
+    ttlSeconds: 14_400,
+    idleTimeoutSeconds: 1_800,
+    capabilities: { desktop: true },
+  });
+  const request = runtimeAdapterReplayRequest({
+    id: "IS-101",
+    adapter_workspace_id: "fleet-a-is-101",
+    adapter_control_plane: "https://controller.example/api",
+    parent_session_id: "IS-100",
+    root_session_id: "IS-99",
+    repo: "example/project",
+    branch: "feature/retry",
+    runtime: "crabbox",
+    profile: "desktop-large",
+    command: "codex --yolo",
+    prompt: "continue after timeout",
+    purpose: "repair create",
+    summary: "create outcome unknown",
+    owner: "operator",
+    created_by: "service",
+    adapter_ttl_seconds: 14_400,
+    adapter_idle_timeout_seconds: 1_800,
+    adapter_requested_capabilities_json: JSON.stringify({
+      terminal: true,
+      takeover: true,
+      vnc: true,
+      desktop: true,
+      logs: true,
+      artifacts: true,
+    }),
+    adapter_create_payload_json: createPayloadJson,
+  });
 
-	assert.deepEqual(request, {
-		id: "IS-101",
-		adapterWorkspaceId: "fleet-a-is-101",
-		adapterControlPlane: "https://controller.example/api",
-		parentSessionId: "IS-100",
-		rootSessionId: "IS-99",
-		repo: "example/project",
-		branch: "feature/retry",
-		runtime: "crabbox",
-		profile: "desktop-large",
-		command: "codex --yolo",
-		prompt: "continue after timeout",
-		purpose: "repair create",
-		summary: "create outcome unknown",
-		owner: "operator",
-		createdBy: "service",
-		adapterTtlSeconds: 14_400,
-		adapterIdleTimeoutSeconds: 1_800,
-		adapterRequestedCapabilities: {
-			terminal: true,
-			takeover: true,
-			vnc: true,
-			desktop: true,
-			logs: true,
-			artifacts: true,
-		},
-		adapterCreatePayloadJson: createPayloadJson,
-	});
-	assert.equal(shouldReplayRuntimeAdapterCreate("provisioning", true), true);
-	assert.equal(shouldReplayRuntimeAdapterCreate("pending_adapter", true), true);
-	assert.equal(shouldReplayRuntimeAdapterCreate("provisioning", false), false);
-	assert.equal(shouldReplayRuntimeAdapterCreate("ready", true), false);
-	assert.equal(shouldReplayRuntimeAdapterCreate("stopping", true), false);
-	assert.equal(
-		validatedRuntimeAdapterCreatePayloadJson(createPayloadJson, {
-			workspaceId: "fleet-a-is-101",
-			ttlSeconds: 14_400,
-			idleTimeoutSeconds: 1_800,
-			desktop: true,
-		}),
-		createPayloadJson,
-	);
+  assert.deepEqual(request, {
+    id: "IS-101",
+    adapterWorkspaceId: "fleet-a-is-101",
+    adapterControlPlane: "https://controller.example/api",
+    parentSessionId: "IS-100",
+    rootSessionId: "IS-99",
+    repo: "example/project",
+    branch: "feature/retry",
+    runtime: "crabbox",
+    profile: "desktop-large",
+    command: "codex --yolo",
+    prompt: "continue after timeout",
+    purpose: "repair create",
+    summary: "create outcome unknown",
+    owner: "operator",
+    createdBy: "service",
+    adapterTtlSeconds: 14_400,
+    adapterIdleTimeoutSeconds: 1_800,
+    adapterRequestedCapabilities: {
+      terminal: true,
+      takeover: true,
+      vnc: true,
+      desktop: true,
+      logs: true,
+      artifacts: true,
+    },
+    adapterCreatePayloadJson: createPayloadJson,
+  });
+  assert.equal(shouldReplayRuntimeAdapterCreate("provisioning", true), true);
+  assert.equal(shouldReplayRuntimeAdapterCreate("pending_adapter", true), true);
+  assert.equal(shouldReplayRuntimeAdapterCreate("provisioning", false), false);
+  assert.equal(shouldReplayRuntimeAdapterCreate("ready", true), false);
+  assert.equal(shouldReplayRuntimeAdapterCreate("stopping", true), false);
+  assert.equal(
+    validatedRuntimeAdapterCreatePayloadJson(createPayloadJson, {
+      workspaceId: "fleet-a-is-101",
+      ttlSeconds: 14_400,
+      idleTimeoutSeconds: 1_800,
+      desktop: true,
+    }),
+    createPayloadJson,
+  );
 });
 
 test("failed adapter workspaces become terminal only after release", () => {
-	assert.deepEqual(adapterFailureReleaseState("stopping"), {
-		status: "stopping",
-		terminalStatus: "failed",
-		message: "runtime workspace release pending",
-	});
-	assert.deepEqual(adapterFailureReleaseState("stopped"), {
-		status: "failed",
-		terminalStatus: null,
-		message: "runtime workspace released",
-	});
+  assert.deepEqual(adapterFailureReleaseState("stopping"), {
+    status: "stopping",
+    terminalStatus: "failed",
+    message: "runtime workspace release pending",
+  });
+  assert.deepEqual(adapterFailureReleaseState("stopped"), {
+    status: "failed",
+    terminalStatus: null,
+    message: "runtime workspace released",
+  });
 });
 
 test("adapter failure release retains the actual failure reason", () => {
-	assert.equal(
-		retainedRuntimeAdapterFailureMessage(
-			"runtime adapter provision failed: HTTP 422",
-			"release transport failed",
-			"generic release text",
-		),
-		"runtime adapter provision failed: HTTP 422",
-	);
+  assert.equal(
+    retainedRuntimeAdapterFailureMessage(
+      "runtime adapter provision failed: HTTP 422",
+      "release transport failed",
+      "generic release text",
+    ),
+    "runtime adapter provision failed: HTTP 422",
+  );
 });
 
 test("runtime adapter terminal failures stay retryable until lifecycle release", () => {
-	assert.equal(runtimeAdapterTerminalFailureStatus("runtime-v1"), "detached");
-	assert.equal(runtimeAdapterTerminalFailureStatus("legacy"), "expired");
-	assert.equal(runtimeAdapterTerminalFailureStatus(null), "expired");
+  assert.equal(runtimeAdapterTerminalFailureStatus("runtime-v1"), "detached");
+  assert.equal(runtimeAdapterTerminalFailureStatus("legacy"), "expired");
+  assert.equal(runtimeAdapterTerminalFailureStatus(null), "expired");
 });
 
 test("runtime adapter provider identities never become legacy lease ids", () => {
-	assert.equal(legacyLeaseIdForAdapter("runtime-v1", "sandbox:provider-owned"), null);
-	assert.equal(legacyLeaseIdForAdapter("runtime-v1", "cloudflare:provider-owned"), null);
-	assert.equal(legacyLeaseIdForAdapter("legacy", "sandbox:legacy-owned"), "sandbox:legacy-owned");
+  assert.equal(legacyLeaseIdForAdapter("runtime-v1", "sandbox:provider-owned"), null);
+  assert.equal(legacyLeaseIdForAdapter("runtime-v1", "cloudflare:provider-owned"), null);
+  assert.equal(legacyLeaseIdForAdapter("legacy", "sandbox:legacy-owned"), "sandbox:legacy-owned");
 });
 
 test("confirmed stop races terminalize only after create ambiguity clears", () => {
-	assert.deepEqual(resolveCreateAfterStopRace(true, "failed"), {
-		status: "stopping",
-		terminalStatus: "failed",
-	});
-	assert.deepEqual(resolveCreateAfterStopRace(false, "failed"), {
-		status: "failed",
-		terminalStatus: null,
-	});
-	assert.deepEqual(resolveCreateAfterStopRace(false, null), {
-		status: "stopped",
-		terminalStatus: null,
-	});
+  assert.deepEqual(resolveCreateAfterStopRace(true, "failed"), {
+    status: "stopping",
+    terminalStatus: "failed",
+  });
+  assert.deepEqual(resolveCreateAfterStopRace(false, "failed"), {
+    status: "failed",
+    terminalStatus: null,
+  });
+  assert.deepEqual(resolveCreateAfterStopRace(false, null), {
+    status: "stopped",
+    terminalStatus: null,
+  });
 });
 
 test("runtime adapter lifecycle cannot escape durable session ownership", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const stopStart = source.indexOf("async function stopSupersededRuntimeAdapterProvision");
-	const stopEnd = source.indexOf("async function resolveInteractiveSessionLineage", stopStart);
-	const stopSource = source.slice(stopStart, stopEnd);
-	const reconcileStart = source.indexOf("async function reconcileExternalInteractiveSession(");
-	const reconcileEnd = source.indexOf("function reconciledInteractiveStatus", reconcileStart);
-	const reconcileSource = source.slice(reconcileStart, reconcileEnd);
-	const releaseStart = source.indexOf("async function releaseFailedRuntimeAdapterProvision");
-	const releaseEnd = source.indexOf("function runtimeAdapterProvisionResult", releaseStart);
-	const releaseSource = source.slice(releaseStart, releaseEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const stopStart = source.indexOf("async function stopSupersededRuntimeAdapterProvision");
+  const stopEnd = source.indexOf("async function resolveInteractiveSessionLineage", stopStart);
+  const stopSource = source.slice(stopStart, stopEnd);
+  const reconcileStart = source.indexOf("async function reconcileExternalInteractiveSession(");
+  const reconcileEnd = source.indexOf("function reconciledInteractiveStatus", reconcileStart);
+  const reconcileSource = source.slice(reconcileStart, reconcileEnd);
+  const releaseStart = source.indexOf("async function releaseFailedRuntimeAdapterProvision");
+  const releaseEnd = source.indexOf("function runtimeAdapterProvisionResult", releaseStart);
+  const releaseSource = source.slice(releaseStart, releaseEnd);
 
-	assert.match(
-		source,
-		/versioned runtime adapter requires a durable interactive session lifecycle/,
-	);
-	assert.match(stopSource, /recordConfirmedRuntimeAdapterRelease/);
-	assert.match(stopSource, /select\(\[[\s\S]*"adapter_create_pending"[\s\S]*"terminal_status"/);
-	assert.match(stopSource, /AND adapter_create_pending = \$\{lifecycle\.adapter_create_pending\}/);
-	assert.match(stopSource, /terminal_status IS NULL/);
-	assert.match(stopSource, /AND updated_at = \$\{lifecycle\.updated_at\}/);
-	assert.match(stopSource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
-	assert.match(stopSource, /env\.DB\.batch/);
-	assert.match(stopSource, /INSERT INTO interactive_session_events/);
-	assert.match(stopSource, /finalizeTerminalInteractiveSession/);
-	assert.match(stopSource, /terminal_finalize_pending: 1/);
-	assert.ok(
-		stopSource.indexOf("clearRuntimeAdapterCreatePending") <
-			stopSource.indexOf("const release = await stopRuntimeAdapterWorkspaceForSession"),
-	);
-	assert.ok(
-		releaseSource.indexOf("stageFailedRuntimeAdapterRelease") <
-			releaseSource.indexOf("stopRuntimeAdapterWorkspace"),
-	);
-	assert.match(releaseSource, /status: "stopping"/);
-	assert.match(releaseSource, /release\.message/);
-	assert.match(releaseSource, /pendingMessage/);
-	assert.match(releaseSource, /terminal_status: "failed"/);
-	assert.match(releaseSource, /adapter_create_pending: 0/);
-	assert.match(reconcileSource, /current\.stoppedAt \?\? now/);
-	assert.match(reconcileSource, /finalizeTerminalInteractiveSession/);
-	assert.match(source, /AND NOT EXISTS \(/);
-	assert.match(source, /archiveInteractiveSessionLogs\(env, id, now, \{ force: true \}\)/);
+  assert.match(
+    source,
+    /versioned runtime adapter requires a durable interactive session lifecycle/,
+  );
+  assert.match(stopSource, /recordConfirmedRuntimeAdapterRelease/);
+  assert.match(stopSource, /select\(\[[\s\S]*"adapter_create_pending"[\s\S]*"terminal_status"/);
+  assert.match(stopSource, /AND adapter_create_pending = \$\{lifecycle\.adapter_create_pending\}/);
+  assert.match(stopSource, /terminal_status IS NULL/);
+  assert.match(stopSource, /AND updated_at = \$\{lifecycle\.updated_at\}/);
+  assert.match(stopSource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
+  assert.match(stopSource, /env\.DB\.batch/);
+  assert.match(stopSource, /INSERT INTO interactive_session_events/);
+  assert.match(stopSource, /finalizeTerminalInteractiveSession/);
+  assert.match(stopSource, /terminal_finalize_pending: 1/);
+  assert.ok(
+    stopSource.indexOf("clearRuntimeAdapterCreatePending") <
+      stopSource.indexOf("const release = await stopRuntimeAdapterWorkspaceForSession"),
+  );
+  assert.ok(
+    releaseSource.indexOf("stageFailedRuntimeAdapterRelease") <
+      releaseSource.indexOf("stopRuntimeAdapterWorkspace"),
+  );
+  assert.match(releaseSource, /status: "stopping"/);
+  assert.match(releaseSource, /release\.message/);
+  assert.match(releaseSource, /pendingMessage/);
+  assert.match(releaseSource, /terminal_status: "failed"/);
+  assert.match(releaseSource, /adapter_create_pending: 0/);
+  assert.match(reconcileSource, /current\.stoppedAt \?\? now/);
+  assert.match(reconcileSource, /finalizeTerminalInteractiveSession/);
+  assert.match(source, /AND NOT EXISTS \(/);
+  assert.match(source, /archiveInteractiveSessionLogs\(env, id, now, \{ force: true \}\)/);
 });
 
 test("confirmed adapter failure release keeps the original failure evidence", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const migration = await readFile(
-		new URL("../migrations/0021_runtime_adapter_hardening.sql", import.meta.url),
-		"utf8",
-	);
-	const releaseStart = source.indexOf("async function recordConfirmedRuntimeAdapterRelease");
-	const releaseEnd = source.indexOf(
-		"async function clearRuntimeAdapterCreatePending",
-		releaseStart,
-	);
-	const releaseSource = source.slice(releaseStart, releaseEnd);
-	const finalizeStart = source.indexOf("async function finalizeTerminalInteractiveSession");
-	const finalizeEnd = source.indexOf("async function archiveInteractiveSessionLogs", finalizeStart);
-	const finalizeSource = source.slice(finalizeStart, finalizeEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const migration = await readFile(
+    new URL("../migrations/0021_runtime_adapter_hardening.sql", import.meta.url),
+    "utf8",
+  );
+  const releaseStart = source.indexOf("async function recordConfirmedRuntimeAdapterRelease");
+  const releaseEnd = source.indexOf(
+    "async function clearRuntimeAdapterCreatePending",
+    releaseStart,
+  );
+  const releaseSource = source.slice(releaseStart, releaseEnd);
+  const finalizeStart = source.indexOf("async function finalizeTerminalInteractiveSession");
+  const finalizeEnd = source.indexOf("async function archiveInteractiveSessionLogs", finalizeStart);
+  const finalizeSource = source.slice(finalizeStart, finalizeEnd);
 
-	assert.match(releaseSource, /"terminal_failure_reason"/);
-	assert.match(releaseSource, /retainedRuntimeAdapterFailureMessage/);
-	assert.match(
-		releaseSource,
-		/terminal_failure_reason: resolved\.status === "failed" \? failureMessage/,
-	);
-	assert.match(releaseSource, /reconcile_error: resolved\.status === "failed" \? failureMessage/);
-	assert.match(releaseSource, /\? failureMessage/);
-	assert.match(finalizeSource, /retainedRuntimeAdapterFailureMessage/);
-	assert.match(finalizeSource, /INSERT INTO interactive_session_events/);
-	assert.match(finalizeSource, /SELECT \$\{id\}, 'system', \$\{message\}/);
-	assert.match(migration, /ADD COLUMN terminal_failure_reason TEXT/);
+  assert.match(releaseSource, /"terminal_failure_reason"/);
+  assert.match(releaseSource, /retainedRuntimeAdapterFailureMessage/);
+  assert.match(
+    releaseSource,
+    /terminal_failure_reason: resolved\.status === "failed" \? failureMessage/,
+  );
+  assert.match(releaseSource, /reconcile_error: resolved\.status === "failed" \? failureMessage/);
+  assert.match(releaseSource, /\? failureMessage/);
+  assert.match(finalizeSource, /retainedRuntimeAdapterFailureMessage/);
+  assert.match(finalizeSource, /INSERT INTO interactive_session_events/);
+  assert.match(finalizeSource, /SELECT \$\{id\}, 'system', \$\{message\}/);
+  assert.match(migration, /ADD COLUMN terminal_failure_reason TEXT/);
 });
 
 test("terminal archive finalization remains durably retryable", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const migration = await readFile(
-		new URL("../migrations/0021_runtime_adapter_hardening.sql", import.meta.url),
-		"utf8",
-	);
-	const appendStart = source.indexOf("async function appendInteractiveSessionEvent");
-	const appendEnd = source.indexOf(
-		"async function finalizeTerminalInteractiveSession",
-		appendStart,
-	);
-	const appendSource = source.slice(appendStart, appendEnd);
-	const finalizeStart = source.indexOf("async function finalizeTerminalInteractiveSession");
-	const finalizeEnd = source.indexOf("async function archiveInteractiveSessionLogs", finalizeStart);
-	const finalizeSource = source.slice(finalizeStart, finalizeEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const migration = await readFile(
+    new URL("../migrations/0021_runtime_adapter_hardening.sql", import.meta.url),
+    "utf8",
+  );
+  const appendStart = source.indexOf("async function appendInteractiveSessionEvent");
+  const appendEnd = source.indexOf(
+    "async function finalizeTerminalInteractiveSession",
+    appendStart,
+  );
+  const appendSource = source.slice(appendStart, appendEnd);
+  const finalizeStart = source.indexOf("async function finalizeTerminalInteractiveSession");
+  const finalizeEnd = source.indexOf("async function archiveInteractiveSessionLogs", finalizeStart);
+  const finalizeSource = source.slice(finalizeStart, finalizeEnd);
 
-	assert.match(source, /expression\("terminal_finalize_pending", "=", 1\)/);
-	assert.match(source, /row\.terminal_finalize_pending === 1/);
-	assert.match(source, /const terminalCleanupDeletePending = 2/);
-	assert.match(source, /completeTerminalFinalization/);
-	assert.match(source, /SET terminal_finalize_pending = 0/);
-	assert.match(source, /interactive_session_log_archives\.events_key IS NULL/);
-	assert.match(source, /interactive_session_log_archives\.transcript_key IS NULL/);
-	assert.match(source, /interactive_session_log_archives\.summary_key IS NULL/);
-	assert.match(source, /archive\.session_updated_at = interactive_sessions\.updated_at/);
-	assert.match(
-		source,
-		/excluded\.session_updated_at > interactive_session_log_archives\.session_updated_at/,
-	);
-	assert.match(
-		source,
-		/excluded\.session_updated_at IS interactive_session_log_archives\.session_updated_at/,
-	);
-	assert.doesNotMatch(
-		source,
-		/session_updated_at IS NOT excluded\.session_updated_at[\s\S]*excluded\.updated_at >=/,
-	);
-	assert.match(appendSource, /executeBatch\(env, \[/);
-	assert.match(appendSource, /insertInto\("interactive_session_events"\)/);
-	assert.match(appendSource, /terminalFinalizationPendingQuery\(db, id\)/);
-	assert.match(finalizeSource, /executeBatch\(env, \[/);
-	assert.match(finalizeSource, /INSERT INTO interactive_session_events/);
-	assert.match(finalizeSource, /terminalFinalizationPendingQuery\(db, id\)/);
-	assert.match(migration, /ADD COLUMN terminal_finalize_pending INTEGER NOT NULL DEFAULT 0/);
-	assert.match(migration, /ADD COLUMN session_updated_at INTEGER/);
-	assert.match(migration, /status IN \('stopped', 'expired', 'failed'\)/);
+  assert.match(source, /expression\("terminal_finalize_pending", "=", 1\)/);
+  assert.match(source, /row\.terminal_finalize_pending === 1/);
+  assert.match(source, /const terminalCleanupDeletePending = 2/);
+  assert.match(source, /completeTerminalFinalization/);
+  assert.match(source, /SET terminal_finalize_pending = 0/);
+  assert.match(source, /interactive_session_log_archives\.events_key IS NULL/);
+  assert.match(source, /interactive_session_log_archives\.transcript_key IS NULL/);
+  assert.match(source, /interactive_session_log_archives\.summary_key IS NULL/);
+  assert.match(source, /archive\.session_updated_at = interactive_sessions\.updated_at/);
+  assert.match(
+    source,
+    /excluded\.session_updated_at > interactive_session_log_archives\.session_updated_at/,
+  );
+  assert.match(
+    source,
+    /excluded\.session_updated_at IS interactive_session_log_archives\.session_updated_at/,
+  );
+  assert.doesNotMatch(
+    source,
+    /session_updated_at IS NOT excluded\.session_updated_at[\s\S]*excluded\.updated_at >=/,
+  );
+  assert.match(appendSource, /executeBatch\(env, \[/);
+  assert.match(appendSource, /insertInto\("interactive_session_events"\)/);
+  assert.match(appendSource, /terminalFinalizationPendingQuery\(db, id\)/);
+  assert.match(finalizeSource, /executeBatch\(env, \[/);
+  assert.match(finalizeSource, /INSERT INTO interactive_session_events/);
+  assert.match(finalizeSource, /terminalFinalizationPendingQuery\(db, id\)/);
+  assert.match(migration, /ADD COLUMN terminal_finalize_pending INTEGER NOT NULL DEFAULT 0/);
+  assert.match(migration, /ADD COLUMN session_updated_at INTEGER/);
+  assert.match(migration, /status IN \('stopped', 'expired', 'failed'\)/);
 });
 
 test("enabling R2 requeues D1-only terminal archives for object backfill", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const backfillStart = source.indexOf("async function requeueTerminalArchiveObjectBackfill");
-	const batchStart = source.indexOf(
-		"async function reconcileExternalInteractiveSessionBatch",
-		backfillStart,
-	);
-	const targetedStart = source.indexOf(
-		"async function reconcileExternalInteractiveSessionById",
-		batchStart,
-	);
-	const reconcileStart = source.indexOf(
-		"async function reconcileExternalInteractiveSession(",
-		targetedStart,
-	);
-	const backfillSource = source.slice(backfillStart, batchStart);
-	const batchSource = source.slice(batchStart, targetedStart);
-	const targetedSource = source.slice(targetedStart, reconcileStart);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const backfillStart = source.indexOf("async function requeueTerminalArchiveObjectBackfill");
+  const batchStart = source.indexOf(
+    "async function reconcileExternalInteractiveSessionBatch",
+    backfillStart,
+  );
+  const targetedStart = source.indexOf(
+    "async function reconcileExternalInteractiveSessionById",
+    batchStart,
+  );
+  const reconcileStart = source.indexOf(
+    "async function reconcileExternalInteractiveSession(",
+    targetedStart,
+  );
+  const backfillSource = source.slice(backfillStart, batchStart);
+  const batchSource = source.slice(batchStart, targetedStart);
+  const targetedSource = source.slice(targetedStart, reconcileStart);
 
-	assert.match(backfillSource, /if \(!env\.SESSION_LOGS\) return/);
-	assert.match(backfillSource, /session\.terminal_finalize_pending = 0/);
-	assert.match(backfillSource, /archive\.events_key IS NULL/);
-	assert.match(backfillSource, /archive\.transcript_key IS NULL/);
-	assert.match(backfillSource, /archive\.summary_key IS NULL/);
-	assert.match(backfillSource, /SET terminal_finalize_pending = 1/);
-	assert.match(backfillSource, /last_reconciled_at = NULL/);
-	assert.match(batchSource, /await requeueTerminalArchiveObjectBackfill\(env\)/);
-	assert.match(targetedSource, /await requeueTerminalArchiveObjectBackfill\(env, id\)/);
+  assert.match(backfillSource, /if \(!env\.SESSION_LOGS\) return/);
+  assert.match(backfillSource, /session\.terminal_finalize_pending = 0/);
+  assert.match(backfillSource, /archive\.events_key IS NULL/);
+  assert.match(backfillSource, /archive\.transcript_key IS NULL/);
+  assert.match(backfillSource, /archive\.summary_key IS NULL/);
+  assert.match(backfillSource, /SET terminal_finalize_pending = 1/);
+  assert.match(backfillSource, /last_reconciled_at = NULL/);
+  assert.match(batchSource, /await requeueTerminalArchiveObjectBackfill\(env\)/);
+  assert.match(targetedSource, /await requeueTerminalArchiveObjectBackfill\(env, id\)/);
 });
 
 test("runtime reconciliation has scheduled and targeted lifecycle clocks", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const config = await readFile(new URL("../wrangler.jsonc", import.meta.url), "utf8");
-	const targetedStart = source.indexOf("async function reconcileExternalInteractiveSessionById");
-	const targetedEnd = source.indexOf(
-		"async function reconcileExternalInteractiveSession(",
-		targetedStart,
-	);
-	const targetedSource = source.slice(targetedStart, targetedEnd);
-	const batchStart = source.indexOf("async function reconcileExternalInteractiveSessionBatch");
-	const batchEnd = source.indexOf("async function reconcileExternalInteractiveSessionById");
-	const batchSource = source.slice(batchStart, batchEnd);
-	const reconcileStart = source.indexOf("async function reconcileExternalInteractiveSession(");
-	const reconcileEnd = source.indexOf("function reconciledInteractiveStatus", reconcileStart);
-	const reconcileSource = source.slice(reconcileStart, reconcileEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const config = await readFile(new URL("../wrangler.jsonc", import.meta.url), "utf8");
+  const targetedStart = source.indexOf("async function reconcileExternalInteractiveSessionById");
+  const targetedEnd = source.indexOf(
+    "async function reconcileExternalInteractiveSession(",
+    targetedStart,
+  );
+  const targetedSource = source.slice(targetedStart, targetedEnd);
+  const batchStart = source.indexOf("async function reconcileExternalInteractiveSessionBatch");
+  const batchEnd = source.indexOf("async function reconcileExternalInteractiveSessionById");
+  const batchSource = source.slice(batchStart, batchEnd);
+  const reconcileStart = source.indexOf("async function reconcileExternalInteractiveSession(");
+  const reconcileEnd = source.indexOf("function reconciledInteractiveStatus", reconcileStart);
+  const reconcileSource = source.slice(reconcileStart, reconcileEnd);
 
-	assert.match(source, /async scheduled\(/);
-	assert.match(source, /context\.waitUntil\(\s*reconcileInteractiveSessionLifecycleBatch/);
-	assert.match(config, /"crons": \["\* \* \* \* \*"\]/);
-	assert.match(batchSource, /expression\("terminal_finalize_pending", "=", 1\)/);
-	assert.match(batchSource, /expression\("adapter", "=", runtimeAdapterName\)/);
-	assert.match(targetedSource, /reconcileCredentialPolicyCleanupBatch\(env, now, id\)/);
-	assert.match(targetedSource, /row\.terminal_finalize_pending === 1/);
-	assert.match(targetedSource, /row\.adapter !== runtimeAdapterName/);
-	assert.match(targetedSource, /runtimeAdapterReconcileIntervalMs/);
-	assert.match(targetedSource, /reconcileExternalInteractiveSession\(env, row, now\)/);
-	assert.ok(
-		reconcileSource.indexOf("if (terminalFinalizationStatus)") <
-			reconcileSource.indexOf("inspectRuntimeAdapterWorkspace"),
-	);
-	assert.match(source, /async function readFreshInteractiveSession/);
-	assert.match(source, /async function interactiveSessionPty[\s\S]*readFreshInteractiveSession/);
-	assert.match(source, /async function interactiveSessionVnc[\s\S]*readFreshInteractiveSession/);
-	assert.match(source, /scheduled interactive session reconciliation failed/);
-	assert.match(
-		source,
-		/async function reconcileInteractiveSessionLifecycleBatch[\s\S]*reconcileCredentialPolicyCleanupBatch[\s\S]*reconcileExternalInteractiveSessionBatch/,
-	);
-	assert.match(reconcileSource, /const claimAt = Math\.max/);
-	assert.match(reconcileSource, /where\("updated_at", "=", row\.updated_at\)/);
-	assert.match(reconcileSource, /const completedAt = Math\.max\(Date\.now\(\), claimAt\)/);
-	assert.match(
-		reconcileSource,
-		/const completionVersion = Math\.max\(completedAt, row\.updated_at \+ 1\)/,
-	);
-	assert.match(reconcileSource, /last_reconciled_at: completedAt/);
-	assert.match(reconcileSource, /updated_at: completionVersion/);
-	assert.match(reconcileSource, /INSERT INTO interactive_session_events/);
-	assert.match(reconcileSource, /env\.DB\.batch/);
-	assert.match(reconcileSource, /reconcile_error: safeProviderError/);
-	assert.doesNotMatch(reconcileSource, /updated_at: now/);
+  assert.match(source, /async scheduled\(/);
+  assert.match(source, /context\.waitUntil\(\s*reconcileInteractiveSessionLifecycleBatch/);
+  assert.match(config, /"crons": \["\* \* \* \* \*"\]/);
+  assert.match(batchSource, /expression\("terminal_finalize_pending", "=", 1\)/);
+  assert.match(batchSource, /expression\("adapter", "=", runtimeAdapterName\)/);
+  assert.match(targetedSource, /reconcileCredentialPolicyCleanupBatch\(env, now, id\)/);
+  assert.match(targetedSource, /row\.terminal_finalize_pending === 1/);
+  assert.match(targetedSource, /row\.adapter !== runtimeAdapterName/);
+  assert.match(targetedSource, /runtimeAdapterReconcileIntervalMs/);
+  assert.match(targetedSource, /reconcileExternalInteractiveSession\(env, row, now\)/);
+  assert.ok(
+    reconcileSource.indexOf("if (terminalFinalizationStatus)") <
+      reconcileSource.indexOf("inspectRuntimeAdapterWorkspace"),
+  );
+  assert.match(source, /async function readFreshInteractiveSession/);
+  assert.match(source, /async function interactiveSessionPty[\s\S]*readFreshInteractiveSession/);
+  assert.match(source, /async function interactiveSessionVnc[\s\S]*readFreshInteractiveSession/);
+  assert.match(source, /scheduled interactive session reconciliation failed/);
+  assert.match(
+    source,
+    /async function reconcileInteractiveSessionLifecycleBatch[\s\S]*reconcileCredentialPolicyCleanupBatch[\s\S]*reconcileExternalInteractiveSessionBatch/,
+  );
+  assert.match(reconcileSource, /const claimAt = Math\.max/);
+  assert.match(reconcileSource, /where\("updated_at", "=", row\.updated_at\)/);
+  assert.match(reconcileSource, /const completedAt = Math\.max\(Date\.now\(\), claimAt\)/);
+  assert.match(
+    reconcileSource,
+    /const completionVersion = Math\.max\(completedAt, row\.updated_at \+ 1\)/,
+  );
+  assert.match(reconcileSource, /last_reconciled_at: completedAt/);
+  assert.match(reconcileSource, /updated_at: completionVersion/);
+  assert.match(reconcileSource, /INSERT INTO interactive_session_events/);
+  assert.match(reconcileSource, /env\.DB\.batch/);
+  assert.match(reconcileSource, /reconcile_error: safeProviderError/);
+  assert.doesNotMatch(reconcileSource, /updated_at: now/);
 });
 
 test("recurring terminal authorization never awaits provider reconciliation", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const grantStart = source.indexOf("function terminalInputGrant");
-	const grantEnd = source.indexOf("function sendTerminalFrame", grantStart);
-	const grantSource = source.slice(grantStart, grantEnd);
-	const controlStart = source.indexOf("async function canControlInteractiveSessionById");
-	const controlEnd = source.indexOf("function canGrantDelegatedControl", controlStart);
-	const controlSource = source.slice(controlStart, controlEnd);
-	const shareStart = source.indexOf("async function isSharedSessionToken");
-	const shareEnd = source.indexOf("function sendTerminalFrame", shareStart);
-	const shareSource = source.slice(shareStart, shareEnd);
-	const bridgeStart = source.indexOf("function bridgeWebSockets");
-	const bridgeEnd = source.indexOf("async function webSocketMessageData", bridgeStart);
-	const bridgeSource = source.slice(bridgeStart, bridgeEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const grantStart = source.indexOf("function terminalInputGrant");
+  const grantEnd = source.indexOf("function sendTerminalFrame", grantStart);
+  const grantSource = source.slice(grantStart, grantEnd);
+  const controlStart = source.indexOf("async function canControlInteractiveSessionById");
+  const controlEnd = source.indexOf("function canGrantDelegatedControl", controlStart);
+  const controlSource = source.slice(controlStart, controlEnd);
+  const shareStart = source.indexOf("async function isSharedSessionToken");
+  const shareEnd = source.indexOf("function sendTerminalFrame", shareStart);
+  const shareSource = source.slice(shareStart, shareEnd);
+  const bridgeStart = source.indexOf("function bridgeWebSockets");
+  const bridgeEnd = source.indexOf("async function webSocketMessageData", bridgeStart);
+  const bridgeSource = source.slice(bridgeStart, bridgeEnd);
 
-	assert.match(grantSource, /cachedBooleanGrant/);
-	assert.match(grantSource, /terminalSubscriptionReconciler/);
-	assert.match(grantSource, /void reconcileExternalInteractiveSessionById/);
-	assert.doesNotMatch(controlSource, /reconcileExternalInteractiveSessionById/);
-	assert.doesNotMatch(controlSource, /reconcileCredentialPolicyCleanupBatch|runtimeAdapterFetch/);
-	assert.doesNotMatch(shareSource, /reconcileExternalInteractiveSessionById/);
-	assert.doesNotMatch(shareSource, /reconcileCredentialPolicyCleanupBatch|runtimeAdapterFetch/);
-	assert.match(bridgeSource, /reconcileSubscription\?\.\(\)/);
-	assert.doesNotMatch(bridgeSource, /await reconcileSubscription/);
+  assert.match(grantSource, /cachedBooleanGrant/);
+  assert.match(grantSource, /terminalSubscriptionReconciler/);
+  assert.match(grantSource, /void reconcileExternalInteractiveSessionById/);
+  assert.doesNotMatch(controlSource, /reconcileExternalInteractiveSessionById/);
+  assert.doesNotMatch(controlSource, /reconcileCredentialPolicyCleanupBatch|runtimeAdapterFetch/);
+  assert.doesNotMatch(shareSource, /reconcileExternalInteractiveSessionById/);
+  assert.doesNotMatch(shareSource, /reconcileCredentialPolicyCleanupBatch|runtimeAdapterFetch/);
+  assert.match(bridgeSource, /reconcileSubscription\?\.\(\)/);
+  assert.doesNotMatch(bridgeSource, /await reconcileSubscription/);
 });
 
 test("public auth deployment metadata excludes runtime routing", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const publicStart = source.indexOf("function publicDeploymentConfig");
-	const publicEnd = source.indexOf("class D1Dialect", publicStart);
-	const publicSource = source.slice(publicStart, publicEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const publicStart = source.indexOf("function publicDeploymentConfig");
+  const publicEnd = source.indexOf("class D1Dialect", publicStart);
+  const publicSource = source.slice(publicStart, publicEnd);
 
-	assert.match(source, /deployment: publicDeploymentConfig\(env\)/);
-	assert.match(publicSource, /label, canonicalUrl, productUrl, sshHost/);
-	assert.doesNotMatch(publicSource, /preferredRepo|defaultRuntime|defaultProfile|RUNTIME_ADAPTER/);
+  assert.match(source, /deployment: publicDeploymentConfig\(env\)/);
+  assert.match(publicSource, /label, canonicalUrl, productUrl, sshHost/);
+  assert.doesNotMatch(publicSource, /preferredRepo|defaultRuntime|defaultProfile|RUNTIME_ADAPTER/);
 });
 
 test("strict session rows and cleanup preserve terminal finalization anchors", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const cleanupStart = source.indexOf("async function cleanupInteractiveSessions");
-	const cleanupEnd = source.indexOf("async function mutateInteractiveSession", cleanupStart);
-	const cleanupSource = source.slice(cleanupStart, cleanupEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const cleanupStart = source.indexOf("async function cleanupInteractiveSessions");
+  const cleanupEnd = source.indexOf("async function mutateInteractiveSession", cleanupStart);
+  const cleanupSource = source.slice(cleanupStart, cleanupEnd);
 
-	assert.match(source, /type InteractiveSessionRow = Selectable<InteractiveSessionTable>/);
-	assert.match(cleanupSource, /where\("terminal_finalize_pending", "=", 0\)/);
-	assert.match(cleanupSource, /deleteFinalizedInteractiveSession\(env, row, archive\)/);
-	assert.match(cleanupSource, /terminalCleanupDeletePending/);
-	assert.match(cleanupSource, /updated_at", "=", row\.updated_at/);
-	assert.match(cleanupSource, /executeBatch\(env, \[/);
-	const archiveIndex = cleanupSource.indexOf('.selectFrom("interactive_session_log_archives")');
-	const deleteIndex = cleanupSource.indexOf("deleteFinalizedInteractiveSession(env, row, archive)");
-	const objectCleanupIndex = cleanupSource.indexOf("cleanupSessionLogArchiveObjects(env, archive)");
-	assert.ok(archiveIndex >= 0 && deleteIndex > archiveIndex && objectCleanupIndex > deleteIndex);
-	assert.match(cleanupSource, /session archive object cleanup leaked/);
-	assert.match(cleanupSource, /events_key IS \$\{archive\?\.events_key/);
-	assert.match(cleanupSource, /transcript_key IS \$\{archive\?\.transcript_key/);
-	assert.match(cleanupSource, /summary_key IS \$\{archive\?\.summary_key/);
-	assert.match(cleanupSource, /deleteFrom\("interactive_session_events"\)/);
-	assert.match(cleanupSource, /deleteFrom\("interactive_session_log_archives"\)/);
-	assert.match(cleanupSource, /deleteFrom\("interactive_sessions"\)/);
-	assert.match(cleanupSource, /FROM interactive_session_credential_policies/);
-	assert.equal(cleanupSource.match(/WITH RECURSIVE active_ancestor\(id\)/g)?.length, 2);
-	assert.match(cleanupSource, /SELECT parent_session_id[\s\S]*FROM interactive_sessions/);
-	assert.match(cleanupSource, /JOIN active_ancestor ON session\.id = active_ancestor\.id/);
-	assert.match(cleanupSource, /WHERE id = interactive_sessions\.id/);
-	assert.match(cleanupSource, /WHERE id = \$\{row\.id\}/);
-	assert.match(source, /terminalFinalizationPendingQuery/);
-	assert.match(source, /executeBatch\(env, \[[\s\S]*interactive_session_events/);
-	assert.match(source, /COALESCE\([\s\S]*event_count[\s\S]*count\(\*\)/);
-	assert.match(source, /events_key IS NOT NULL/);
+  assert.match(source, /type InteractiveSessionRow = Selectable<InteractiveSessionTable>/);
+  assert.match(cleanupSource, /where\("terminal_finalize_pending", "=", 0\)/);
+  assert.match(cleanupSource, /deleteFinalizedInteractiveSession\(env, row, archive\)/);
+  assert.match(cleanupSource, /terminalCleanupDeletePending/);
+  assert.match(cleanupSource, /updated_at", "=", row\.updated_at/);
+  assert.match(cleanupSource, /executeBatch\(env, \[/);
+  const archiveIndex = cleanupSource.indexOf('.selectFrom("interactive_session_log_archives")');
+  const deleteIndex = cleanupSource.indexOf("deleteFinalizedInteractiveSession(env, row, archive)");
+  const objectCleanupIndex = cleanupSource.indexOf("cleanupSessionLogArchiveObjects(env, archive)");
+  assert.ok(archiveIndex >= 0 && deleteIndex > archiveIndex && objectCleanupIndex > deleteIndex);
+  assert.match(cleanupSource, /session archive object cleanup leaked/);
+  assert.match(cleanupSource, /events_key IS \$\{archive\?\.events_key/);
+  assert.match(cleanupSource, /transcript_key IS \$\{archive\?\.transcript_key/);
+  assert.match(cleanupSource, /summary_key IS \$\{archive\?\.summary_key/);
+  assert.match(cleanupSource, /deleteFrom\("interactive_session_events"\)/);
+  assert.match(cleanupSource, /deleteFrom\("interactive_session_log_archives"\)/);
+  assert.match(cleanupSource, /deleteFrom\("interactive_sessions"\)/);
+  assert.match(cleanupSource, /FROM interactive_session_credential_policies/);
+  assert.equal(
+    cleanupSource.match(/WITH RECURSIVE active_ancestor\(id\)/g)?.length,
+    2,
+  );
+  assert.match(cleanupSource, /SELECT parent_session_id[\s\S]*FROM interactive_sessions/);
+  assert.match(cleanupSource, /JOIN active_ancestor ON session\.id = active_ancestor\.id/);
+  assert.match(cleanupSource, /WHERE id = interactive_sessions\.id/);
+  assert.match(cleanupSource, /WHERE id = \$\{row\.id\}/);
+  assert.match(source, /terminalFinalizationPendingQuery/);
+  assert.match(source, /executeBatch\(env, \[[\s\S]*interactive_session_events/);
+  assert.match(source, /COALESCE\([\s\S]*event_count[\s\S]*count\(\*\)/);
+  assert.match(source, /events_key IS NOT NULL/);
 });
 
 test("summary and sharing events invalidate terminal cleanup snapshots", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const cleanupStart = source.indexOf("async function deleteFinalizedInteractiveSession");
-	const cleanupEnd = source.indexOf("async function mutateInteractiveSession", cleanupStart);
-	const cleanupSource = source.slice(cleanupStart, cleanupEnd);
-	const shareStart = source.indexOf('if (action === "share_link")');
-	const shareEnd = source.indexOf('if (action === "enable_multiplayer")', shareStart);
-	const shareSource = source.slice(shareStart, shareEnd);
-	const summaryStart = source.indexOf("async function updateInteractiveSessionSummary");
-	const summaryEnd = source.indexOf("async function readInteractiveSessionLogs", summaryStart);
-	const summarySource = source.slice(summaryStart, summaryEnd);
-	const metadataStart = source.indexOf("async function mutateInteractiveSessionMetadataAtomically");
-	const metadataEnd = source.indexOf("async function mutateInteractiveSession(", metadataStart);
-	const metadataSource = source.slice(metadataStart, metadataEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const cleanupStart = source.indexOf("async function deleteFinalizedInteractiveSession");
+  const cleanupEnd = source.indexOf("async function mutateInteractiveSession", cleanupStart);
+  const cleanupSource = source.slice(cleanupStart, cleanupEnd);
+  const shareStart = source.indexOf('if (action === "share_link")');
+  const shareEnd = source.indexOf('if (action === "enable_multiplayer")', shareStart);
+  const shareSource = source.slice(shareStart, shareEnd);
+  const summaryStart = source.indexOf("async function updateInteractiveSessionSummary");
+  const summaryEnd = source.indexOf("async function readInteractiveSessionLogs", summaryStart);
+  const summarySource = source.slice(summaryStart, summaryEnd);
+  const metadataStart = source.indexOf("async function mutateInteractiveSessionMetadataAtomically");
+  const metadataEnd = source.indexOf("async function mutateInteractiveSession(", metadataStart);
+  const metadataSource = source.slice(metadataStart, metadataEnd);
 
-	assert.match(cleanupSource, /where\("updated_at", "=", row\.updated_at\)/);
-	assert.match(cleanupSource, /terminal_finalize_pending: terminalCleanupDeletePending/);
-	assert.match(cleanupSource, /event_count = \$\{archive\?\.event_count/);
-	assert.match(cleanupSource, /archived_at = \$\{archive\?\.archived_at/);
-	assert.match(cleanupSource, /count\(\*\)/);
-	assert.match(shareSource, /mutateInteractiveSessionMetadataAtomically/);
-	assert.match(summarySource, /mutateInteractiveSessionMetadataAtomically/);
-	assert.match(metadataSource, /INSERT INTO interactive_session_events/);
-	assert.match(metadataSource, /terminal_finalize_pending: sql<number>`CASE/);
-	assert.match(metadataSource, /WHEN status IN \('stopped', 'expired', 'failed'\) THEN 1/);
-	assert.match(metadataSource, /updated_at = \$\{session\.updatedAt\}/);
-	assert.match(metadataSource, /\.returning\("updated_at"\)/);
-	assert.match(metadataSource, /env\.DB\.batch/);
-	assert.ok(metadataSource.indexOf("eventQuery") < metadataSource.indexOf("updateQuery"));
+  assert.match(cleanupSource, /where\("updated_at", "=", row\.updated_at\)/);
+  assert.match(cleanupSource, /terminal_finalize_pending: terminalCleanupDeletePending/);
+  assert.match(cleanupSource, /event_count = \$\{archive\?\.event_count/);
+  assert.match(cleanupSource, /archived_at = \$\{archive\?\.archived_at/);
+  assert.match(cleanupSource, /count\(\*\)/);
+  assert.match(shareSource, /mutateInteractiveSessionMetadataAtomically/);
+  assert.match(summarySource, /mutateInteractiveSessionMetadataAtomically/);
+  assert.match(metadataSource, /INSERT INTO interactive_session_events/);
+  assert.match(metadataSource, /terminal_finalize_pending: sql<number>`CASE/);
+  assert.match(metadataSource, /WHEN status IN \('stopped', 'expired', 'failed'\) THEN 1/);
+  assert.match(metadataSource, /updated_at = \$\{session\.updatedAt\}/);
+  assert.match(metadataSource, /\.returning\("updated_at"\)/);
+  assert.match(metadataSource, /env\.DB\.batch/);
+  assert.ok(metadataSource.indexOf("eventQuery") < metadataSource.indexOf("updateQuery"));
 });
 
 test("development identity login requires an explicit local gate", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const config = await readFile(new URL("../wrangler.jsonc", import.meta.url), "utf8");
-	const loginSource = source.slice(
-		source.indexOf("async function devIdentityLogin"),
-		source.indexOf("async function githubLogin"),
-	);
-	const requireSource = source.slice(
-		source.indexOf("async function requireUser"),
-		source.indexOf("async function optionalUser"),
-	);
-	const authStart = source.indexOf("function authMethods");
-	const authSource = source.slice(authStart, source.indexOf("function actor", authStart));
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const config = await readFile(new URL("../wrangler.jsonc", import.meta.url), "utf8");
+  const loginSource = source.slice(
+    source.indexOf("async function devIdentityLogin"),
+    source.indexOf("async function githubLogin"),
+  );
+  const requireSource = source.slice(
+    source.indexOf("async function requireUser"),
+    source.indexOf("async function optionalUser"),
+  );
+  const authStart = source.indexOf("function authMethods");
+  const authSource = source.slice(authStart, source.indexOf("function actor", authStart));
 
-	assert.match(source, /function devIdentityEnabled\(env: RuntimeEnv, request: Request\)/);
-	assert.match(loginSource, /devIdentityEnabled\(env, request\)/);
-	assert.match(requireSource, /devIdentityEnabled\(env, request\)/);
-	assert.match(requireSource, /deleteFrom\("sessions"\)/);
-	assert.match(authSource, /devIdentityEnabled\(env, request\)/);
-	assert.match(
-		authSource,
-		/developmentIdentityEnabled\(env\.CRABFLEET_DEV_LOGIN_ENABLED, request\.url\)/,
-	);
-	assert.match(config, /"CRABFLEET_DEV_LOGIN_ENABLED": "false"/);
+  assert.match(source, /function devIdentityEnabled\(env: RuntimeEnv, request: Request\)/);
+  assert.match(loginSource, /devIdentityEnabled\(env, request\)/);
+  assert.match(requireSource, /devIdentityEnabled\(env, request\)/);
+  assert.match(requireSource, /deleteFrom\("sessions"\)/);
+  assert.match(authSource, /devIdentityEnabled\(env, request\)/);
+  assert.match(
+    authSource,
+    /developmentIdentityEnabled\(env\.CRABFLEET_DEV_LOGIN_ENABLED, request\.url\)/,
+  );
+  assert.match(config, /"CRABFLEET_DEV_LOGIN_ENABLED": "false"/);
 });
 
 test("runtime adapter credentials are preflighted before session allocation", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
-	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
-	const createSource = source.slice(createStart, createEnd);
-	const preflightStart = source.indexOf("function requireRuntimeAdapterCreatePreflight");
-	const preflightEnd = source.indexOf(
-		"async function stopSupersededRuntimeAdapterProvision",
-		preflightStart,
-	);
-	const preflightSource = source.slice(preflightStart, preflightEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const createStart = source.indexOf("async function createInteractiveSessionFromInput");
+  const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
+  const createSource = source.slice(createStart, createEnd);
+  const preflightStart = source.indexOf("function requireRuntimeAdapterCreatePreflight");
+  const preflightEnd = source.indexOf(
+    "async function stopSupersededRuntimeAdapterProvision",
+    preflightStart,
+  );
+  const preflightSource = source.slice(preflightStart, preflightEnd);
 
-	assert.ok(
-		createSource.indexOf("requireRuntimeAdapterCreatePreflight(env, runtime, profile)") <
-			createSource.indexOf("nextInteractiveSessionId(env)"),
-	);
-	assert.ok(
-		createSource.indexOf("requireRuntimeAdapterCreatePreflight(env, runtime, profile)") <
-			createSource.indexOf('.insertInto("interactive_sessions")'),
-	);
-	assert.match(preflightSource, /runtime === "container" && env\.SANDBOX/);
-	assert.match(preflightSource, /runtimeAdapterToken\(env\)/);
-	assert.match(preflightSource, /configuredRuntimeAdapterControlPlane\(env, profile\)/);
-	assert.match(preflightSource, /runtimeAdapterControlPlaneForProfile/);
-	assert.match(preflightSource, /runtime adapter token is not configured/);
+  assert.ok(
+    createSource.indexOf("requireRuntimeAdapterCreatePreflight(env, runtime, profile)") <
+      createSource.indexOf("nextInteractiveSessionId(env)"),
+  );
+  assert.ok(
+    createSource.indexOf("requireRuntimeAdapterCreatePreflight(env, runtime, profile)") <
+      createSource.indexOf('.insertInto("interactive_sessions")'),
+  );
+  assert.match(preflightSource, /runtime === "container" && env\.SANDBOX/);
+  assert.match(preflightSource, /runtimeAdapterToken\(env\)/);
+  assert.match(preflightSource, /configuredRuntimeAdapterControlPlane\(env, profile\)/);
+  assert.match(preflightSource, /runtimeAdapterControlPlaneForProfile/);
+  assert.match(preflightSource, /runtime adapter token is not configured/);
 });
 
 test("runtime adapter operations stay bound to the registered control plane", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const migration = await readFile(
-		new URL("../migrations/0020_runtime_adapter_lifecycle.sql", import.meta.url),
-		"utf8",
-	);
-	const bindingStart = source.indexOf("function configuredRuntimeAdapterControlPlane");
-	const bindingEnd = source.indexOf(
-		"async function stopSupersededRuntimeAdapterProvision",
-		bindingStart,
-	);
-	const bindingSource = source.slice(bindingStart, bindingEnd);
-	const provisionStart = source.indexOf("async function provisionWithRuntimeAdapter");
-	const provisionEnd = source.indexOf("function persistedRuntimeAdapterSeconds", provisionStart);
-	const provisionSource = source.slice(provisionStart, provisionEnd);
-	const inspectStart = source.indexOf("async function inspectRuntimeAdapterWorkspace");
-	const inspectEnd = source.indexOf(
-		"async function reconcileStoppingRuntimeAdapterWorkspace",
-		inspectStart,
-	);
-	const inspectSource = source.slice(inspectStart, inspectEnd);
-	const stopStart = source.indexOf("async function stopRuntimeAdapterWorkspace(");
-	const stopEnd = source.indexOf("async function runtimeAdapterFetch", stopStart);
-	const stopSource = source.slice(stopStart, stopEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const migration = await readFile(
+    new URL("../migrations/0020_runtime_adapter_lifecycle.sql", import.meta.url),
+    "utf8",
+  );
+  const bindingStart = source.indexOf("function configuredRuntimeAdapterControlPlane");
+  const bindingEnd = source.indexOf(
+    "async function stopSupersededRuntimeAdapterProvision",
+    bindingStart,
+  );
+  const bindingSource = source.slice(bindingStart, bindingEnd);
+  const provisionStart = source.indexOf("async function provisionWithRuntimeAdapter");
+  const provisionEnd = source.indexOf("function persistedRuntimeAdapterSeconds", provisionStart);
+  const provisionSource = source.slice(provisionStart, provisionEnd);
+  const inspectStart = source.indexOf("async function inspectRuntimeAdapterWorkspace");
+  const inspectEnd = source.indexOf(
+    "async function reconcileStoppingRuntimeAdapterWorkspace",
+    inspectStart,
+  );
+  const inspectSource = source.slice(inspectStart, inspectEnd);
+  const stopStart = source.indexOf("async function stopRuntimeAdapterWorkspace(");
+  const stopEnd = source.indexOf("async function runtimeAdapterFetch", stopStart);
+  const stopSource = source.slice(stopStart, stopEnd);
 
-	assert.match(migration, /ADD COLUMN adapter_control_plane TEXT/);
-	assert.match(source, /adapter_control_plane: adapterControlPlane/);
-	assert.match(bindingSource, /configuredControlPlane !== registeredControlPlane/);
-	assert.match(bindingSource, /configuredRuntimeAdapterControlPlane\(env, profile\)/);
-	assert.match(bindingSource, /control plane differs from workspace registration/);
-	assert.match(provisionSource, /requireRegisteredRuntimeAdapterControlPlane/);
-	assert.match(provisionSource, /runtimeAdapterCollectionUrl\(baseUrl\)/);
-	assert.match(inspectSource, /session\.adapter_control_plane/);
-	assert.match(inspectSource, /runtimeAdapterWorkspaceUrl\(controlPlane, adapterWorkspaceId\)/);
-	assert.match(stopSource, /requireRegisteredRuntimeAdapterControlPlane/);
-	assert.match(stopSource, /runtimeAdapterWorkspaceUrl\(controlPlane, adapterWorkspaceId\)/);
-	assert.doesNotMatch(
-		inspectSource,
-		/runtimeAdapterWorkspaceUrl\(env\.CRABBOX_RUNTIME_ADAPTER_URL/,
-	);
-	assert.doesNotMatch(stopSource, /response\.status === 404[\s\S]*CRABBOX_RUNTIME_ADAPTER_URL/);
+  assert.match(migration, /ADD COLUMN adapter_control_plane TEXT/);
+  assert.match(source, /adapter_control_plane: adapterControlPlane/);
+  assert.match(bindingSource, /configuredControlPlane !== registeredControlPlane/);
+  assert.match(bindingSource, /configuredRuntimeAdapterControlPlane\(env, profile\)/);
+  assert.match(bindingSource, /control plane differs from workspace registration/);
+  assert.match(provisionSource, /requireRegisteredRuntimeAdapterControlPlane/);
+  assert.match(provisionSource, /runtimeAdapterCollectionUrl\(baseUrl\)/);
+  assert.match(inspectSource, /session\.adapter_control_plane/);
+  assert.match(inspectSource, /runtimeAdapterWorkspaceUrl\(controlPlane, adapterWorkspaceId\)/);
+  assert.match(stopSource, /requireRegisteredRuntimeAdapterControlPlane/);
+  assert.match(stopSource, /runtimeAdapterWorkspaceUrl\(controlPlane, adapterWorkspaceId\)/);
+  assert.doesNotMatch(
+    inspectSource,
+    /runtimeAdapterWorkspaceUrl\(env\.CRABBOX_RUNTIME_ADAPTER_URL/,
+  );
+  assert.doesNotMatch(stopSource, /response\.status === 404[\s\S]*CRABBOX_RUNTIME_ADAPTER_URL/);
 });
 
 test("runtime adapter requests reject redirects with edge-supported fetch semantics", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const fetchStart = source.indexOf("async function runtimeAdapterFetch");
-	const fetchEnd = source.indexOf("async function readRuntimeAdapterResponseBody", fetchStart);
-	const fetchSource = source.slice(fetchStart, fetchEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const fetchStart = source.indexOf("async function runtimeAdapterFetch");
+  const fetchEnd = source.indexOf("async function readRuntimeAdapterResponseBody", fetchStart);
+  const fetchSource = source.slice(fetchStart, fetchEnd);
 
-	assert.match(fetchSource, /redirect: "manual"/);
-	assert.match(fetchSource, /response\.status >= 300 && response\.status < 400/);
-	assert.match(fetchSource, /runtime adapter redirect refused/);
-	assert.doesNotMatch(fetchSource, /redirect: "error"/);
+  assert.match(fetchSource, /redirect: "manual"/);
+  assert.match(fetchSource, /response\.status >= 300 && response\.status < 400/);
+  assert.match(fetchSource, /runtime adapter redirect refused/);
+  assert.doesNotMatch(fetchSource, /redirect: "error"/);
 });
 
 test("pending runtime adapter creates replay before any inspect", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const inspectStart = source.indexOf("async function inspectRuntimeAdapterWorkspace");
-	const inspectEnd = source.indexOf(
-		"async function reconcileStoppingRuntimeAdapterWorkspace",
-		inspectStart,
-	);
-	const inspectSource = source.slice(inspectStart, inspectEnd);
-	const provisionStart = source.indexOf("async function provisionWithRuntimeAdapter");
-	const provisionEnd = source.indexOf("function persistedRuntimeAdapterSeconds", provisionStart);
-	const provisionSource = source.slice(provisionStart, provisionEnd);
-	const replayIndex = inspectSource.indexOf(
-		"shouldReplayRuntimeAdapterCreate(session.status, session.adapter_create_pending === 1)",
-	);
-	const inspectFetchIndex = inspectSource.indexOf("const response = await runtimeAdapterFetch(");
-	const missingIndex = inspectSource.indexOf("if (response.status === 404)");
-	const missingSource = inspectSource.slice(missingIndex);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const inspectStart = source.indexOf("async function inspectRuntimeAdapterWorkspace");
+  const inspectEnd = source.indexOf(
+    "async function reconcileStoppingRuntimeAdapterWorkspace",
+    inspectStart,
+  );
+  const inspectSource = source.slice(inspectStart, inspectEnd);
+  const provisionStart = source.indexOf("async function provisionWithRuntimeAdapter");
+  const provisionEnd = source.indexOf("function persistedRuntimeAdapterSeconds", provisionStart);
+  const provisionSource = source.slice(provisionStart, provisionEnd);
+  const replayIndex = inspectSource.indexOf(
+    "shouldReplayRuntimeAdapterCreate(session.status, session.adapter_create_pending === 1)",
+  );
+  const inspectFetchIndex = inspectSource.indexOf("const response = await runtimeAdapterFetch(");
+  const missingIndex = inspectSource.indexOf("if (response.status === 404)");
+  const missingSource = inspectSource.slice(missingIndex);
 
-	assert.ok(replayIndex >= 0);
-	assert.ok(inspectFetchIndex >= 0);
-	assert.ok(replayIndex < inspectFetchIndex);
-	assert.match(inspectSource, /runtimeAdapterReplayRequest\(runtimeAdapterRecord\(session\)\)/);
-	assert.ok(missingIndex >= 0);
-	assert.doesNotMatch(missingSource, /provisionWithRuntimeAdapter/);
-	assert.match(provisionSource, /const replayingPendingCreate = reconciliationOwner !== undefined/);
-	assert.match(
-		provisionSource,
-		/!replayingPendingCreate && definitiveRuntimeAdapterCreateFailure\(response\.status\)/,
-	);
-	assert.match(provisionSource, /runtime adapter create replay blocked/);
+  assert.ok(replayIndex >= 0);
+  assert.ok(inspectFetchIndex >= 0);
+  assert.ok(replayIndex < inspectFetchIndex);
+  assert.match(inspectSource, /runtimeAdapterReplayRequest\(runtimeAdapterRecord\(session\)\)/);
+  assert.ok(missingIndex >= 0);
+  assert.doesNotMatch(missingSource, /provisionWithRuntimeAdapter/);
+  assert.match(provisionSource, /const replayingPendingCreate = reconciliationOwner !== undefined/);
+  assert.match(
+    provisionSource,
+    /!replayingPendingCreate && definitiveRuntimeAdapterCreateFailure\(response\.status\)/,
+  );
+  assert.match(provisionSource, /runtime adapter create replay blocked/);
 });
 
 test("stopping create replay owns the exact persisted lifecycle", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const reconcileStart = source.indexOf("async function reconcileStoppingRuntimeAdapterWorkspace");
-	const replayStart = source.indexOf("async function replayStoppingRuntimeAdapterCreate");
-	const replayEnd = source.indexOf("async function stopRuntimeAdapterWorkspace(", replayStart);
-	const reconcileSource = source.slice(reconcileStart, replayStart);
-	const replaySource = source.slice(replayStart, replayEnd);
-	const unresolvedIndex = reconcileSource.indexOf("if (!replay.resolved)");
-	const deleteIndex = reconcileSource.indexOf("stopRuntimeAdapterWorkspace(");
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const reconcileStart = source.indexOf("async function reconcileStoppingRuntimeAdapterWorkspace");
+  const replayStart = source.indexOf("async function replayStoppingRuntimeAdapterCreate");
+  const replayEnd = source.indexOf("async function stopRuntimeAdapterWorkspace(", replayStart);
+  const reconcileSource = source.slice(reconcileStart, replayStart);
+  const replaySource = source.slice(replayStart, replayEnd);
+  const unresolvedIndex = reconcileSource.indexOf("if (!replay.resolved)");
+  const deleteIndex = reconcileSource.indexOf("stopRuntimeAdapterWorkspace(");
 
-	assert.match(reconcileSource, /replayStoppingRuntimeAdapterCreate\([\s\S]*env,[\s\S]*session,/);
-	assert.doesNotMatch(reconcileSource, /provisionWithRuntimeAdapter/);
-	assert.ok(unresolvedIndex >= 0);
-	assert.ok(deleteIndex >= 0);
-	assert.ok(unresolvedIndex < deleteIndex);
-	assert.match(reconcileSource, /reconcileError: replay\.message/);
-	assert.match(reconcileSource, /createPending: true/);
-	assert.match(replaySource, /AND adapter_control_plane = \$\{controlPlane\}/);
-	assert.match(replaySource, /AND adapter_create_payload_json = \$\{createPayloadJson\}/);
-	assert.match(replaySource, /AND adapter_create_pending = 1/);
-	assert.match(replaySource, /AND status = 'stopping'/);
-	assert.match(replaySource, /AND updated_at = \$\{session\.updated_at\}/);
-	assert.match(replaySource, /AND last_reconciled_at = \$\{reconciliationClaimAt\}/);
-	assert.match(replaySource, /runtimeAdapterCollectionUrl\(controlPlane\)/);
-	assert.match(replaySource, /idempotency-key": adapterWorkspaceId/);
-	assert.match(replaySource, /adapter_create_pending: 0/);
-	assert.match(replaySource, /reconcile_error: message/);
-	assert.match(replaySource, /INSERT INTO interactive_session_events/);
-	assert.match(replaySource, /env\.DB\.batch/);
+  assert.match(reconcileSource, /replayStoppingRuntimeAdapterCreate\([\s\S]*env,[\s\S]*session,/);
+  assert.doesNotMatch(reconcileSource, /provisionWithRuntimeAdapter/);
+  assert.ok(unresolvedIndex >= 0);
+  assert.ok(deleteIndex >= 0);
+  assert.ok(unresolvedIndex < deleteIndex);
+  assert.match(reconcileSource, /reconcileError: replay\.message/);
+  assert.match(reconcileSource, /createPending: true/);
+  assert.match(replaySource, /AND adapter_control_plane = \$\{controlPlane\}/);
+  assert.match(replaySource, /AND adapter_create_payload_json = \$\{createPayloadJson\}/);
+  assert.match(replaySource, /AND adapter_create_pending = 1/);
+  assert.match(replaySource, /AND status = 'stopping'/);
+  assert.match(replaySource, /AND updated_at = \$\{session\.updated_at\}/);
+  assert.match(replaySource, /AND last_reconciled_at = \$\{reconciliationClaimAt\}/);
+  assert.match(replaySource, /runtimeAdapterCollectionUrl\(controlPlane\)/);
+  assert.match(replaySource, /idempotency-key": adapterWorkspaceId/);
+  assert.match(replaySource, /adapter_create_pending: 0/);
+  assert.match(replaySource, /reconcile_error: message/);
+  assert.match(replaySource, /INSERT INTO interactive_session_events/);
+  assert.match(replaySource, /env\.DB\.batch/);
 });
 
 test("every session-bound adapter delete waits for create ambiguity to clear", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const releaseStart = source.indexOf("async function stopRuntimeAdapterWorkspaceForSession");
-	const releaseEnd = source.indexOf("async function runtimeAdapterFetch", releaseStart);
-	const releaseSource = source.slice(releaseStart, releaseEnd);
-	const pendingGateIndex = releaseSource.indexOf("if (registration?.adapter_create_pending !== 0)");
-	const providerDeleteIndex = releaseSource.indexOf("return stopRuntimeAdapterWorkspace(");
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const releaseStart = source.indexOf("async function stopRuntimeAdapterWorkspaceForSession");
+  const releaseEnd = source.indexOf("async function runtimeAdapterFetch", releaseStart);
+  const releaseSource = source.slice(releaseStart, releaseEnd);
+  const pendingGateIndex = releaseSource.indexOf("if (registration?.adapter_create_pending !== 0)");
+  const providerDeleteIndex = releaseSource.indexOf("return stopRuntimeAdapterWorkspace(");
 
-	assert.match(
-		releaseSource,
-		/select\(\["adapter_control_plane", "adapter_create_pending", "profile"\]\)/,
-	);
-	assert.ok(pendingGateIndex >= 0);
-	assert.ok(providerDeleteIndex >= 0);
-	assert.ok(pendingGateIndex < providerDeleteIndex);
-	assert.match(releaseSource, /status: "stopping"/);
-	assert.match(releaseSource, /runtime adapter stop waiting for create resolution/);
+  assert.match(
+    releaseSource,
+    /select\(\["adapter_control_plane", "adapter_create_pending", "profile"\]\)/,
+  );
+  assert.ok(pendingGateIndex >= 0);
+  assert.ok(providerDeleteIndex >= 0);
+  assert.ok(pendingGateIndex < providerDeleteIndex);
+  assert.match(releaseSource, /status: "stopping"/);
+  assert.match(releaseSource, /runtime adapter stop waiting for create resolution/);
 });
 
 test("stateless Sandbox provision hook acquires durable standalone ownership", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const migration = await readFile(
-		new URL("../migrations/0022_credential_policy_cleanup.sql", import.meta.url),
-		"utf8",
-	);
-	const expiryMigration = await readFile(
-		new URL("../migrations/0023_standalone_sandbox_expiry.sql", import.meta.url),
-		"utf8",
-	);
-	const endpointStart = source.indexOf("async function provisionInteractiveEndpoint");
-	const endpointEnd = source.indexOf("function isBuiltInInteractiveProvisionUrl", endpointStart);
-	const endpointSource = source.slice(endpointStart, endpointEnd);
-	const ownershipStart = source.indexOf("function sandboxCredentialPolicyOwnerCondition");
-	const ownershipEnd = source.indexOf(
-		"function sandboxCredentialPolicyRegistrationQueries",
-		ownershipStart,
-	);
-	const ownershipSource = source.slice(ownershipStart, ownershipEnd);
-	const managedStart = source.indexOf("async function provisionManagedSandboxEndpoint");
-	const managedEnd = source.indexOf("async function provisionStandaloneSandbox", managedStart);
-	const managedSource = source.slice(managedStart, managedEnd);
-	const managedCommitSource = managedSource.slice(managedSource.indexOf("const commitRevision"));
-	const ptyStart = source.indexOf("async function standaloneSandboxPty");
-	const ptyEnd = source.indexOf("function isBuiltInInteractiveProvisionUrl", ptyStart);
-	const ptySource = source.slice(ptyStart, ptyEnd);
-	const sandboxStart = source.indexOf("async function provisionWithSandbox");
-	const sandboxEnd = source.indexOf("function sandboxManagedOwnershipCondition", sandboxStart);
-	const sandboxSource = source.slice(sandboxStart, sandboxEnd);
-	const activationSource = endpointSource.slice(endpointSource.indexOf("const activationVersion"));
-	const stopStart = source.indexOf("async function stopStandaloneSandboxProvision");
-	const stopEnd = source.indexOf("function standaloneSandboxAttachUrl", stopStart);
-	const stopSource = source.slice(stopStart, stopEnd);
-	const expiryStart = source.indexOf("async function expireStandaloneSandboxProvisions");
-	const expirySource = source.slice(expiryStart, stopStart);
-	const standaloneCleanupStart = source.indexOf(
-		"async function completeStandaloneSandboxProvisionCleanup",
-	);
-	const standaloneCleanupEnd = source.indexOf(
-		"async function completeCredentialPolicyCleanupSession",
-		standaloneCleanupStart,
-	);
-	const standaloneCleanupSource = source.slice(standaloneCleanupStart, standaloneCleanupEnd);
-	const strictAuthStart = source.indexOf("function authorizeProvisionBearerToken");
-	const strictAuthEnd = source.indexOf("function sandboxProvisionPreflightError", strictAuthStart);
-	const strictAuthSource = source.slice(strictAuthStart, strictAuthEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const migration = await readFile(
+    new URL("../migrations/0022_credential_policy_cleanup.sql", import.meta.url),
+    "utf8",
+  );
+  const expiryMigration = await readFile(
+    new URL("../migrations/0023_standalone_sandbox_expiry.sql", import.meta.url),
+    "utf8",
+  );
+  const endpointStart = source.indexOf("async function provisionInteractiveEndpoint");
+  const endpointEnd = source.indexOf("function isBuiltInInteractiveProvisionUrl", endpointStart);
+  const endpointSource = source.slice(endpointStart, endpointEnd);
+  const ownershipStart = source.indexOf("function sandboxCredentialPolicyOwnerCondition");
+  const ownershipEnd = source.indexOf(
+    "function sandboxCredentialPolicyRegistrationQueries",
+    ownershipStart,
+  );
+  const ownershipSource = source.slice(ownershipStart, ownershipEnd);
+  const managedStart = source.indexOf("async function provisionManagedSandboxEndpoint");
+  const managedEnd = source.indexOf("async function provisionStandaloneSandbox", managedStart);
+  const managedSource = source.slice(managedStart, managedEnd);
+  const managedCommitSource = managedSource.slice(managedSource.indexOf("const commitRevision"));
+  const ptyStart = source.indexOf("async function standaloneSandboxPty");
+  const ptyEnd = source.indexOf("function isBuiltInInteractiveProvisionUrl", ptyStart);
+  const ptySource = source.slice(ptyStart, ptyEnd);
+  const sandboxStart = source.indexOf("async function provisionWithSandbox");
+  const sandboxEnd = source.indexOf("function sandboxManagedOwnershipCondition", sandboxStart);
+  const sandboxSource = source.slice(sandboxStart, sandboxEnd);
+  const activationSource = endpointSource.slice(endpointSource.indexOf("const activationVersion"));
+  const stopStart = source.indexOf("async function stopStandaloneSandboxProvision");
+  const stopEnd = source.indexOf("function standaloneSandboxAttachUrl", stopStart);
+  const stopSource = source.slice(stopStart, stopEnd);
+  const expiryStart = source.indexOf("async function expireStandaloneSandboxProvisions");
+  const expirySource = source.slice(expiryStart, stopStart);
+  const standaloneCleanupStart = source.indexOf(
+    "async function completeStandaloneSandboxProvisionCleanup",
+  );
+  const standaloneCleanupEnd = source.indexOf(
+    "async function completeCredentialPolicyCleanupSession",
+    standaloneCleanupStart,
+  );
+  const standaloneCleanupSource = source.slice(standaloneCleanupStart, standaloneCleanupEnd);
+  const strictAuthStart = source.indexOf("function authorizeProvisionBearerToken");
+  const strictAuthEnd = source.indexOf("function sandboxProvisionPreflightError", strictAuthStart);
+  const strictAuthSource = source.slice(strictAuthStart, strictAuthEnd);
 
-	assert.match(endpointSource, /selectFrom\("interactive_sessions"\)/);
-	assert.match(endpointSource, /managed && managed\.preparation_pending !== 0/);
-	assert.match(endpointSource, /if \(managed\)/);
-	assert.ok(
-		endpointSource.indexOf("if (managed)") <
-			endpointSource.indexOf("return provisionStandaloneSandbox(env, payload)"),
-	);
-	assert.match(endpointSource, /provisionManagedSandboxEndpoint\(env, payload, managed\)/);
-	assert.match(endpointSource, /managedInteractiveSessionId\(payload\.id\)/);
-	assert.match(endpointSource, /managed session namespace/);
-	assert.match(endpointSource, /INSERT INTO standalone_sandbox_provisions/);
-	assert.match(endpointSource, /ownership_claim_expires_at/);
-	assert.match(endpointSource, /\$\{sandboxLeaseId\(lease\)\}/);
-	assert.match(endpointSource, /lease_id = excluded\.lease_id/);
-	assert.match(endpointSource, /provisionWithSandbox\([\s\S]*fence/);
-	assert.match(endpointSource, /state: "active"/);
-	assert.match(ownershipSource, /FROM standalone_sandbox_provisions AS owner/);
-	assert.match(ownershipSource, /owner\.ownership_claim = \$\{ownershipFence\.claim\}/);
-	assert.match(managedSource, /managedSandboxProvisionPayloadMatches/);
-	assert.ok(
-		managedSource.indexOf("managedSandboxProvisionPayloadMatches") <
-			managedSource.indexOf("newSandboxLease(payload.id)"),
-	);
-	assert.match(managedSource, /where\("updated_at", "=", session\.updated_at\)/);
-	assert.match(managedSource, /session\.preparation_pending !== 0/);
-	assert.match(managedSource, /\.where\("preparation_pending", "=", 0\)/);
-	assert.match(managedSource, /sandbox_refresh_claim: fence\.claim/);
-	assert.match(managedSource, /const agentToken = newAgentToken\(\)/);
-	assert.match(managedSource, /const agentTokenHash = await sha256\(agentToken\)/);
-	assert.match(managedSource, /agent_token_hash: agentTokenHash/);
-	assert.match(managedSource, /agent_token_hash IS \$\{session\.agent_token_hash\}/);
-	assert.match(managedSource, /provisionWithSandbox\(env, payload, agentToken, lease, fence\)/);
-	assert.ok(
-		managedSource.indexOf("sandboxProvisionPreflightError(env, payload)") <
-			managedSource.indexOf("const agentToken = newAgentToken()"),
-	);
-	assert.match(managedSource, /stageFailedManagedSandboxProvision/);
-	assert.match(managedSource, /where\("agent_token_hash", "=", agentTokenHash\)/);
-	assert.doesNotMatch(managedSource, /provisionWithSandbox\(env, payload, undefined/);
-	assert.match(managedSource, /executeBatch\(env, commitQueries\)/);
-	assert.match(managedCommitSource, /MAX\(updated_at \+ 1, \$\{commitRevision\}\)/);
-	assert.doesNotMatch(managedCommitSource, /where\("updated_at", "=", now\)/);
-	assert.match(managedCommitSource, /lease_id IS \$\{fence\.refreshLeaseId\}/);
-	assert.match(managedCommitSource, /sandbox_refresh_claim", "=", fence\.claim/);
-	assert.match(managedCommitSource, /sandbox_refresh_claim_expires_at", "=", fence\.expiresAt/);
-	assert.match(managedSource, /previousSandboxId/);
-	assert.match(managedSource, /state: "cleanup_pending"/);
-	assert.match(managedSource, /claimed\.numUpdatedRows/);
-	assert.match(ptySource, /authorizeProvisionEndpoint\(request, env\)/);
-	assert.match(ptySource, /standalone_sandbox_provisions/);
-	assert.match(ptySource, /where\("state", "=", "active"\)/);
-	assert.match(ptySource, /owner\.expires_at <= Date\.now\(\)/);
-	assert.match(ptySource, /stageStandaloneSandboxProvisionCleanup/);
-	assert.match(ptySource, /activeSandboxCredentialPolicyGeneration/);
-	assert.match(ptySource, /terminalHeaders\.delete\("authorization"\)/);
-	assert.match(ptySource, /const pair = new WebSocketPair\(\)/);
-	assert.match(ptySource, /response\.webSocket\.accept\(\)/);
-	assert.match(ptySource, /bridgeWebSockets\(/);
-	assert.match(ptySource, /standaloneSandboxTerminalGrant/);
-	assert.match(ptySource, /cachedBooleanGrant/);
-	assert.match(ptySource, /where\("request_hash", "=", ownership\.requestHash\)/);
-	assert.match(ptySource, /where\("expires_at", ">", now\)/);
-	assert.match(ptySource, /where\("updated_at", "=", ownership\.updatedAt\)/);
-	assert.match(ptySource, /activeSandboxCredentialPolicyCondition/);
-	assert.match(ptySource, /return new Response\(null, \{ status: 101, webSocket: client \}\)/);
-	assert.doesNotMatch(ptySource, /return response;/);
-	assert.match(standaloneCleanupSource, /deleteSession\(lease\.terminalSessionId\)/);
-	assert.match(standaloneCleanupSource, /isSandboxSessionAlreadyGone/);
-	assert.ok(
-		standaloneCleanupSource.indexOf("deleteSession(lease.terminalSessionId)") <
-			standaloneCleanupSource.indexOf('.deleteFrom("standalone_sandbox_provisions")'),
-	);
-	assert.match(standaloneCleanupSource, /where\("updated_at", "=", owner\.updated_at\)/);
-	assert.match(sandboxSource, /standaloneSandboxAttachUrl\(env, session\.id\)/);
-	assert.match(
-		endpointSource,
-		/const activationVersion = Math\.max\(Date\.now\(\), finishedAt \+ 1\)/,
-	);
-	assert.match(activationSource, /executeBatch\(env, \[/);
-	assert.ok(
-		activationSource.indexOf('.updateTable("interactive_session_credential_policies")') <
-			activationSource.indexOf('.updateTable("standalone_sandbox_provisions")'),
-	);
-	assert.match(activationSource, /set\(\{ updated_at: activationVersion \}\)/);
-	assert.match(
-		endpointSource,
-		/activeSandboxCredentialPolicyCondition\([\s\S]*policyGeneration,[\s\S]*activationVersion/,
-	);
-	assert.match(migration, /CREATE TABLE IF NOT EXISTS standalone_sandbox_provisions/);
-	assert.match(migration, /request_hash TEXT NOT NULL/);
-	assert.match(migration, /sandbox_id TEXT NOT NULL UNIQUE/);
-	assert.match(expiryMigration, /ADD COLUMN expires_at INTEGER/);
-	assert.match(expiryMigration, /substr\(lower\(id\), 4\) NOT GLOB '\*\[\^0-9\]\*'/);
-	assert.match(expiryMigration, /idx_standalone_sandbox_provision_expiry/);
-	assert.match(expirySource, /state = 'active'/);
-	assert.match(expirySource, /expires_at <= \$\{now\}/);
-	assert.match(expirySource, /substr\(lower\(id\), 4\) NOT GLOB '\*\[\^0-9\]\*'/);
-	assert.match(stopSource, /authorizeProvisionBearerToken\(request, env\)/);
-	assert.match(strictAuthSource, /if \(!env\.CRABBOX_INTERACTIVE_PROVISION_TOKEN\)/);
-	assert.match(strictAuthSource, /throw serviceUnavailable/);
-	assert.doesNotMatch(strictAuthSource, /hasBackend/);
-	assert.match(stopSource, /stageStandaloneSandboxProvisionCleanup/);
-	assert.match(stopSource, /reconcileCredentialPolicyCleanupBatch/);
-	assert.match(stopSource, /status: remaining \? "stopping" : "stopped"/);
-	assert.match(source, /CRABBOX_STANDALONE_SANDBOX_TTL_SECONDS/);
-	assert.match(source, /function managedInteractiveSessionId/);
-	assert.match(source, /standaloneProvisionStopMatch/);
-	assert.match(source, /stopStandaloneSandboxProvision/);
-	assert.match(source, /policy\?\.expiresAt !== undefined && policy\.expiresAt <= Date\.now\(\)/);
-	assert.match(source, /standaloneSandboxPolicyExpiresAt/);
-	assert.match(
-		source,
-		/selectFrom\("standalone_sandbox_provisions"\)[\s\S]*failed to allocate an unreserved interactive session id/,
-	);
-	assert.match(source, /id = \$\{id\} COLLATE NOCASE/);
-	assert.match(expiryMigration, /UPDATE id_sequences/);
-	assert.match(expiryMigration, /MAX\(CAST\(substr\(lower\(id\), 4\) AS INTEGER\)\)/);
+  assert.match(endpointSource, /selectFrom\("interactive_sessions"\)/);
+  assert.match(endpointSource, /managed && managed\.preparation_pending !== 0/);
+  assert.match(endpointSource, /if \(managed\)/);
+  assert.ok(
+    endpointSource.indexOf("if (managed)") <
+      endpointSource.indexOf("return provisionStandaloneSandbox(env, payload)"),
+  );
+  assert.match(endpointSource, /provisionManagedSandboxEndpoint\(env, payload, managed\)/);
+  assert.match(endpointSource, /managedInteractiveSessionId\(payload\.id\)/);
+  assert.match(endpointSource, /managed session namespace/);
+  assert.match(endpointSource, /INSERT INTO standalone_sandbox_provisions/);
+  assert.match(endpointSource, /ownership_claim_expires_at/);
+  assert.match(endpointSource, /\$\{sandboxLeaseId\(lease\)\}/);
+  assert.match(endpointSource, /lease_id = excluded\.lease_id/);
+  assert.match(endpointSource, /provisionWithSandbox\([\s\S]*fence/);
+  assert.match(endpointSource, /state: "active"/);
+  assert.match(ownershipSource, /FROM standalone_sandbox_provisions AS owner/);
+  assert.match(ownershipSource, /owner\.ownership_claim = \$\{ownershipFence\.claim\}/);
+  assert.match(managedSource, /managedSandboxProvisionPayloadMatches/);
+  assert.ok(
+    managedSource.indexOf("managedSandboxProvisionPayloadMatches") <
+      managedSource.indexOf("newSandboxLease(payload.id)"),
+  );
+  assert.match(managedSource, /where\("updated_at", "=", session\.updated_at\)/);
+  assert.match(managedSource, /session\.preparation_pending !== 0/);
+  assert.match(managedSource, /\.where\("preparation_pending", "=", 0\)/);
+  assert.match(managedSource, /sandbox_refresh_claim: fence\.claim/);
+  assert.match(managedSource, /const agentToken = newAgentToken\(\)/);
+  assert.match(managedSource, /const agentTokenHash = await sha256\(agentToken\)/);
+  assert.match(managedSource, /agent_token_hash: agentTokenHash/);
+  assert.match(managedSource, /agent_token_hash IS \$\{session\.agent_token_hash\}/);
+  assert.match(managedSource, /provisionWithSandbox\(env, payload, agentToken, lease, fence\)/);
+  assert.ok(
+    managedSource.indexOf("sandboxProvisionPreflightError(env, payload)") <
+      managedSource.indexOf("const agentToken = newAgentToken()"),
+  );
+  assert.match(managedSource, /stageFailedManagedSandboxProvision/);
+  assert.match(managedSource, /where\("agent_token_hash", "=", agentTokenHash\)/);
+  assert.doesNotMatch(managedSource, /provisionWithSandbox\(env, payload, undefined/);
+  assert.match(managedSource, /executeBatch\(env, commitQueries\)/);
+  assert.match(managedCommitSource, /MAX\(updated_at \+ 1, \$\{commitRevision\}\)/);
+  assert.doesNotMatch(managedCommitSource, /where\("updated_at", "=", now\)/);
+  assert.match(managedCommitSource, /lease_id IS \$\{fence\.refreshLeaseId\}/);
+  assert.match(managedCommitSource, /sandbox_refresh_claim", "=", fence\.claim/);
+  assert.match(managedCommitSource, /sandbox_refresh_claim_expires_at", "=", fence\.expiresAt/);
+  assert.match(managedSource, /previousSandboxId/);
+  assert.match(managedSource, /state: "cleanup_pending"/);
+  assert.match(managedSource, /claimed\.numUpdatedRows/);
+  assert.match(ptySource, /authorizeProvisionEndpoint\(request, env\)/);
+  assert.match(ptySource, /standalone_sandbox_provisions/);
+  assert.match(ptySource, /where\("state", "=", "active"\)/);
+  assert.match(ptySource, /owner\.expires_at <= Date\.now\(\)/);
+  assert.match(ptySource, /stageStandaloneSandboxProvisionCleanup/);
+  assert.match(ptySource, /activeSandboxCredentialPolicyGeneration/);
+  assert.match(ptySource, /terminalHeaders\.delete\("authorization"\)/);
+  assert.match(ptySource, /const pair = new WebSocketPair\(\)/);
+  assert.match(ptySource, /response\.webSocket\.accept\(\)/);
+  assert.match(ptySource, /bridgeWebSockets\(/);
+  assert.match(ptySource, /standaloneSandboxTerminalGrant/);
+  assert.match(ptySource, /cachedBooleanGrant/);
+  assert.match(ptySource, /where\("request_hash", "=", ownership\.requestHash\)/);
+  assert.match(ptySource, /where\("expires_at", ">", now\)/);
+  assert.match(ptySource, /where\("updated_at", "=", ownership\.updatedAt\)/);
+  assert.match(ptySource, /activeSandboxCredentialPolicyCondition/);
+  assert.match(ptySource, /return new Response\(null, \{ status: 101, webSocket: client \}\)/);
+  assert.doesNotMatch(ptySource, /return response;/);
+  assert.match(standaloneCleanupSource, /deleteSession\(lease\.terminalSessionId\)/);
+  assert.match(standaloneCleanupSource, /isSandboxSessionAlreadyGone/);
+  assert.ok(
+    standaloneCleanupSource.indexOf("deleteSession(lease.terminalSessionId)") <
+      standaloneCleanupSource.indexOf('.deleteFrom("standalone_sandbox_provisions")'),
+  );
+  assert.match(standaloneCleanupSource, /where\("updated_at", "=", owner\.updated_at\)/);
+  assert.match(sandboxSource, /standaloneSandboxAttachUrl\(env, session\.id\)/);
+  assert.match(
+    endpointSource,
+    /const activationVersion = Math\.max\(Date\.now\(\), finishedAt \+ 1\)/,
+  );
+  assert.match(activationSource, /executeBatch\(env, \[/);
+  assert.ok(
+    activationSource.indexOf('.updateTable("interactive_session_credential_policies")') <
+      activationSource.indexOf('.updateTable("standalone_sandbox_provisions")'),
+  );
+  assert.match(activationSource, /set\(\{ updated_at: activationVersion \}\)/);
+  assert.match(
+    endpointSource,
+    /activeSandboxCredentialPolicyCondition\([\s\S]*policyGeneration,[\s\S]*activationVersion/,
+  );
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS standalone_sandbox_provisions/);
+  assert.match(migration, /request_hash TEXT NOT NULL/);
+  assert.match(migration, /sandbox_id TEXT NOT NULL UNIQUE/);
+  assert.match(expiryMigration, /ADD COLUMN expires_at INTEGER/);
+  assert.match(expiryMigration, /substr\(lower\(id\), 4\) NOT GLOB '\*\[\^0-9\]\*'/);
+  assert.match(expiryMigration, /idx_standalone_sandbox_provision_expiry/);
+  assert.match(expirySource, /state = 'active'/);
+  assert.match(expirySource, /expires_at <= \$\{now\}/);
+  assert.match(expirySource, /substr\(lower\(id\), 4\) NOT GLOB '\*\[\^0-9\]\*'/);
+  assert.match(stopSource, /authorizeProvisionBearerToken\(request, env\)/);
+  assert.match(strictAuthSource, /if \(!env\.CRABBOX_INTERACTIVE_PROVISION_TOKEN\)/);
+  assert.match(strictAuthSource, /throw serviceUnavailable/);
+  assert.doesNotMatch(strictAuthSource, /hasBackend/);
+  assert.match(stopSource, /stageStandaloneSandboxProvisionCleanup/);
+  assert.match(stopSource, /reconcileCredentialPolicyCleanupBatch/);
+  assert.match(stopSource, /status: remaining \? "stopping" : "stopped"/);
+  assert.match(source, /CRABBOX_STANDALONE_SANDBOX_TTL_SECONDS/);
+  assert.match(source, /function managedInteractiveSessionId/);
+  assert.match(source, /standaloneProvisionStopMatch/);
+  assert.match(source, /stopStandaloneSandboxProvision/);
+  assert.match(source, /policy\?\.expiresAt !== undefined && policy\.expiresAt <= Date\.now\(\)/);
+  assert.match(source, /standaloneSandboxPolicyExpiresAt/);
+  assert.match(
+    source,
+    /selectFrom\("standalone_sandbox_provisions"\)[\s\S]*failed to allocate an unreserved interactive session id/,
+  );
+  assert.match(source, /id = \$\{id\} COLLATE NOCASE/);
+  assert.match(expiryMigration, /UPDATE id_sequences/);
+  assert.match(expiryMigration, /MAX\(CAST\(substr\(lower\(id\), 4\) AS INTEGER\)\)/);
 });
 
 test("Sandbox credential egress proves the durable generation and owner", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const readStart = source.indexOf("async function sandboxCredentialPolicy(");
-	const readEnd = source.indexOf("async function sandboxOutbound", readStart);
-	const readSource = source.slice(readStart, readEnd);
-	const controlStart = source.indexOf("export class SessionControlDO");
-	const controlEnd = source.indexOf(
-		"function validSandboxCredentialPolicyRegistration",
-		controlStart,
-	);
-	const controlSource = source.slice(controlStart, controlEnd);
-	const egressStart = controlSource.indexOf("const egressMatch");
-	const egressEnd = controlSource.indexOf("const sandboxMatch", egressStart);
-	const egressSource = controlSource.slice(egressStart, egressEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const readStart = source.indexOf("async function sandboxCredentialPolicy(");
+  const readEnd = source.indexOf("async function sandboxOutbound", readStart);
+  const readSource = source.slice(readStart, readEnd);
+  const controlStart = source.indexOf("export class SessionControlDO");
+  const controlEnd = source.indexOf(
+    "function validSandboxCredentialPolicyRegistration",
+    controlStart,
+  );
+  const controlSource = source.slice(controlStart, controlEnd);
+  const egressStart = controlSource.indexOf("const egressMatch");
+  const egressEnd = controlSource.indexOf("const sandboxMatch", egressStart);
+  const egressSource = controlSource.slice(egressStart, egressEnd);
 
-	assert.match(readSource, /x-crabfleet-policy-generation/);
-	assert.match(readSource, /response\.status === 409/);
-	assert.match(readSource, /repairLegacySandboxCredentialPolicyBatch/);
-	assert.match(readSource, /response = await stub\.fetch\(policyUrl\)/);
-	assert.match(readSource, /sandboxCredentialPolicyHasDurableOwner/);
-	assert.match(readSource, /interactive_session_credential_policies/);
-	assert.match(readSource, /activeSandboxCredentialPolicyGeneration/);
-	assert.match(readSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
-	assert.match(readSource, /policy\.expiresAt === standalone\.expires_at/);
-	assert.match(controlSource, /const current = storedSandboxCredentialPolicy\(stored\)/);
-	assert.match(controlSource, /if \(!current \|\| !policy\)/);
-	assert.doesNotMatch(egressSource, /storage\.delete/);
-	assert.match(egressSource, /legacy credential policy migration required/);
-	assert.match(egressSource, /status: 409/);
-	assert.match(controlSource, /return current\.policy/);
-	assert.doesNotMatch(
-		controlSource,
-		/storedSandboxCredentialPolicy\(value\)\?\.policy \?\? legacySandboxCredentialPolicy/,
-	);
+  assert.match(readSource, /x-crabfleet-policy-generation/);
+  assert.match(readSource, /response\.status === 409/);
+  assert.match(readSource, /repairLegacySandboxCredentialPolicyBatch/);
+  assert.match(readSource, /response = await stub\.fetch\(policyUrl\)/);
+  assert.match(readSource, /sandboxCredentialPolicyHasDurableOwner/);
+  assert.match(readSource, /interactive_session_credential_policies/);
+  assert.match(readSource, /activeSandboxCredentialPolicyGeneration/);
+  assert.match(readSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
+  assert.match(readSource, /policy\.expiresAt === standalone\.expires_at/);
+  assert.match(controlSource, /const current = storedSandboxCredentialPolicy\(stored\)/);
+  assert.match(controlSource, /if \(!current \|\| !policy\)/);
+  assert.doesNotMatch(egressSource, /storage\.delete/);
+  assert.match(egressSource, /legacy credential policy migration required/);
+  assert.match(egressSource, /status: 409/);
+  assert.match(controlSource, /return current\.policy/);
+  assert.doesNotMatch(
+    controlSource,
+    /storedSandboxCredentialPolicy\(value\)\?\.policy \?\? legacySandboxCredentialPolicy/,
+  );
 });
 
 test("cron generation-wraps migrated legacy policies under exact live ownership", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const batchStart = source.indexOf("async function reconcileCredentialPolicyCleanupBatch");
-	const batchEnd = source.indexOf("async function reconcileCredentialPolicyCleanup(", batchStart);
-	const batchSource = source.slice(batchStart, batchEnd);
-	const beginStart = source.indexOf("async function beginLegacySandboxCredentialPolicyRepair");
-	const renewStart = source.indexOf(
-		"async function renewSandboxCredentialPolicyRegistration",
-		beginStart,
-	);
-	const repairSource = source.slice(beginStart, renewStart);
-	const controlStart = source.indexOf("export class SessionControlDO");
-	const controlEnd = source.indexOf("function storedSandboxCredentialPolicy", controlStart);
-	const controlSource = source.slice(controlStart, controlEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const batchStart = source.indexOf("async function reconcileCredentialPolicyCleanupBatch");
+  const batchEnd = source.indexOf("async function reconcileCredentialPolicyCleanup(", batchStart);
+  const batchSource = source.slice(batchStart, batchEnd);
+  const beginStart = source.indexOf("async function beginLegacySandboxCredentialPolicyRepair");
+  const renewStart = source.indexOf(
+    "async function renewSandboxCredentialPolicyRegistration",
+    beginStart,
+  );
+  const repairSource = source.slice(beginStart, renewStart);
+  const controlStart = source.indexOf("export class SessionControlDO");
+  const controlEnd = source.indexOf("function storedSandboxCredentialPolicy", controlStart);
+  const controlSource = source.slice(controlStart, controlEnd);
 
-	assert.ok(
-		batchSource.indexOf("repairLegacySandboxCredentialPolicyBatch") <
-			batchSource.indexOf("scanCredentialPolicyCleanupPage"),
-	);
-	assert.match(repairSource, /credentialPolicyLegacyGenerationPrefix/);
-	assert.match(repairSource, /credentialPolicyLegacyRepairClaimPrefix/);
-	assert.match(repairSource, /sandboxCredentialPolicyRegistrationQueries/);
-	assert.match(repairSource, /const ownership: SandboxCurrentLeaseFence/);
-	assert.match(repairSource, /renewSandboxCredentialPolicyRegistration/);
-	assert.match(repairSource, /\/api\/session-control\/migrate-legacy/);
-	assert.match(repairSource, /sandboxIds: registration\.lookupIds/);
-	assert.match(repairSource, /finishSandboxCredentialPolicyRegistration/);
-	assert.match(repairSource, /registration_claim_expires_at", "<=", now/);
-	assert.match(controlSource, /migratedCredentialPolicyRecord/);
-	assert.match(controlSource, /const sourcePolicy = records/);
-	assert.match(controlSource, /migratedRecords/);
-	assert.match(controlSource, /credentialPolicyMigrationCleanupMatches/);
-	assert.match(controlSource, /this\.ctx\.storage\.transaction/);
+  assert.ok(
+    batchSource.indexOf("repairLegacySandboxCredentialPolicyBatch") <
+      batchSource.indexOf("scanCredentialPolicyCleanupPage"),
+  );
+  assert.match(repairSource, /credentialPolicyLegacyGenerationPrefix/);
+  assert.match(repairSource, /credentialPolicyLegacyRepairClaimPrefix/);
+  assert.match(repairSource, /sandboxCredentialPolicyRegistrationQueries/);
+  assert.match(repairSource, /const ownership: SandboxCurrentLeaseFence/);
+  assert.match(repairSource, /renewSandboxCredentialPolicyRegistration/);
+  assert.match(repairSource, /\/api\/session-control\/migrate-legacy/);
+  assert.match(repairSource, /sandboxIds: registration\.lookupIds/);
+  assert.match(repairSource, /finishSandboxCredentialPolicyRegistration/);
+  assert.match(repairSource, /registration_claim_expires_at", "<=", now/);
+  assert.match(controlSource, /migratedCredentialPolicyRecord/);
+  assert.match(controlSource, /const sourcePolicy = records/);
+  assert.match(controlSource, /migratedRecords/);
+  assert.match(controlSource, /credentialPolicyMigrationCleanupMatches/);
+  assert.match(controlSource, /this\.ctx\.storage\.transaction/);
 });
 
 test("active credential-policy generations recover after a post-DO crash", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const scanStart = source.indexOf("async function scanCredentialPolicyCleanupPage");
-	const scanEnd = source.indexOf("async function readCredentialPolicyScanPage", scanStart);
-	const scanSource = source.slice(scanStart, scanEnd);
-	const repairStart = source.indexOf(
-		"async function repairActiveSandboxCredentialPolicyRegistration",
-	);
-	const repairEnd = source.indexOf("function credentialPolicyScanRequiresCleanup", repairStart);
-	const repairSource = source.slice(repairStart, repairEnd);
-	const promoteStart = source.indexOf("async function promoteSandboxCredentialPolicyRegistration");
-	const promoteEnd = source.indexOf("async function sandboxCredentialPolicyExists", promoteStart);
-	const promoteSource = source.slice(promoteStart, promoteEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const scanStart = source.indexOf("async function scanCredentialPolicyCleanupPage");
+  const scanEnd = source.indexOf("async function readCredentialPolicyScanPage", scanStart);
+  const scanSource = source.slice(scanStart, scanEnd);
+  const repairStart = source.indexOf(
+    "async function repairActiveSandboxCredentialPolicyRegistration",
+  );
+  const repairEnd = source.indexOf("function credentialPolicyScanRequiresCleanup", repairStart);
+  const repairSource = source.slice(repairStart, repairEnd);
+  const promoteStart = source.indexOf("async function promoteSandboxCredentialPolicyRegistration");
+  const promoteEnd = source.indexOf("async function sandboxCredentialPolicyExists", promoteStart);
+  const promoteSource = source.slice(promoteStart, promoteEnd);
 
-	assert.ok(
-		scanSource.indexOf("repairActiveSandboxCredentialPolicyRegistration") <
-			scanSource.indexOf("credentialPolicyScanRequiresCleanup"),
-	);
-	assert.match(scanSource, /repairedRegistrations/);
-	assert.match(scanSource, /deferredRegistrations/);
-	assert.match(repairSource, /row\.policy_state !== "registering"/);
-	assert.match(repairSource, /row\.registration_claim_expires_at/);
-	assert.match(repairSource, /credentialPolicyScanOwnershipFence/);
-	assert.match(repairSource, /sandboxCredentialPolicyExists/);
-	assert.match(repairSource, /recordSandboxCredentialPolicyRefs\([\s\S]*"active"/);
-	assert.match(repairSource, /repair lost durable ownership/);
-	assert.match(promoteSource, /state: "active"/);
-	assert.match(promoteSource, /registration_claim: null/);
-	assert.match(promoteSource, /registration_claim_expires_at: null/);
-	assert.match(promoteSource, /where\("registration_generation", "=", generation\)/);
-	assert.match(promoteSource, /expression\("registration_claim_expires_at", "<=", now\)/);
-	assert.match(promoteSource, /sandboxCredentialPolicyOwnerCondition/);
+  assert.ok(
+    scanSource.indexOf("repairActiveSandboxCredentialPolicyRegistration") <
+      scanSource.indexOf("credentialPolicyScanRequiresCleanup"),
+  );
+  assert.match(scanSource, /repairedRegistrations/);
+  assert.match(scanSource, /deferredRegistrations/);
+  assert.match(repairSource, /row\.policy_state !== "registering"/);
+  assert.match(repairSource, /row\.registration_claim_expires_at/);
+  assert.match(repairSource, /credentialPolicyScanOwnershipFence/);
+  assert.match(repairSource, /sandboxCredentialPolicyExists/);
+  assert.match(repairSource, /recordSandboxCredentialPolicyRefs\([\s\S]*"active"/);
+  assert.match(repairSource, /repair lost durable ownership/);
+  assert.match(promoteSource, /state: "active"/);
+  assert.match(promoteSource, /registration_claim: null/);
+  assert.match(promoteSource, /registration_claim_expires_at: null/);
+  assert.match(promoteSource, /where\("registration_generation", "=", generation\)/);
+  assert.match(promoteSource, /expression\("registration_claim_expires_at", "<=", now\)/);
+  assert.match(promoteSource, /sandboxCredentialPolicyOwnerCondition/);
 });
 
 test("Sandbox credential registration always proves exact durable ownership", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const ownerStart = source.indexOf("function sandboxManagedOwnershipCondition");
-	const ownerEnd = source.indexOf("async function abandonSandboxCredentialPolicyRegistration");
-	const ownerSource = source.slice(ownerStart, ownerEnd);
-	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
-	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
-	const createSource = source.slice(createStart, createEnd);
-	const ensureStart = source.indexOf("async function ensureSandboxCredentialPolicy");
-	const ensureEnd = source.indexOf("async function recordSandboxCredentialPolicyRefs", ensureStart);
-	const ensureSource = source.slice(ensureStart, ensureEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const ownerStart = source.indexOf("function sandboxManagedOwnershipCondition");
+  const ownerEnd = source.indexOf("async function abandonSandboxCredentialPolicyRegistration");
+  const ownerSource = source.slice(ownerStart, ownerEnd);
+  const createStart = source.indexOf("async function createInteractiveSessionFromInput");
+  const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
+  const createSource = source.slice(createStart, createEnd);
+  const ensureStart = source.indexOf("async function ensureSandboxCredentialPolicy");
+  const ensureEnd = source.indexOf("async function recordSandboxCredentialPolicyRefs", ensureStart);
+  const ensureSource = source.slice(ensureStart, ensureEnd);
 
-	assert.doesNotMatch(ownerSource, /ownershipFence\?:/);
-	assert.doesNotMatch(
-		ownerSource,
-		/ownershipFence: SandboxCredentialPolicyOwnershipFence \| undefined/,
-	);
-	assert.doesNotMatch(ownerSource, /1 = 1/);
-	assert.match(ownerSource, /lease_id = \$\{ownershipFence\.leaseId\}/);
-	assert.match(ownerSource, /sandbox_refresh_claim = \$\{ownershipFence\.claim\}/);
-	assert.match(ownerSource, /AND \$\{sandboxId\} = \$\{ownershipFence\.sandboxId\}/);
-	assert.match(createSource, /const initialSandboxLease/);
-	assert.match(createSource, /const initialAgentTokenHash = await sha256\(agentToken\)/);
-	assert.match(createSource, /lease_id: initialSandboxOwnership\?\.leaseId/);
-	assert.match(createSource, /ownership: initialSandboxOwnership/);
-	assert.match(ensureSource, /sandboxCurrentLeaseFence|SandboxCurrentLeaseFence/);
-	assert.match(ensureSource, /credentialPolicyLegacyGenerationPrefix/);
-	assert.match(ensureSource, /repairLegacySandboxCredentialPolicy/);
-	assert.match(
-		ensureSource,
-		/registerSandboxCredentialPolicy\(env, session, sandboxId, ownership\)/,
-	);
+  assert.doesNotMatch(ownerSource, /ownershipFence\?:/);
+  assert.doesNotMatch(
+    ownerSource,
+    /ownershipFence: SandboxCredentialPolicyOwnershipFence \| undefined/,
+  );
+  assert.doesNotMatch(ownerSource, /1 = 1/);
+  assert.match(ownerSource, /lease_id = \$\{ownershipFence\.leaseId\}/);
+  assert.match(ownerSource, /sandbox_refresh_claim = \$\{ownershipFence\.claim\}/);
+  assert.match(ownerSource, /AND \$\{sandboxId\} = \$\{ownershipFence\.sandboxId\}/);
+  assert.match(createSource, /const initialSandboxLease/);
+  assert.match(createSource, /const initialAgentTokenHash = await sha256\(agentToken\)/);
+  assert.match(createSource, /lease_id: initialSandboxOwnership\?\.leaseId/);
+  assert.match(createSource, /ownership: initialSandboxOwnership/);
+  assert.match(ensureSource, /sandboxCurrentLeaseFence|SandboxCurrentLeaseFence/);
+  assert.match(ensureSource, /credentialPolicyLegacyGenerationPrefix/);
+  assert.match(ensureSource, /repairLegacySandboxCredentialPolicy/);
+  assert.match(
+    ensureSource,
+    /registerSandboxCredentialPolicy\(env, session, sandboxId, ownership\)/,
+  );
 });
 
 test("initial terminal adapter responses enter durable finalization", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
-	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
-	const createSource = source.slice(createStart, createEnd);
-	const completionStart = createSource.indexOf("const provisionUpdate");
-	const completionEnd = createSource.indexOf(
-		"if ((provisionUpdate.numUpdatedRows",
-		completionStart,
-	);
-	const completionSource = createSource.slice(completionStart, completionEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const createStart = source.indexOf("async function createInteractiveSessionFromInput");
+  const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
+  const createSource = source.slice(createStart, createEnd);
+  const completionStart = createSource.indexOf("const provisionUpdate");
+  const completionEnd = createSource.indexOf(
+    "if ((provisionUpdate.numUpdatedRows",
+    completionStart,
+  );
+  const completionSource = createSource.slice(completionStart, completionEnd);
 
-	assert.ok(createStart >= 0 && createEnd > createStart);
-	assert.match(createSource, /const initialTerminalStatus: "stopped" \| "expired" \| "failed"/);
-	assert.match(createSource, /terminal_finalize_pending: initialTerminalStatus \? 1 : 0/);
-	assert.match(createSource, /stopped_at: terminalAt/);
-	assert.match(createSource, /agent_token_hash: null/);
-	assert.match(createSource, /attach_url: initialTerminalStatus \? null/);
-	assert.match(createSource, /adapter_create_pending: initialTerminalStatus/);
-	assert.match(completionSource, /MAX\(updated_at \+ 1, \$\{completionVersionFloor\}\)/);
-	assert.doesNotMatch(completionSource, /where\("updated_at"/);
-	assert.match(createSource, /lease_id IS \$\{initialSandboxOwnership\?\.leaseId \?\? null\}/);
-	assert.match(createSource, /where\("agent_token_hash", "=", initialAgentTokenHash\)/);
-	assert.match(createSource, /where\("sandbox_refresh_sandbox_id", "is", null\)/);
-	assert.match(createSource, /where\("sandbox_refresh_claim", "is", null\)/);
-	assert.match(createSource, /where\("sandbox_refresh_claim_expires_at", "is", null\)/);
-	assert.match(createSource, /finalizeTerminalInteractiveSession/);
+  assert.ok(createStart >= 0 && createEnd > createStart);
+  assert.match(createSource, /const initialTerminalStatus: "stopped" \| "expired" \| "failed"/);
+  assert.match(createSource, /terminal_finalize_pending: initialTerminalStatus \? 1 : 0/);
+  assert.match(createSource, /stopped_at: terminalAt/);
+  assert.match(createSource, /agent_token_hash: null/);
+  assert.match(createSource, /attach_url: initialTerminalStatus \? null/);
+  assert.match(createSource, /adapter_create_pending: initialTerminalStatus/);
+  assert.match(completionSource, /MAX\(updated_at \+ 1, \$\{completionVersionFloor\}\)/);
+  assert.doesNotMatch(completionSource, /where\("updated_at"/);
+  assert.match(createSource, /lease_id IS \$\{initialSandboxOwnership\?\.leaseId \?\? null\}/);
+  assert.match(createSource, /where\("agent_token_hash", "=", initialAgentTokenHash\)/);
+  assert.match(createSource, /where\("sandbox_refresh_sandbox_id", "is", null\)/);
+  assert.match(createSource, /where\("sandbox_refresh_claim", "is", null\)/);
+  assert.match(createSource, /where\("sandbox_refresh_claim_expires_at", "is", null\)/);
+  assert.match(createSource, /finalizeTerminalInteractiveSession/);
 });
 
 test("create-only adapters reject stopping responses before persistence", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const externalStart = source.indexOf("async function provisionInteractiveSession");
-	const externalEnd = source.indexOf("async function provisionInteractiveEndpoint", externalStart);
-	const externalSource = source.slice(externalStart, externalEnd);
-	const forwardedStart = source.indexOf("function provisionResultFromBody");
-	const forwardedEnd = source.indexOf("function failedProvision", forwardedStart);
-	const forwardedSource = source.slice(forwardedStart, forwardedEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const externalStart = source.indexOf("async function provisionInteractiveSession");
+  const externalEnd = source.indexOf("async function provisionInteractiveEndpoint", externalStart);
+  const externalSource = source.slice(externalStart, externalEnd);
+  const forwardedStart = source.indexOf("function provisionResultFromBody");
+  const forwardedEnd = source.indexOf("function failedProvision", forwardedStart);
+  const forwardedSource = source.slice(forwardedStart, forwardedEnd);
 
-	assert.match(externalSource, /createOnlyAdapterStatus\(body\.status\)/);
-	assert.match(forwardedSource, /createOnlyAdapterStatus\(body\.status\)/);
-	assert.match(forwardedSource, /if \(!status\) return failedProvision/);
+  assert.match(externalSource, /createOnlyAdapterStatus\(body\.status\)/);
+  assert.match(forwardedSource, /createOnlyAdapterStatus\(body\.status\)/);
+  assert.match(forwardedSource, /if \(!status\) return failedProvision/);
 });
 
 test("Sandbox cleanup and legacy stops use durable terminal transitions", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const actionStart = source.indexOf('if (action === "stop")');
-	const actionEnd = source.indexOf('throw badRequest("unknown action")', actionStart);
-	const stopSource = source.slice(actionStart, actionEnd);
-	const legacyCompleteIndex = stopSource.indexOf("completeLegacyInteractiveSessionStop");
-	const cleanupIndex = stopSource.lastIndexOf(
-		"stageTerminalCredentialPolicyCleanupById",
-		legacyCompleteIndex,
-	);
-	const reconcileIndex = stopSource.indexOf("reconcileCredentialPolicyCleanupBatch", cleanupIndex);
-	const completeStart = source.indexOf("async function completeLegacyInteractiveSessionStop");
-	const completeEnd = source.indexOf("async function mutateInteractiveSession(", completeStart);
-	const completeSource = source.slice(completeStart, completeEnd);
-	const scheduledStart = source.indexOf(
-		"async function reconcileLegacyStoppingInteractiveSessionBatch",
-	);
-	const scheduledEnd = source.indexOf(
-		"async function requeueTerminalArchiveObjectBackfill",
-		scheduledStart,
-	);
-	const scheduledSource = source.slice(scheduledStart, scheduledEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const actionStart = source.indexOf('if (action === "stop")');
+  const actionEnd = source.indexOf('throw badRequest("unknown action")', actionStart);
+  const stopSource = source.slice(actionStart, actionEnd);
+  const legacyCompleteIndex = stopSource.indexOf("completeLegacyInteractiveSessionStop");
+  const cleanupIndex = stopSource.lastIndexOf(
+    "stageTerminalCredentialPolicyCleanupById",
+    legacyCompleteIndex,
+  );
+  const reconcileIndex = stopSource.indexOf("reconcileCredentialPolicyCleanupBatch", cleanupIndex);
+  const completeStart = source.indexOf("async function completeLegacyInteractiveSessionStop");
+  const completeEnd = source.indexOf("async function mutateInteractiveSession(", completeStart);
+  const completeSource = source.slice(completeStart, completeEnd);
+  const scheduledStart = source.indexOf(
+    "async function reconcileLegacyStoppingInteractiveSessionBatch",
+  );
+  const scheduledEnd = source.indexOf(
+    "async function requeueTerminalArchiveObjectBackfill",
+    scheduledStart,
+  );
+  const scheduledSource = source.slice(scheduledStart, scheduledEnd);
 
-	assert.ok(actionStart >= 0 && actionEnd > actionStart);
-	assert.ok(
-		cleanupIndex >= 0 && reconcileIndex > cleanupIndex && legacyCompleteIndex > reconcileIndex,
-	);
-	assert.match(stopSource, /const staged = await stageTerminalCredentialPolicyCleanupById/);
-	assert.match(stopSource, /if \(!staged\)/);
-	assert.match(stopSource, /credential_cleanup_terminal_status/);
-	assert.match(
-		stopSource,
-		/completeLegacyInteractiveSessionStop\(env, session, actor\(user\), now\)/,
-	);
-	assert.match(completeSource, /env\.DB\.batch/);
-	assert.match(completeSource, /interactive workspace stop requested/);
-	assert.match(completeSource, /interactive workspace stopped/);
-	assert.match(completeSource, /status: "stopped"/);
-	assert.match(completeSource, /terminal_finalize_pending: 1/);
-	assert.match(completeSource, /AND status = \$\{owner\.status\}/);
-	assert.match(completeSource, /AND updated_at = \$\{owner\.updatedAt\}/);
-	assert.match(completeSource, /finalizeTerminalInteractiveSession/);
-	assert.doesNotMatch(completeSource, /status: "stopping"/);
-	assert.match(scheduledSource, /where\("status", "=", "stopping"\)/);
-	assert.match(scheduledSource, /\.where\("runtime", "!=", githubActionsRuntime\)/);
-	assert.match(scheduledSource, /completeLegacyInteractiveSessionStop/);
-	assert.match(completeSource, /if \(owner\.runtime === githubActionsRuntime\) return false/);
-	assert.match(completeSource, /async function stopGitHubActionsSession/);
-	assert.match(completeSource, /work_state: ""/);
-	assert.match(completeSource, /work_phase: "session_ended"/);
-	assert.match(completeSource, /workflow run not canceled/);
-	assert.match(stopSource, /session\.runtime === githubActionsRuntime/);
-	assert.match(stopSource, /stopGitHubActionsSession\(env, session, userActor, now\)/);
-	assert.match(stopSource, /interactive session lifecycle changed; retry stop/);
-	assert.match(stopSource, /const current = await readInteractiveSession\(env, id\)/);
-	assert.match(stopSource, /current\.adapter !== runtimeAdapterName/);
-	assert.match(stopSource, /current\.adapterWorkspaceId !== session\.adapterWorkspaceId/);
-	assert.match(stopSource, /\["stopping", "stopped", "expired", "failed"\]\.includes/);
+  assert.ok(actionStart >= 0 && actionEnd > actionStart);
+  assert.ok(
+    cleanupIndex >= 0 && reconcileIndex > cleanupIndex && legacyCompleteIndex > reconcileIndex,
+  );
+  assert.match(stopSource, /const staged = await stageTerminalCredentialPolicyCleanupById/);
+  assert.match(stopSource, /if \(!staged\)/);
+  assert.match(stopSource, /credential_cleanup_terminal_status/);
+  assert.match(
+    stopSource,
+    /completeLegacyInteractiveSessionStop\(env, session, actor\(user\), now\)/,
+  );
+  assert.match(completeSource, /env\.DB\.batch/);
+  assert.match(completeSource, /interactive workspace stop requested/);
+  assert.match(completeSource, /interactive workspace stopped/);
+  assert.match(completeSource, /status: "stopped"/);
+  assert.match(completeSource, /terminal_finalize_pending: 1/);
+  assert.match(completeSource, /AND status = \$\{owner\.status\}/);
+  assert.match(completeSource, /AND updated_at = \$\{owner\.updatedAt\}/);
+  assert.match(completeSource, /finalizeTerminalInteractiveSession/);
+  assert.doesNotMatch(completeSource, /status: "stopping"/);
+  assert.match(scheduledSource, /where\("status", "=", "stopping"\)/);
+  assert.match(scheduledSource, /\.where\("runtime", "!=", githubActionsRuntime\)/);
+  assert.match(scheduledSource, /completeLegacyInteractiveSessionStop/);
+  assert.match(completeSource, /if \(owner\.runtime === githubActionsRuntime\) return false/);
+  assert.match(completeSource, /async function stopGitHubActionsSession/);
+  assert.match(completeSource, /work_state: ""/);
+  assert.match(completeSource, /work_phase: "session_ended"/);
+  assert.match(completeSource, /workflow run not canceled/);
+  assert.match(stopSource, /session\.runtime === githubActionsRuntime/);
+  assert.match(stopSource, /stopGitHubActionsSession\(env, session, userActor, now\)/);
+  assert.match(stopSource, /interactive session lifecycle changed; retry stop/);
+  assert.match(stopSource, /const current = await readInteractiveSession\(env, id\)/);
+  assert.match(stopSource, /current\.adapter !== runtimeAdapterName/);
+  assert.match(stopSource, /current\.adapterWorkspaceId !== session\.adapterWorkspaceId/);
+  assert.match(stopSource, /\["stopping", "stopped", "expired", "failed"\]\.includes/);
 });
 
 test("legacy expiry enters the shared retryable terminal finalizer", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const expiryStart = source.indexOf("async function markInteractiveTerminalUnavailable");
-	const expiryEnd = source.indexOf("async function uploadInteractiveSessionClipboard", expiryStart);
-	const expirySource = source.slice(expiryStart, expiryEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const expiryStart = source.indexOf("async function markInteractiveTerminalUnavailable");
+  const expiryEnd = source.indexOf("async function uploadInteractiveSessionClipboard", expiryStart);
+  const expirySource = source.slice(expiryStart, expiryEnd);
 
-	assert.match(expirySource, /status: "expired"/);
-	assert.match(expirySource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
-	assert.match(expirySource, /where\("updated_at", "=", existing\.updated_at\)/);
-	assert.match(expirySource, /terminal_finalize_pending: 1/);
-	assert.match(expirySource, /finalizeTerminalInteractiveSession\(env, id, "expired", now\)/);
-	assert.match(expirySource, /stageTerminalCredentialPolicyCleanupById/);
-	assert.match(
-		expirySource,
-		/stageTerminalCredentialPolicyCleanupById\([\s\S]*?"failed",\s*message,[\s\S]*?now,\s*message/,
-	);
-	assert.match(expirySource, /reconcileCredentialPolicyCleanupBatch\(env, now, id\)/);
-	assert.ok(
-		expirySource.indexOf("stageTerminalCredentialPolicyCleanup") <
-			expirySource.indexOf("reconcileCredentialPolicyCleanupBatch"),
-	);
+  assert.match(expirySource, /status: "expired"/);
+  assert.match(expirySource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
+  assert.match(expirySource, /where\("updated_at", "=", existing\.updated_at\)/);
+  assert.match(expirySource, /terminal_finalize_pending: 1/);
+  assert.match(expirySource, /finalizeTerminalInteractiveSession\(env, id, "expired", now\)/);
+  assert.match(expirySource, /stageTerminalCredentialPolicyCleanupById/);
+  assert.match(
+    expirySource,
+    /stageTerminalCredentialPolicyCleanupById\([\s\S]*?"failed",\s*message,[\s\S]*?now,\s*message/,
+  );
+  assert.match(expirySource, /reconcileCredentialPolicyCleanupBatch\(env, now, id\)/);
+  assert.ok(
+    expirySource.indexOf("stageTerminalCredentialPolicyCleanup") <
+      expirySource.indexOf("reconcileCredentialPolicyCleanupBatch"),
+  );
 });
 
 test("idempotent legacy terminal stop verifies credential cleanup", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const actionStart = source.indexOf('if (action === "stop")');
-	const legacyCompleteIndex = source.indexOf(
-		"completeLegacyInteractiveSessionStop(env, session",
-		actionStart,
-	);
-	const fastPathSource = source.slice(actionStart, legacyCompleteIndex);
-	const unregisterStart = source.indexOf("async function unregisterSandboxCredentialPolicyLookup");
-	const unregisterEnd = source.indexOf(
-		"function sandboxCredentialPolicyRefQueries",
-		unregisterStart,
-	);
-	const unregisterSource = source.slice(unregisterStart, unregisterEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const actionStart = source.indexOf('if (action === "stop")');
+  const legacyCompleteIndex = source.indexOf(
+    "completeLegacyInteractiveSessionStop(env, session",
+    actionStart,
+  );
+  const fastPathSource = source.slice(actionStart, legacyCompleteIndex);
+  const unregisterStart = source.indexOf("async function unregisterSandboxCredentialPolicyLookup");
+  const unregisterEnd = source.indexOf(
+    "function sandboxCredentialPolicyRefQueries",
+    unregisterStart,
+  );
+  const unregisterSource = source.slice(unregisterStart, unregisterEnd);
 
-	assert.match(fastPathSource, /isSandboxInteractiveSession\(session\)/);
-	assert.match(fastPathSource, /stageTerminalCredentialPolicyCleanup/);
-	assert.match(fastPathSource, /reconcileCredentialPolicyCleanupBatch/);
-	assert.match(unregisterSource, /if \(!stub\) throw serviceUnavailable/);
-	assert.match(unregisterSource, /if \(!response\.ok\)/);
-	assert.doesNotMatch(unregisterSource, /response\.status !== 404/);
-	assert.match(unregisterSource, /sandbox credential policy cleanup failed/);
+  assert.match(fastPathSource, /isSandboxInteractiveSession\(session\)/);
+  assert.match(fastPathSource, /stageTerminalCredentialPolicyCleanup/);
+  assert.match(fastPathSource, /reconcileCredentialPolicyCleanupBatch/);
+  assert.match(unregisterSource, /if \(!stub\) throw serviceUnavailable/);
+  assert.match(unregisterSource, /if \(!response\.ok\)/);
+  assert.doesNotMatch(unregisterSource, /response\.status !== 404/);
+  assert.match(unregisterSource, /sandbox credential policy cleanup failed/);
 });
 
 test("sandbox credential cleanup is durably staged and retried", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const migration = await readFile(
-		new URL("../migrations/0022_credential_policy_cleanup.sql", import.meta.url),
-		"utf8",
-	);
-	const stageStart = source.indexOf("async function stageTerminalCredentialPolicyCleanup");
-	const stageEnd = source.indexOf("type CredentialPolicyScanRow", stageStart);
-	const stageSource = source.slice(stageStart, stageEnd);
-	const scanStart = stageEnd;
-	const batchStart = source.indexOf(
-		"async function reconcileCredentialPolicyCleanupBatch",
-		scanStart,
-	);
-	const scanSource = source.slice(scanStart, batchStart);
-	const batchEnd = source.indexOf("async function reconcileCredentialPolicyCleanup(", batchStart);
-	const batchSource = source.slice(batchStart, batchEnd);
-	const cleanupStart = batchEnd;
-	const cleanupEnd = source.indexOf(
-		"async function completeCredentialPolicyCleanupSession",
-		cleanupStart,
-	);
-	const cleanupSource = source.slice(cleanupStart, cleanupEnd);
-	const completionEnd = source.indexOf("function legacyInteractiveSessionLeaseId", cleanupEnd);
-	const completionSource = source.slice(cleanupEnd, completionEnd);
-	const provisionStart = source.indexOf("async function provisionWithSandbox");
-	const provisionEnd = source.indexOf(
-		"async function registerSandboxCredentialPolicy",
-		provisionStart,
-	);
-	const provisionSource = source.slice(provisionStart, provisionEnd);
-	const registerStart = provisionEnd;
-	const registerEnd = source.indexOf("async function ensureSandboxCredentialPolicy", registerStart);
-	const registerSource = source.slice(registerStart, registerEnd);
-	const registrationLifecycleStart = source.indexOf(
-		"function sandboxCredentialPolicyRegistrationQueries",
-	);
-	const registrationLifecycleSource = source.slice(registrationLifecycleStart, registerEnd);
-	const finishStart = source.indexOf("async function finishSandboxCredentialPolicyRegistration");
-	const finishEnd = source.indexOf(
-		"async function abandonSandboxCredentialPolicyRegistration",
-		finishStart,
-	);
-	const finishSource = source.slice(finishStart, finishEnd);
-	const abandonEnd = source.indexOf("async function registerSandboxCredentialPolicy", finishEnd);
-	const abandonSource = source.slice(finishEnd, abandonEnd);
-	const scanDecisionStart = source.indexOf("function credentialPolicyScanRequiresCleanup");
-	const scanDecisionEnd = source.indexOf(
-		"async function normalizeCredentialPolicyCleanupGroups",
-		scanDecisionStart,
-	);
-	const scanDecisionSource = source.slice(scanDecisionStart, scanDecisionEnd);
-	const controlStart = source.indexOf("export class SessionControlDO");
-	const controlEnd = source.indexOf("function dedupeSandboxPolicies", controlStart);
-	const controlSource = source.slice(controlStart, controlEnd);
-	const refreshStart = source.indexOf("async function ensureCurrentSandboxLease");
-	const refreshEnd = source.indexOf("async function prepareSandboxWorkspace", refreshStart);
-	const refreshSource = source.slice(refreshStart, refreshEnd);
-	const ownershipStart = source.indexOf("function sandboxTerminalCleanupOwnership");
-	const ownershipSource = source.slice(ownershipStart, stageStart);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const migration = await readFile(
+    new URL("../migrations/0022_credential_policy_cleanup.sql", import.meta.url),
+    "utf8",
+  );
+  const stageStart = source.indexOf("async function stageTerminalCredentialPolicyCleanup");
+  const stageEnd = source.indexOf("type CredentialPolicyScanRow", stageStart);
+  const stageSource = source.slice(stageStart, stageEnd);
+  const scanStart = stageEnd;
+  const batchStart = source.indexOf(
+    "async function reconcileCredentialPolicyCleanupBatch",
+    scanStart,
+  );
+  const scanSource = source.slice(scanStart, batchStart);
+  const batchEnd = source.indexOf("async function reconcileCredentialPolicyCleanup(", batchStart);
+  const batchSource = source.slice(batchStart, batchEnd);
+  const cleanupStart = batchEnd;
+  const cleanupEnd = source.indexOf(
+    "async function completeCredentialPolicyCleanupSession",
+    cleanupStart,
+  );
+  const cleanupSource = source.slice(cleanupStart, cleanupEnd);
+  const completionEnd = source.indexOf("function legacyInteractiveSessionLeaseId", cleanupEnd);
+  const completionSource = source.slice(cleanupEnd, completionEnd);
+  const provisionStart = source.indexOf("async function provisionWithSandbox");
+  const provisionEnd = source.indexOf(
+    "async function registerSandboxCredentialPolicy",
+    provisionStart,
+  );
+  const provisionSource = source.slice(provisionStart, provisionEnd);
+  const registerStart = provisionEnd;
+  const registerEnd = source.indexOf("async function ensureSandboxCredentialPolicy", registerStart);
+  const registerSource = source.slice(registerStart, registerEnd);
+  const registrationLifecycleStart = source.indexOf(
+    "function sandboxCredentialPolicyRegistrationQueries",
+  );
+  const registrationLifecycleSource = source.slice(registrationLifecycleStart, registerEnd);
+  const finishStart = source.indexOf("async function finishSandboxCredentialPolicyRegistration");
+  const finishEnd = source.indexOf(
+    "async function abandonSandboxCredentialPolicyRegistration",
+    finishStart,
+  );
+  const finishSource = source.slice(finishStart, finishEnd);
+  const abandonEnd = source.indexOf("async function registerSandboxCredentialPolicy", finishEnd);
+  const abandonSource = source.slice(finishEnd, abandonEnd);
+  const scanDecisionStart = source.indexOf("function credentialPolicyScanRequiresCleanup");
+  const scanDecisionEnd = source.indexOf(
+    "async function normalizeCredentialPolicyCleanupGroups",
+    scanDecisionStart,
+  );
+  const scanDecisionSource = source.slice(scanDecisionStart, scanDecisionEnd);
+  const controlStart = source.indexOf("export class SessionControlDO");
+  const controlEnd = source.indexOf("function dedupeSandboxPolicies", controlStart);
+  const controlSource = source.slice(controlStart, controlEnd);
+  const refreshStart = source.indexOf("async function ensureCurrentSandboxLease");
+  const refreshEnd = source.indexOf("async function prepareSandboxWorkspace", refreshStart);
+  const refreshSource = source.slice(refreshStart, refreshEnd);
+  const ownershipStart = source.indexOf("function sandboxTerminalCleanupOwnership");
+  const ownershipSource = source.slice(ownershipStart, stageStart);
 
-	assert.match(stageSource, /executeBatch\(env, \[sessionTransition, \.\.\.policyTransitions\]\)/);
-	assert.match(stageSource, /status: "stopping"/);
-	assert.match(stageSource, /credential_cleanup_terminal_status: cleanupIntent/);
-	assert.match(stageSource, /credential_cleanup_terminal_status = 'failed'/);
-	assert.match(stageSource, /credential_cleanup_terminal_status = 'expired'/);
-	assert.match(stageSource, /terminalCleanupIntentRank/);
-	assert.match(stageSource, /sandbox_refresh_claim: null/);
-	assert.match(stageSource, /sandboxManagedStoredOwnershipCondition\(ownership\.fence\)/);
-	assert.match(stageSource, /where\("updated_at", "=", session\.updated_at\)/);
-	assert.match(stageSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
-	assert.match(stageSource, /\.where\("sandbox_id", "=", sandboxId\)/);
-	assert.match(stageSource, /agent_token_hash: null/);
-	assert.match(stageSource, /controller: null/);
-	assert.match(stageSource, /terminal_failure_reason:/);
-	assert.match(stageSource, /failureReason/);
-	assert.match(stageSource, /NULLIF\(terminal_failure_reason, ''\)/);
-	assert.match(stageSource, /terminal_failure_reason: failureEvidence/);
-	assert.match(stageSource, /state: "cleanup_pending"/);
-	assert.match(stageSource, /for \(let attempt = 0; attempt < 3; attempt \+= 1\)/);
-	assert.match(ownershipSource, /sandboxLeaseWithoutRefresh/);
-	assert.match(ownershipSource, /sandbox_refresh_claim_expires_at/);
-	assert.match(ownershipSource, /sandboxIds: \[\.\.\.new Set/);
-	assert.match(scanSource, /credentialPolicyScanLimit/);
-	assert.match(scanSource, /scan_max_rowid/);
-	assert.match(scanSource, /maximumCredentialPolicyRowid/);
-	assert.match(scanSource, /policy\.rowid > \$\{cursor\}/);
-	assert.match(scanSource, /policy\.rowid <= \$\{maxRowid\}/);
-	assert.doesNotMatch(scanSource, /affectedSessions/);
-	assert.doesNotMatch(scanSource, /const transitioned = await update\.executeTakeFirst\(\)/);
-	assert.match(scanSource, /const sessionTransition = sql/);
-	assert.match(scanSource, /executeBatch\(env, \[sessionTransition, policyTransition\]\)/);
-	assert.match(scanSource, /executeBatch\(env, \[ownerTransition, policyTransition\]\)/);
-	assert.match(scanSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
-	assert.match(scanSource, /AND status IS \$\{row\.session_status\}/);
-	assert.match(scanSource, /AND lease_id IS \$\{row\.session_lease_id\}/);
-	assert.match(scanSource, /AND agent_token_hash IS \$\{row\.session_agent_token_hash\}/);
-	assert.match(scanSource, /standalone\.ownership_claim AS standalone_claim/);
-	assert.match(scanSource, /AND updated_at IS \$\{row\.session_updated_at\}/);
-	assert.match(scanSource, /\.where\("sandbox_id", "=", row\.sandbox_id\)/);
-	assert.match(scanSource, /\.where\("lookup_id", "=", row\.lookup_id\)/);
-	assert.match(
-		scanSource,
-		/\.where\("registration_generation", "=", row\.registration_generation\)/,
-	);
-	assert.match(scanSource, /terminal_failure_reason = CASE/);
-	assert.match(scanSource, /credential_cleanup_terminal_status = 'failed'/);
-	assert.match(scanSource, /credential_cleanup_terminal_status = 'expired'/);
-	assert.match(scanSource, /const transitionRevision = Math\.max/);
-	assert.match(scanSource, /agent_token_hash = NULL/);
-	assert.match(scanSource, /credentialPolicySandboxIsExpected/);
-	assert.match(scanSource, /sandbox_refresh_claim = NULL/);
-	assert.match(scanSource, /normalizeCredentialPolicyCleanupGroups/);
-	assert.match(scanSource, /group_max_session_id/);
-	assert.match(batchSource, /scanCredentialPolicyCleanupPage/);
-	assert.match(batchSource, /normalizeCredentialPolicyCleanupGroups/);
-	assert.match(batchSource, /COALESCE\(last_attempt_at, created_at\)/);
-	assert.match(batchSource, /\.limit\(credentialPolicyCleanupLimit\)/);
-	assert.match(batchSource, /completeStandaloneSandboxProvisionCleanupSafely/);
-	assert.match(cleanupSource, /cleanup_claim_expires_at/);
-	assert.match(cleanupSource, /registration_claim_expires_at > \$\{now\}/);
-	assert.match(cleanupSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
-	assert.ok(
-		cleanupSource.indexOf("cleanup_claim = ${claim}") <
-			cleanupSource.indexOf("unregisterSandboxCredentialPolicyLookup"),
-	);
-	assert.match(cleanupSource, /last_error:/);
-	assert.match(cleanupSource, /cleanup_claim: null/);
-	assert.match(cleanupSource, /async function completeStandaloneSandboxProvisionCleanupSafely/);
-	assert.match(cleanupSource, /standalone Sandbox cleanup pending/);
-	assert.match(cleanupSource, /standalone_sandbox_provisions/);
-	assert.match(cleanupSource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
-	assert.match(cleanupSource, /cleanup failure persistence failed/);
-	assert.match(completionSource, /NOT EXISTS \(/);
-	assert.match(completionSource, /status: terminalStatus/);
-	assert.match(completionSource, /terminal_finalize_pending: 1/);
-	assert.match(completionSource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
-	assert.match(completionSource, /\.where\("status", "=", session\.status\)/);
-	assert.match(completionSource, /\.where\("updated_at", "=", session\.updated_at\)/);
-	assert.match(completionSource, /retainedRuntimeAdapterFailureMessage/);
-	assert.match(completionSource, /terminal_failure_reason:/);
-	assert.match(completionSource, /\? failureMessage/);
-	assert.match(batchSource, /completeCredentialPolicyCleanupSession\(env, session\.id/);
-	assert.ok(
-		provisionSource.indexOf("stageTerminalCredentialPolicyCleanupById") <
-			provisionSource.indexOf("reconcileCredentialPolicyCleanupBatch"),
-	);
-	assert.match(provisionSource, /failureAt,\s*cleanupMessage,\s*ownershipFence/);
-	assert.match(provisionSource, /try \{[\s\S]*sandboxProvisionPreflightError\(env, session\)/);
-	assert.match(provisionSource, /!agentToken/);
-	assert.match(provisionSource, /managed Sandbox agent token is unavailable/);
-	assert.match(registrationLifecycleSource, /registration_generation/);
-	assert.match(registrationLifecycleSource, /registration_claim/);
-	assert.match(registrationLifecycleSource, /registration_claim_expires_at/);
-	assert.doesNotMatch(registrationLifecycleSource, /ownershipFence\?:/);
-	assert.doesNotMatch(registrationLifecycleSource, /1 = 1/);
-	assert.match(registrationLifecycleSource, /sandboxCredentialPolicyOwnerCondition/);
-	assert.match(registrationLifecycleSource, /sandboxCredentialPolicyOwnerCondition/);
-	assert.ok(
-		registerSource.indexOf("beginSandboxCredentialPolicyRegistration") <
-			registerSource.indexOf(
-				'stub.fetch("https://crabfleet.internal/api/session-control/register"',
-			),
-	);
-	assert.ok(
-		registerSource.indexOf("renewSandboxCredentialPolicyRegistration") <
-			registerSource.indexOf(
-				'stub.fetch("https://crabfleet.internal/api/session-control/register"',
-			),
-	);
-	assert.ok(
-		registerSource.indexOf('stub.fetch("https://crabfleet.internal/api/session-control/register"') <
-			registerSource.indexOf("finishSandboxCredentialPolicyRegistration"),
-	);
-	assert.doesNotMatch(finishSource, /INSERT INTO|insertInto/);
-	assert.match(finishSource, /state: "active"/);
-	assert.match(finishSource, /where\(sandboxCredentialPolicyOwnerCondition/);
-	assert.doesNotMatch(finishSource, /cleanup_pending/);
-	assert.match(registerSource, /abandonSandboxCredentialPolicyRegistration/);
-	assert.match(abandonSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
-	assert.match(abandonSource, /THEN 'cleanup_pending'/);
-	assert.match(abandonSource, /ELSE 'registering'/);
-	assert.ok(
-		scanDecisionSource.indexOf("sandboxExpected") <
-			scanDecisionSource.indexOf("if (registrationAbandoned) return true"),
-	);
-	assert.doesNotMatch(scanDecisionSource, /row\.session_agent_token_hash !== null/);
-	assert.match(scanDecisionSource, /sandboxExpected &&[\s\S]*row\.session_status === "ready"/);
-	assert.match(controlSource, /sandboxPolicyTombstoneKey/);
-	assert.match(controlSource, /credentialPolicyRegistrationAccepted/);
-	assert.match(controlSource, /credentialPolicyCleanupMatches/);
-	assert.match(controlSource, /this\.ctx\.storage\.transaction/);
-	assert.doesNotMatch(source, /async function unregisterSandboxCredentialPolicy\(/);
-	assert.match(migration, /CREATE TABLE IF NOT EXISTS interactive_session_credential_policies/);
-	assert.match(migration, /state IN \('registering', 'active', 'cleanup_pending'\)/);
-	assert.match(migration, /registration_generation TEXT NOT NULL/);
-	assert.match(migration, /registration_claim_expires_at INTEGER/);
-	assert.match(migration, /CREATE TABLE IF NOT EXISTS credential_policy_reconcile_state/);
-	assert.match(migration, /scan_max_rowid INTEGER NOT NULL/);
-	assert.match(migration, /group_max_session_id TEXT NOT NULL/);
-	assert.match(migration, /ADD COLUMN sandbox_refresh_sandbox_id TEXT/);
-	assert.match(migration, /ADD COLUMN sandbox_refresh_claim TEXT/);
-	assert.match(migration, /ADD COLUMN sandbox_refresh_claim_expires_at INTEGER/);
-	assert.match(migration, /CREATE TABLE IF NOT EXISTS standalone_sandbox_provisions/);
-	assert.match(migration, /idx_interactive_policy_fair_cleanup/);
-	assert.match(migration, /COALESCE\(last_attempt_at, created_at\)/);
-	assert.match(migration, /terminal_failure_reason = CASE/);
-	assert.match(migration, /terminal_finalize_pending = 0/);
-	assert.match(migration, /agent_token_hash = NULL/);
-	assert.match(migration, /SET\s+status = 'stopping'/);
-	assert.match(refreshSource, /sandbox_refresh_sandbox_id: refreshFence\.sandboxId/);
-	assert.match(refreshSource, /sandbox_refresh_claim: refreshFence\.claim/);
-	assert.match(refreshSource, /sandbox_refresh_claim_expires_at: refreshFence\.expiresAt/);
-	assert.match(refreshSource, /const agentToken = newAgentToken\(\)/);
-	assert.ok(
-		refreshSource.indexOf("sandboxProvisionPreflightError(env, refreshPayload)") <
-			refreshSource.indexOf("const agentToken = newAgentToken()"),
-	);
-	assert.match(refreshSource, /agent_token_hash: agentTokenHash/);
-	assert.match(refreshSource, /provisionWithSandbox\([\s\S]*?agentToken,[\s\S]*?refreshLease/);
-	assert.match(refreshSource, /where\("agent_token_hash", "=", agentTokenHash\)/);
-	assert.match(refreshSource, /sandbox_refresh_claim_expires_at", "=", refreshFence\.expiresAt/);
-	assert.match(refreshSource, /executeBatch\(env, commitQueries\)/);
-	assert.match(refreshSource, /state: "cleanup_pending"/);
-	assert.match(refreshSource, /stageFailedManagedSandboxProvision/);
-	assert.ok(
-		refreshSource.indexOf("sandbox_refresh_claim: null") <
-			refreshSource.lastIndexOf("reconcileCredentialPolicyCleanupBatch"),
-	);
-	assert.doesNotMatch(
-		refreshSource,
-		/queueSandboxCredentialPolicyCleanup\(env, session\.id, oldSandboxId, refreshedAt\)/,
-	);
-	assert.match(refreshSource, /const current = await readInteractiveSession/);
+  assert.match(stageSource, /executeBatch\(env, \[sessionTransition, \.\.\.policyTransitions\]\)/);
+  assert.match(stageSource, /status: "stopping"/);
+  assert.match(stageSource, /credential_cleanup_terminal_status: cleanupIntent/);
+  assert.match(stageSource, /credential_cleanup_terminal_status = 'failed'/);
+  assert.match(stageSource, /credential_cleanup_terminal_status = 'expired'/);
+  assert.match(stageSource, /terminalCleanupIntentRank/);
+  assert.match(stageSource, /sandbox_refresh_claim: null/);
+  assert.match(stageSource, /sandboxManagedStoredOwnershipCondition\(ownership\.fence\)/);
+  assert.match(stageSource, /where\("updated_at", "=", session\.updated_at\)/);
+  assert.match(stageSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
+  assert.match(stageSource, /\.where\("sandbox_id", "=", sandboxId\)/);
+  assert.match(stageSource, /agent_token_hash: null/);
+  assert.match(stageSource, /controller: null/);
+  assert.match(stageSource, /terminal_failure_reason:/);
+  assert.match(stageSource, /failureReason/);
+  assert.match(stageSource, /NULLIF\(terminal_failure_reason, ''\)/);
+  assert.match(stageSource, /terminal_failure_reason: failureEvidence/);
+  assert.match(stageSource, /state: "cleanup_pending"/);
+  assert.match(stageSource, /for \(let attempt = 0; attempt < 3; attempt \+= 1\)/);
+  assert.match(ownershipSource, /sandboxLeaseWithoutRefresh/);
+  assert.match(ownershipSource, /sandbox_refresh_claim_expires_at/);
+  assert.match(ownershipSource, /sandboxIds: \[\.\.\.new Set/);
+  assert.match(scanSource, /credentialPolicyScanLimit/);
+  assert.match(scanSource, /scan_max_rowid/);
+  assert.match(scanSource, /maximumCredentialPolicyRowid/);
+  assert.match(scanSource, /policy\.rowid > \$\{cursor\}/);
+  assert.match(scanSource, /policy\.rowid <= \$\{maxRowid\}/);
+  assert.doesNotMatch(scanSource, /affectedSessions/);
+  assert.doesNotMatch(scanSource, /const transitioned = await update\.executeTakeFirst\(\)/);
+  assert.match(scanSource, /const sessionTransition = sql/);
+  assert.match(scanSource, /executeBatch\(env, \[sessionTransition, policyTransition\]\)/);
+  assert.match(scanSource, /executeBatch\(env, \[ownerTransition, policyTransition\]\)/);
+  assert.match(scanSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
+  assert.match(scanSource, /AND status IS \$\{row\.session_status\}/);
+  assert.match(scanSource, /AND lease_id IS \$\{row\.session_lease_id\}/);
+  assert.match(scanSource, /AND agent_token_hash IS \$\{row\.session_agent_token_hash\}/);
+  assert.match(scanSource, /standalone\.ownership_claim AS standalone_claim/);
+  assert.match(scanSource, /AND updated_at IS \$\{row\.session_updated_at\}/);
+  assert.match(scanSource, /\.where\("sandbox_id", "=", row\.sandbox_id\)/);
+  assert.match(scanSource, /\.where\("lookup_id", "=", row\.lookup_id\)/);
+  assert.match(
+    scanSource,
+    /\.where\("registration_generation", "=", row\.registration_generation\)/,
+  );
+  assert.match(scanSource, /terminal_failure_reason = CASE/);
+  assert.match(scanSource, /credential_cleanup_terminal_status = 'failed'/);
+  assert.match(scanSource, /credential_cleanup_terminal_status = 'expired'/);
+  assert.match(scanSource, /const transitionRevision = Math\.max/);
+  assert.match(scanSource, /agent_token_hash = NULL/);
+  assert.match(scanSource, /credentialPolicySandboxIsExpected/);
+  assert.match(scanSource, /sandbox_refresh_claim = NULL/);
+  assert.match(scanSource, /normalizeCredentialPolicyCleanupGroups/);
+  assert.match(scanSource, /group_max_session_id/);
+  assert.match(batchSource, /scanCredentialPolicyCleanupPage/);
+  assert.match(batchSource, /normalizeCredentialPolicyCleanupGroups/);
+  assert.match(batchSource, /COALESCE\(last_attempt_at, created_at\)/);
+  assert.match(batchSource, /\.limit\(credentialPolicyCleanupLimit\)/);
+  assert.match(batchSource, /completeStandaloneSandboxProvisionCleanupSafely/);
+  assert.match(cleanupSource, /cleanup_claim_expires_at/);
+  assert.match(cleanupSource, /registration_claim_expires_at > \$\{now\}/);
+  assert.match(cleanupSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
+  assert.ok(
+    cleanupSource.indexOf("cleanup_claim = ${claim}") <
+      cleanupSource.indexOf("unregisterSandboxCredentialPolicyLookup"),
+  );
+  assert.match(cleanupSource, /last_error:/);
+  assert.match(cleanupSource, /cleanup_claim: null/);
+  assert.match(cleanupSource, /async function completeStandaloneSandboxProvisionCleanupSafely/);
+  assert.match(cleanupSource, /standalone Sandbox cleanup pending/);
+  assert.match(cleanupSource, /standalone_sandbox_provisions/);
+  assert.match(cleanupSource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
+  assert.match(cleanupSource, /cleanup failure persistence failed/);
+  assert.match(completionSource, /NOT EXISTS \(/);
+  assert.match(completionSource, /status: terminalStatus/);
+  assert.match(completionSource, /terminal_finalize_pending: 1/);
+  assert.match(completionSource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
+  assert.match(completionSource, /\.where\("status", "=", session\.status\)/);
+  assert.match(completionSource, /\.where\("updated_at", "=", session\.updated_at\)/);
+  assert.match(completionSource, /retainedRuntimeAdapterFailureMessage/);
+  assert.match(completionSource, /terminal_failure_reason:/);
+  assert.match(completionSource, /\? failureMessage/);
+  assert.match(batchSource, /completeCredentialPolicyCleanupSession\(env, session\.id/);
+  assert.ok(
+    provisionSource.indexOf("stageTerminalCredentialPolicyCleanupById") <
+      provisionSource.indexOf("reconcileCredentialPolicyCleanupBatch"),
+  );
+  assert.match(provisionSource, /failureAt,\s*cleanupMessage,\s*ownershipFence/);
+  assert.match(provisionSource, /try \{[\s\S]*sandboxProvisionPreflightError\(env, session\)/);
+  assert.match(provisionSource, /!agentToken/);
+  assert.match(provisionSource, /managed Sandbox agent token is unavailable/);
+  assert.match(registrationLifecycleSource, /registration_generation/);
+  assert.match(registrationLifecycleSource, /registration_claim/);
+  assert.match(registrationLifecycleSource, /registration_claim_expires_at/);
+  assert.doesNotMatch(registrationLifecycleSource, /ownershipFence\?:/);
+  assert.doesNotMatch(registrationLifecycleSource, /1 = 1/);
+  assert.match(registrationLifecycleSource, /sandboxCredentialPolicyOwnerCondition/);
+  assert.match(registrationLifecycleSource, /sandboxCredentialPolicyOwnerCondition/);
+  assert.ok(
+    registerSource.indexOf("beginSandboxCredentialPolicyRegistration") <
+      registerSource.indexOf(
+        'stub.fetch("https://crabfleet.internal/api/session-control/register"',
+      ),
+  );
+  assert.ok(
+    registerSource.indexOf("renewSandboxCredentialPolicyRegistration") <
+      registerSource.indexOf(
+        'stub.fetch("https://crabfleet.internal/api/session-control/register"',
+      ),
+  );
+  assert.ok(
+    registerSource.indexOf('stub.fetch("https://crabfleet.internal/api/session-control/register"') <
+      registerSource.indexOf("finishSandboxCredentialPolicyRegistration"),
+  );
+  assert.doesNotMatch(finishSource, /INSERT INTO|insertInto/);
+  assert.match(finishSource, /state: "active"/);
+  assert.match(finishSource, /where\(sandboxCredentialPolicyOwnerCondition/);
+  assert.doesNotMatch(finishSource, /cleanup_pending/);
+  assert.match(registerSource, /abandonSandboxCredentialPolicyRegistration/);
+  assert.match(abandonSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
+  assert.match(abandonSource, /THEN 'cleanup_pending'/);
+  assert.match(abandonSource, /ELSE 'registering'/);
+  assert.ok(
+    scanDecisionSource.indexOf("sandboxExpected") <
+      scanDecisionSource.indexOf("if (registrationAbandoned) return true"),
+  );
+  assert.doesNotMatch(scanDecisionSource, /row\.session_agent_token_hash !== null/);
+  assert.match(scanDecisionSource, /sandboxExpected &&[\s\S]*row\.session_status === "ready"/);
+  assert.match(controlSource, /sandboxPolicyTombstoneKey/);
+  assert.match(controlSource, /credentialPolicyRegistrationAccepted/);
+  assert.match(controlSource, /credentialPolicyCleanupMatches/);
+  assert.match(controlSource, /this\.ctx\.storage\.transaction/);
+  assert.doesNotMatch(source, /async function unregisterSandboxCredentialPolicy\(/);
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS interactive_session_credential_policies/);
+  assert.match(migration, /state IN \('registering', 'active', 'cleanup_pending'\)/);
+  assert.match(migration, /registration_generation TEXT NOT NULL/);
+  assert.match(migration, /registration_claim_expires_at INTEGER/);
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS credential_policy_reconcile_state/);
+  assert.match(migration, /scan_max_rowid INTEGER NOT NULL/);
+  assert.match(migration, /group_max_session_id TEXT NOT NULL/);
+  assert.match(migration, /ADD COLUMN sandbox_refresh_sandbox_id TEXT/);
+  assert.match(migration, /ADD COLUMN sandbox_refresh_claim TEXT/);
+  assert.match(migration, /ADD COLUMN sandbox_refresh_claim_expires_at INTEGER/);
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS standalone_sandbox_provisions/);
+  assert.match(migration, /idx_interactive_policy_fair_cleanup/);
+  assert.match(migration, /COALESCE\(last_attempt_at, created_at\)/);
+  assert.match(migration, /terminal_failure_reason = CASE/);
+  assert.match(migration, /terminal_finalize_pending = 0/);
+  assert.match(migration, /agent_token_hash = NULL/);
+  assert.match(migration, /SET\s+status = 'stopping'/);
+  assert.match(refreshSource, /sandbox_refresh_sandbox_id: refreshFence\.sandboxId/);
+  assert.match(refreshSource, /sandbox_refresh_claim: refreshFence\.claim/);
+  assert.match(refreshSource, /sandbox_refresh_claim_expires_at: refreshFence\.expiresAt/);
+  assert.match(refreshSource, /const agentToken = newAgentToken\(\)/);
+  assert.ok(
+    refreshSource.indexOf("sandboxProvisionPreflightError(env, refreshPayload)") <
+      refreshSource.indexOf("const agentToken = newAgentToken()"),
+  );
+  assert.match(refreshSource, /agent_token_hash: agentTokenHash/);
+  assert.match(refreshSource, /provisionWithSandbox\([\s\S]*?agentToken,[\s\S]*?refreshLease/);
+  assert.match(refreshSource, /where\("agent_token_hash", "=", agentTokenHash\)/);
+  assert.match(refreshSource, /sandbox_refresh_claim_expires_at", "=", refreshFence\.expiresAt/);
+  assert.match(refreshSource, /executeBatch\(env, commitQueries\)/);
+  assert.match(refreshSource, /state: "cleanup_pending"/);
+  assert.match(refreshSource, /stageFailedManagedSandboxProvision/);
+  assert.ok(
+    refreshSource.indexOf("sandbox_refresh_claim: null") <
+      refreshSource.lastIndexOf("reconcileCredentialPolicyCleanupBatch"),
+  );
+  assert.doesNotMatch(
+    refreshSource,
+    /queueSandboxCredentialPolicyCleanup\(env, session\.id, oldSandboxId, refreshedAt\)/,
+  );
+  assert.match(refreshSource, /const current = await readInteractiveSession/);
 });
 
 test("terminal endpoints enforce current runtime capabilities", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const decorateStart = source.indexOf("function decorateInteractiveSession");
-	const decorateEnd = source.indexOf(
-		"function canChangeInteractiveSessionMultiplayer",
-		decorateStart,
-	);
-	const decorateSource = source.slice(decorateStart, decorateEnd);
-	const directPtyStart = source.indexOf("async function interactiveSessionPty");
-	const directPtyEnd = source.indexOf("async function interactiveSandboxTerminal", directPtyStart);
-	const directPtySource = source.slice(directPtyStart, directPtyEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const decorateStart = source.indexOf("function decorateInteractiveSession");
+  const decorateEnd = source.indexOf(
+    "function canChangeInteractiveSessionMultiplayer",
+    decorateStart,
+  );
+  const decorateSource = source.slice(decorateStart, decorateEnd);
+  const directPtyStart = source.indexOf("async function interactiveSessionPty");
+  const directPtyEnd = source.indexOf("async function interactiveSandboxTerminal", directPtyStart);
+  const directPtySource = source.slice(directPtyStart, directPtyEnd);
 
-	assert.match(source, /type InteractiveSession = \{[\s\S]*ptyAvailable\?: boolean;/);
-	assert.match(source, /if \(!session\.capabilities\.terminal\)/);
-	assert.match(source, /runtimeCapabilities\(row\.runtime, row\.capabilities_json\)\.terminal/);
-	assert.match(source, /runtimeAdapterTerminalFailureStatus\(existing\.adapter\) === "detached"/);
-	assert.match(source, /attachUrl: capabilities\.terminal \? row\.attach_url : null/);
-	assert.match(decorateSource, /const routeKind = interactivePtyRouteKind\(env, session\)/);
-	assert.match(decorateSource, /interactiveTerminalTarget\(env, session, routeKind\)/);
-	assert.match(decorateSource, /routeAvailable/);
-	assert.match(
-		decorateSource,
-		/const proxyManagedTerminal =[\s\S]*session\.runtime === githubActionsRuntime \|\|[\s\S]*session\.adapter === runtimeAdapterName/,
-	);
-	assert.match(
-		decorateSource,
-		/const attachUrl = proxyManagedTerminal[\s\S]*\? ptyAvailable[\s\S]*`\/api\/interactive-sessions\/\$\{encodeURIComponent\(session\.id\)\}\/pty`[\s\S]*: null/,
-	);
-	assert.match(directPtySource, /session\.runtime === githubActionsRuntime/);
-	assert.match(directPtySource, /openInteractiveTerminalUpstream\(/);
-	assert.match(decorateSource, /attachUrl,/);
-	assert.doesNotMatch(
-		decorateSource,
-		/attachUrl: canControl && session\.capabilities\.terminal \? session\.attachUrl : null/,
-	);
+  assert.match(source, /type InteractiveSession = \{[\s\S]*ptyAvailable\?: boolean;/);
+  assert.match(source, /if \(!session\.capabilities\.terminal\)/);
+  assert.match(source, /runtimeCapabilities\(row\.runtime, row\.capabilities_json\)\.terminal/);
+  assert.match(source, /runtimeAdapterTerminalFailureStatus\(existing\.adapter\) === "detached"/);
+  assert.match(source, /attachUrl: capabilities\.terminal \? row\.attach_url : null/);
+  assert.match(decorateSource, /const routeKind = interactivePtyRouteKind\(env, session\)/);
+  assert.match(decorateSource, /interactiveTerminalTarget\(env, session, routeKind\)/);
+  assert.match(decorateSource, /routeAvailable/);
+  assert.match(
+    decorateSource,
+    /const proxyManagedTerminal =[\s\S]*session\.runtime === githubActionsRuntime \|\|[\s\S]*session\.adapter === runtimeAdapterName/,
+  );
+  assert.match(
+    decorateSource,
+    /const attachUrl = proxyManagedTerminal[\s\S]*\? ptyAvailable[\s\S]*`\/api\/interactive-sessions\/\$\{encodeURIComponent\(session\.id\)\}\/pty`[\s\S]*: null/,
+  );
+  assert.match(directPtySource, /session\.runtime === githubActionsRuntime/);
+  assert.match(directPtySource, /openInteractiveTerminalUpstream\(/);
+  assert.match(decorateSource, /attachUrl,/);
+  assert.doesNotMatch(
+    decorateSource,
+    /attachUrl: canControl && session\.capabilities\.terminal \? session\.attachUrl : null/,
+  );
 });
 
 test("non-retryable adapter client errors do not enter ambiguous replay", () => {
-	assert.equal(definitiveRuntimeAdapterCreateFailure(413), true);
-	assert.equal(definitiveRuntimeAdapterCreateFailure(415), true);
-	assert.equal(definitiveRuntimeAdapterCreateFailure(422), true);
-	assert.equal(definitiveRuntimeAdapterCreateFailure(408), false);
-	assert.equal(definitiveRuntimeAdapterCreateFailure(409), false);
-	assert.equal(definitiveRuntimeAdapterCreateFailure(423), false);
-	assert.equal(definitiveRuntimeAdapterCreateFailure(425), false);
-	assert.equal(definitiveRuntimeAdapterCreateFailure(429), false);
-	assert.equal(definitiveRuntimeAdapterCreateFailure(503), false);
+  assert.equal(definitiveRuntimeAdapterCreateFailure(413), true);
+  assert.equal(definitiveRuntimeAdapterCreateFailure(415), true);
+  assert.equal(definitiveRuntimeAdapterCreateFailure(422), true);
+  assert.equal(definitiveRuntimeAdapterCreateFailure(408), false);
+  assert.equal(definitiveRuntimeAdapterCreateFailure(409), false);
+  assert.equal(definitiveRuntimeAdapterCreateFailure(423), false);
+  assert.equal(definitiveRuntimeAdapterCreateFailure(425), false);
+  assert.equal(definitiveRuntimeAdapterCreateFailure(429), false);
+  assert.equal(definitiveRuntimeAdapterCreateFailure(503), false);
 });
 
 test("explicit workspace id conflicts are distinct from retryable 409 responses", () => {
-	assert.equal(
-		runtimeAdapterWorkspaceIdConflict(409, {
-			error: { code: "workspace_id_conflict", message: "workspace id is already owned" },
-		}),
-		true,
-	);
-	assert.equal(runtimeAdapterWorkspaceIdConflict(409, { error: { code: "busy" } }), false);
-	assert.equal(
-		runtimeAdapterWorkspaceIdConflict(422, { error: { code: "workspace_id_conflict" } }),
-		false,
-	);
+  assert.equal(
+    runtimeAdapterWorkspaceIdConflict(409, {
+      error: { code: "workspace_id_conflict", message: "workspace id is already owned" },
+    }),
+    true,
+  );
+  assert.equal(runtimeAdapterWorkspaceIdConflict(409, { error: { code: "busy" } }), false);
+  assert.equal(
+    runtimeAdapterWorkspaceIdConflict(422, { error: { code: "workspace_id_conflict" } }),
+    false,
+  );
 });
 
 test("workspace id conflicts detach without adopting or deleting the existing workspace", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const createStart = source.indexOf("async function provisionWithRuntimeAdapter");
-	const createEnd = source.indexOf("function persistedRuntimeAdapterSeconds", createStart);
-	const createSource = source.slice(createStart, createEnd);
-	const conflictStart = source.indexOf("async function failRuntimeAdapterWorkspaceIdConflict");
-	const conflictEnd = source.indexOf(
-		"async function releaseFailedRuntimeAdapterProvision",
-		conflictStart,
-	);
-	const conflictSource = source.slice(conflictStart, conflictEnd);
-	const stageStart = source.indexOf("async function stageRuntimeAdapterProvision");
-	const stageEnd = source.indexOf("function ambiguousRuntimeAdapterProvision", stageStart);
-	const stageSource = source.slice(stageStart, stageEnd);
-	const stoppingReplayStart = source.indexOf("async function replayStoppingRuntimeAdapterCreate");
-	const stoppingReplayEnd = source.indexOf(
-		"async function stopRuntimeAdapterWorkspace(",
-		stoppingReplayStart,
-	);
-	const stoppingReplaySource = source.slice(stoppingReplayStart, stoppingReplayEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const createStart = source.indexOf("async function provisionWithRuntimeAdapter");
+  const createEnd = source.indexOf("function persistedRuntimeAdapterSeconds", createStart);
+  const createSource = source.slice(createStart, createEnd);
+  const conflictStart = source.indexOf("async function failRuntimeAdapterWorkspaceIdConflict");
+  const conflictEnd = source.indexOf(
+    "async function releaseFailedRuntimeAdapterProvision",
+    conflictStart,
+  );
+  const conflictSource = source.slice(conflictStart, conflictEnd);
+  const stageStart = source.indexOf("async function stageRuntimeAdapterProvision");
+  const stageEnd = source.indexOf("function ambiguousRuntimeAdapterProvision", stageStart);
+  const stageSource = source.slice(stageStart, stageEnd);
+  const stoppingReplayStart = source.indexOf("async function replayStoppingRuntimeAdapterCreate");
+  const stoppingReplayEnd = source.indexOf(
+    "async function stopRuntimeAdapterWorkspace(",
+    stoppingReplayStart,
+  );
+  const stoppingReplaySource = source.slice(stoppingReplayStart, stoppingReplayEnd);
 
-	assert.ok(
-		createSource.indexOf("runtimeAdapterWorkspaceIdConflict") <
-			createSource.indexOf("definitiveRuntimeAdapterCreateFailure"),
-	);
-	assert.match(createSource, /failRuntimeAdapterWorkspaceIdConflict/);
-	assert.match(
-		createSource,
-		/throw conflict\("runtime adapter workspace conflict response is stale"\)/,
-	);
-	assert.match(stageSource, /updated_at: sql<number>`MAX\(updated_at \+ 1, \$\{stageAt\}\)`/);
-	assert.match(
-		stageSource,
-		/returning\(\["status", "updated_at", "last_reconciled_at", "terminal_status"\]\)/,
-	);
-	assert.match(stageSource, /last_reconciled_at", "=", reconciliationOwner\.lastReconciledAt/);
-	assert.match(conflictSource, /adapter: null/);
-	assert.match(conflictSource, /adapter_workspace_id: null/);
-	assert.match(conflictSource, /adapter_control_plane: null/);
-	assert.match(conflictSource, /adapter_create_payload_json: null/);
-	assert.match(conflictSource, /adapter_create_pending: 0/);
-	assert.match(conflictSource, /AND adapter_create_pending = 1/);
-	assert.match(conflictSource, /AND status = \$\{createAttempt\.status\}/);
-	assert.match(conflictSource, /AND updated_at = \$\{createAttempt\.updatedAt\}/);
-	assert.match(conflictSource, /AND \$\{lastReconciledOwner\}/);
-	assert.match(conflictSource, /AND \$\{terminalStatusOwner\}/);
-	assert.match(conflictSource, /if \(!results\.at\(-1\)\?\.results\.length\) return null/);
-	assert.match(conflictSource, /terminal_finalize_pending: 1/);
-	assert.match(conflictSource, /env\.DB\.batch/);
-	assert.match(
-		conflictSource,
-		/finalizeTerminalInteractiveSession\(env, session\.id, "failed", now\)/,
-	);
-	assert.doesNotMatch(conflictSource, /stopRuntimeAdapterWorkspace/);
-	assert.match(stoppingReplaySource, /runtimeAdapterWorkspaceIdConflict/);
-	assert.match(stoppingReplaySource, /terminalResult/);
-	assert.doesNotMatch(stoppingReplaySource, /definitiveRuntimeAdapterCreateFailure/);
+  assert.ok(
+    createSource.indexOf("runtimeAdapterWorkspaceIdConflict") <
+      createSource.indexOf("definitiveRuntimeAdapterCreateFailure"),
+  );
+  assert.match(createSource, /failRuntimeAdapterWorkspaceIdConflict/);
+  assert.match(
+    createSource,
+    /throw conflict\("runtime adapter workspace conflict response is stale"\)/,
+  );
+  assert.match(stageSource, /updated_at: sql<number>`MAX\(updated_at \+ 1, \$\{stageAt\}\)`/);
+  assert.match(
+    stageSource,
+    /returning\(\["status", "updated_at", "last_reconciled_at", "terminal_status"\]\)/,
+  );
+  assert.match(stageSource, /last_reconciled_at", "=", reconciliationOwner\.lastReconciledAt/);
+  assert.match(conflictSource, /adapter: null/);
+  assert.match(conflictSource, /adapter_workspace_id: null/);
+  assert.match(conflictSource, /adapter_control_plane: null/);
+  assert.match(conflictSource, /adapter_create_payload_json: null/);
+  assert.match(conflictSource, /adapter_create_pending: 0/);
+  assert.match(conflictSource, /AND adapter_create_pending = 1/);
+  assert.match(conflictSource, /AND status = \$\{createAttempt\.status\}/);
+  assert.match(conflictSource, /AND updated_at = \$\{createAttempt\.updatedAt\}/);
+  assert.match(conflictSource, /AND \$\{lastReconciledOwner\}/);
+  assert.match(conflictSource, /AND \$\{terminalStatusOwner\}/);
+  assert.match(conflictSource, /if \(!results\.at\(-1\)\?\.results\.length\) return null/);
+  assert.match(conflictSource, /terminal_finalize_pending: 1/);
+  assert.match(conflictSource, /env\.DB\.batch/);
+  assert.match(
+    conflictSource,
+    /finalizeTerminalInteractiveSession\(env, session\.id, "failed", now\)/,
+  );
+  assert.doesNotMatch(conflictSource, /stopRuntimeAdapterWorkspace/);
+  assert.match(stoppingReplaySource, /runtimeAdapterWorkspaceIdConflict/);
+  assert.match(stoppingReplaySource, /terminalResult/);
+  assert.doesNotMatch(stoppingReplaySource, /definitiveRuntimeAdapterCreateFailure/);
 });
 
 test("definitive adapter create errors retain a redacted provider reason before release", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const createStart = source.indexOf("async function provisionWithRuntimeAdapter");
-	const createEnd = source.indexOf("function persistedRuntimeAdapterSeconds", createStart);
-	const createSource = source.slice(createStart, createEnd);
-	const replayStart = source.indexOf("async function replayStoppingRuntimeAdapterCreate");
-	const replayEnd = source.indexOf("async function stopRuntimeAdapterWorkspace", replayStart);
-	const replaySource = source.slice(replayStart, replayEnd);
-	const releaseStart = source.indexOf("async function releaseFailedRuntimeAdapterProvision");
-	const releaseEnd = source.indexOf(
-		"async function persistRuntimeAdapterStopEvidence",
-		releaseStart,
-	);
-	const releaseSource = source.slice(releaseStart, releaseEnd);
-	const bodyStart = source.indexOf("async function readRuntimeAdapterResponseBody");
-	const bodyEnd = source.indexOf("function runtimeAdapterToken", bodyStart);
-	const bodySource = source.slice(bodyStart, bodyEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const createStart = source.indexOf("async function provisionWithRuntimeAdapter");
+  const createEnd = source.indexOf("function persistedRuntimeAdapterSeconds", createStart);
+  const createSource = source.slice(createStart, createEnd);
+  const replayStart = source.indexOf("async function replayStoppingRuntimeAdapterCreate");
+  const replayEnd = source.indexOf("async function stopRuntimeAdapterWorkspace", replayStart);
+  const replaySource = source.slice(replayStart, replayEnd);
+  const releaseStart = source.indexOf("async function releaseFailedRuntimeAdapterProvision");
+  const releaseEnd = source.indexOf(
+    "async function persistRuntimeAdapterStopEvidence",
+    releaseStart,
+  );
+  const releaseSource = source.slice(releaseStart, releaseEnd);
+  const bodyStart = source.indexOf("async function readRuntimeAdapterResponseBody");
+  const bodyEnd = source.indexOf("function runtimeAdapterToken", bodyStart);
+  const bodySource = source.slice(bodyStart, bodyEnd);
 
-	const bodyReadIndex = createSource.indexOf(
-		"responseBody = await readRuntimeAdapterResponseBody(response)",
-	);
-	assert.ok(bodyReadIndex >= 0 && bodyReadIndex < createSource.indexOf("if (!response.ok)"));
-	assert.match(createSource, /redactedAdapterResponseMessage/);
-	assert.match(createSource, /runtime adapter provision failed: \$\{responseMessage\}/);
-	assert.match(createSource, /releaseFailedRuntimeAdapterProvision/);
-	assert.doesNotMatch(createSource, /response\.json/);
-	assert.match(replaySource, /readRuntimeAdapterResponseBody\(response\)/);
-	assert.match(replaySource, /redactedAdapterResponseMessage/);
-	assert.match(replaySource, /reconcile_error: message/);
-	assert.match(replaySource, /INSERT INTO interactive_session_events/);
-	assert.doesNotMatch(replaySource, /response\.json/);
-	assert.ok(
-		releaseSource.indexOf("stageFailedRuntimeAdapterRelease") <
-			releaseSource.indexOf("stopRuntimeAdapterWorkspaceForSession"),
-	);
-	assert.match(bodySource, /await readBoundedResponseText\(response\)/);
-	assert.doesNotMatch(bodySource, /response\.(?:json|text)\(/);
-	assert.match(bodySource, /JSON\.parse\(body\)/);
-	assert.equal(
-		redactedAdapterResponseMessage(
-			{ detail: "capacity unavailable; token=private-value" },
-			"HTTP 422",
-		),
-		"capacity unavailable; [credential]",
-	);
-	const opaqueErrorIds = ["provider-body", "provider-workspace", "provider-error"];
-	const opaqueErrorMessage = redactedAdapterResponseMessage(
-		{
-			providerResourceId: opaqueErrorIds[0],
-			workspace: { provider_resource_id: opaqueErrorIds[1] },
-			error: {
-				leaseId: opaqueErrorIds[2],
-				message: `failed ${opaqueErrorIds.join(" ")}`,
-			},
-		},
-		"HTTP 422",
-	);
-	assert.equal(opaqueErrorMessage, "failed [workspace] [workspace] [workspace]");
-	for (const identifier of opaqueErrorIds) {
-		assert.doesNotMatch(opaqueErrorMessage, new RegExp(identifier));
-	}
+  const bodyReadIndex = createSource.indexOf(
+    "responseBody = await readRuntimeAdapterResponseBody(response)",
+  );
+  assert.ok(bodyReadIndex >= 0 && bodyReadIndex < createSource.indexOf("if (!response.ok)"));
+  assert.match(createSource, /redactedAdapterResponseMessage/);
+  assert.match(createSource, /runtime adapter provision failed: \$\{responseMessage\}/);
+  assert.match(createSource, /releaseFailedRuntimeAdapterProvision/);
+  assert.doesNotMatch(createSource, /response\.json/);
+  assert.match(replaySource, /readRuntimeAdapterResponseBody\(response\)/);
+  assert.match(replaySource, /redactedAdapterResponseMessage/);
+  assert.match(replaySource, /reconcile_error: message/);
+  assert.match(replaySource, /INSERT INTO interactive_session_events/);
+  assert.doesNotMatch(replaySource, /response\.json/);
+  assert.ok(
+    releaseSource.indexOf("stageFailedRuntimeAdapterRelease") <
+      releaseSource.indexOf("stopRuntimeAdapterWorkspaceForSession"),
+  );
+  assert.match(bodySource, /await readBoundedResponseText\(response\)/);
+  assert.doesNotMatch(bodySource, /response\.(?:json|text)\(/);
+  assert.match(bodySource, /JSON\.parse\(body\)/);
+  assert.equal(
+    redactedAdapterResponseMessage(
+      { detail: "capacity unavailable; token=private-value" },
+      "HTTP 422",
+    ),
+    "capacity unavailable; [credential]",
+  );
+  const opaqueErrorIds = ["provider-body", "provider-workspace", "provider-error"];
+  const opaqueErrorMessage = redactedAdapterResponseMessage(
+    {
+      providerResourceId: opaqueErrorIds[0],
+      workspace: { provider_resource_id: opaqueErrorIds[1] },
+      error: {
+        leaseId: opaqueErrorIds[2],
+        message: `failed ${opaqueErrorIds.join(" ")}`,
+      },
+    },
+    "HTTP 422",
+  );
+  assert.equal(opaqueErrorMessage, "failed [workspace] [workspace] [workspace]");
+  for (const identifier of opaqueErrorIds) {
+    assert.doesNotMatch(opaqueErrorMessage, new RegExp(identifier));
+  }
 });
 
 test("successful DELETE requires an implicit or parsed release confirmation", () => {
-	const ready = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "ready" });
-	const stopped = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "stopped" });
-	const wrong = parseAdapterWorkspaceResult({ id: "fleet-b-is-101", status: "stopped" });
-	assert.equal(runtimeAdapterStopOutcome(200, null, "fleet-a-is-101"), "stopping");
-	assert.equal(runtimeAdapterStopOutcome(202, null, "fleet-a-is-101"), "stopping");
-	assert.equal(runtimeAdapterStopOutcome(200, ready, "fleet-a-is-101"), "stopping");
-	assert.equal(runtimeAdapterStopOutcome(200, stopped, "fleet-a-is-101"), "stopped");
-	assert.equal(runtimeAdapterStopOutcome(204, null, "fleet-a-is-101"), "stopped");
-	assert.equal(runtimeAdapterStopOutcome(200, wrong, "fleet-a-is-101"), "identity_mismatch");
+  const ready = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "ready" });
+  const stopped = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "stopped" });
+  const wrong = parseAdapterWorkspaceResult({ id: "fleet-b-is-101", status: "stopped" });
+  assert.equal(runtimeAdapterStopOutcome(200, null, "fleet-a-is-101"), "stopping");
+  assert.equal(runtimeAdapterStopOutcome(202, null, "fleet-a-is-101"), "stopping");
+  assert.equal(runtimeAdapterStopOutcome(200, ready, "fleet-a-is-101"), "stopping");
+  assert.equal(runtimeAdapterStopOutcome(200, stopped, "fleet-a-is-101"), "stopped");
+  assert.equal(runtimeAdapterStopOutcome(204, null, "fleet-a-is-101"), "stopped");
+  assert.equal(runtimeAdapterStopOutcome(200, wrong, "fleet-a-is-101"), "identity_mismatch");
 });
 
 test("adapter DELETE evidence survives pending and confirmed release", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const deleteStart = source.indexOf("async function stopRuntimeAdapterWorkspace(");
-	const deleteEnd = source.indexOf("async function runtimeAdapterFetch", deleteStart);
-	const deleteSource = source.slice(deleteStart, deleteEnd);
-	const reconcileStart = source.indexOf("async function reconcileStoppingRuntimeAdapterWorkspace");
-	const reconcileEnd = source.indexOf("type StoppingRuntimeAdapterReplay", reconcileStart);
-	const reconcileSource = source.slice(reconcileStart, reconcileEnd);
-	const releaseStart = source.indexOf("async function recordConfirmedRuntimeAdapterRelease");
-	const releaseEnd = source.indexOf(
-		"async function clearRuntimeAdapterCreatePending",
-		releaseStart,
-	);
-	const releaseSource = source.slice(releaseStart, releaseEnd);
-	const failedReleaseStart = source.indexOf("async function releaseFailedRuntimeAdapterProvision");
-	const failedReleaseEnd = source.indexOf(
-		"async function stageFailedRuntimeAdapterRelease",
-		failedReleaseStart,
-	);
-	const failedReleaseSource = source.slice(failedReleaseStart, failedReleaseEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const deleteStart = source.indexOf("async function stopRuntimeAdapterWorkspace(");
+  const deleteEnd = source.indexOf("async function runtimeAdapterFetch", deleteStart);
+  const deleteSource = source.slice(deleteStart, deleteEnd);
+  const reconcileStart = source.indexOf("async function reconcileStoppingRuntimeAdapterWorkspace");
+  const reconcileEnd = source.indexOf("type StoppingRuntimeAdapterReplay", reconcileStart);
+  const reconcileSource = source.slice(reconcileStart, reconcileEnd);
+  const releaseStart = source.indexOf("async function recordConfirmedRuntimeAdapterRelease");
+  const releaseEnd = source.indexOf(
+    "async function clearRuntimeAdapterCreatePending",
+    releaseStart,
+  );
+  const releaseSource = source.slice(releaseStart, releaseEnd);
+  const failedReleaseStart = source.indexOf("async function releaseFailedRuntimeAdapterProvision");
+  const failedReleaseEnd = source.indexOf(
+    "async function stageFailedRuntimeAdapterRelease",
+    failedReleaseStart,
+  );
+  const failedReleaseSource = source.slice(failedReleaseStart, failedReleaseEnd);
 
-	assert.match(deleteSource, /await readRuntimeAdapterResponseBody\(response\)/);
-	assert.doesNotMatch(deleteSource, /response\.json/);
-	assert.match(deleteSource, /redactedAdapterResponseMessage/);
-	assert.match(deleteSource, /return \{ status: "stopped", message \}/);
-	assert.match(deleteSource, /return \{ status: outcome, message \}/);
-	assert.match(reconcileSource, /runtime adapter stop pending: \$\{safeProviderError/);
-	assert.match(reconcileSource, /reconcileError: message/);
-	assert.match(reconcileSource, /release\.message/);
-	assert.match(releaseSource, /retainedReleaseMessage/);
-	assert.match(releaseSource, /env\.DB\.batch/);
-	assert.match(releaseSource, /INSERT INTO interactive_session_events/);
-	assert.match(releaseSource, /terminal_finalize_pending: 1/);
-	assert.match(failedReleaseSource, /persistRuntimeAdapterStopEvidence/);
-	assert.match(failedReleaseSource, /await executeBatch\(env, \[/);
-	assert.match(failedReleaseSource, /INSERT INTO interactive_session_events/);
-	assert.match(failedReleaseSource, /AND NOT EXISTS/);
+  assert.match(deleteSource, /await readRuntimeAdapterResponseBody\(response\)/);
+  assert.doesNotMatch(deleteSource, /response\.json/);
+  assert.match(deleteSource, /redactedAdapterResponseMessage/);
+  assert.match(deleteSource, /return \{ status: "stopped", message \}/);
+  assert.match(deleteSource, /return \{ status: outcome, message \}/);
+  assert.match(reconcileSource, /runtime adapter stop pending: \$\{safeProviderError/);
+  assert.match(reconcileSource, /reconcileError: message/);
+  assert.match(reconcileSource, /release\.message/);
+  assert.match(releaseSource, /retainedReleaseMessage/);
+  assert.match(releaseSource, /env\.DB\.batch/);
+  assert.match(releaseSource, /INSERT INTO interactive_session_events/);
+  assert.match(releaseSource, /terminal_finalize_pending: 1/);
+  assert.match(failedReleaseSource, /persistRuntimeAdapterStopEvidence/);
+  assert.match(failedReleaseSource, /await executeBatch\(env, \[/);
+  assert.match(failedReleaseSource, /INSERT INTO interactive_session_events/);
+  assert.match(failedReleaseSource, /AND NOT EXISTS/);
 });
 
 test("adapter workspace paths use the controller id and encode it", () => {
-	assert.equal(normalizeAdapterWorkspaceId("IS-101"), "is-101");
-	assert.equal(
-		runtimeAdapterWorkspaceUrl("https://controller.example/base", "session/one"),
-		"https://controller.example/base/v1/workspaces/session%2Fone",
-	);
-	assert.equal(
-		runtimeAdapterDesktopUrl("https://controller.example/base", "is-101"),
-		"https://controller.example/base/v1/workspaces/is-101/connections/desktop",
-	);
-	assert.equal(
-		runtimeAdapterBrowserVncUrl("https://fleet.example", "IS/101"),
-		"https://fleet.example/api/interactive-sessions/IS%2F101/vnc",
-	);
+  assert.equal(normalizeAdapterWorkspaceId("IS-101"), "is-101");
+  assert.equal(
+    runtimeAdapterWorkspaceUrl("https://controller.example/base", "session/one"),
+    "https://controller.example/base/v1/workspaces/session%2Fone",
+  );
+  assert.equal(
+    runtimeAdapterDesktopUrl("https://controller.example/base", "is-101"),
+    "https://controller.example/base/v1/workspaces/is-101/connections/desktop",
+  );
+  assert.equal(
+    runtimeAdapterBrowserVncUrl("https://fleet.example", "IS/101"),
+    "https://fleet.example/api/interactive-sessions/IS%2F101/vnc",
+  );
 });
 
 test("runtime adapter control-plane identity is canonical and origin-bound", () => {
-	assert.equal(
-		runtimeAdapterControlPlaneIdentity("https://controller.example/api/"),
-		"https://controller.example/api",
-	);
-	assert.equal(
-		runtimeAdapterControlPlaneIdentity("https://controller.example"),
-		"https://controller.example/",
-	);
-	assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api?tenant=a"), null);
-	assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api?"), null);
-	assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api#fragment"), null);
-	assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api#"), null);
-	assert.equal(runtimeAdapterControlPlaneIdentity("http://controller.example/api"), null);
-	assert.equal(
-		runtimeAdapterControlPlaneIdentity("http://127.0.0.1:8788/adapter/"),
-		"http://127.0.0.1:8788/adapter",
-	);
-	assert.equal(
-		runtimeAdapterWorkspaceUrl("https://controller.example/root/adapter", "fleet-is-1"),
-		"https://controller.example/root/adapter/v1/workspaces/fleet-is-1",
-	);
+  assert.equal(
+    runtimeAdapterControlPlaneIdentity("https://controller.example/api/"),
+    "https://controller.example/api",
+  );
+  assert.equal(
+    runtimeAdapterControlPlaneIdentity("https://controller.example"),
+    "https://controller.example/",
+  );
+  assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api?tenant=a"), null);
+  assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api?"), null);
+  assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api#fragment"), null);
+  assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api#"), null);
+  assert.equal(runtimeAdapterControlPlaneIdentity("http://controller.example/api"), null);
+  assert.equal(
+    runtimeAdapterControlPlaneIdentity("http://127.0.0.1:8788/adapter/"),
+    "http://127.0.0.1:8788/adapter",
+  );
+  assert.equal(
+    runtimeAdapterWorkspaceUrl("https://controller.example/root/adapter", "fleet-is-1"),
+    "https://controller.example/root/adapter/v1/workspaces/fleet-is-1",
+  );
 });
 
 test("runtime adapter profile routes expand one allowlisted path segment", () => {
-	assert.equal(
-		runtimeAdapterControlPlaneForProfile(
-			undefined,
-			"https://controller.example/v1/adapters/{profile}/proxy/",
-			"linux-desktop",
-		),
-		"https://controller.example/v1/adapters/linux-desktop/proxy",
-	);
-	assert.equal(
-		runtimeAdapterControlPlaneForProfile(
-			undefined,
-			"https://controller.example/v1/adapters/{profile}/proxy",
-			"macos-desktop",
-		),
-		"https://controller.example/v1/adapters/macos-desktop/proxy",
-	);
-	assert.equal(
-		runtimeAdapterControlPlaneForProfile(
-			"https://controller.example/default",
-			undefined,
-			"legacy.profile",
-		),
-		"https://controller.example/default",
-	);
-	assert.equal(
-		runtimeAdapterControlPlaneForProfile(
-			"https://controller.example/default",
-			"https://controller.example/{profile}",
-			"linux-desktop",
-		),
-		null,
-	);
-	assert.equal(
-		runtimeAdapterControlPlaneForProfile(
-			undefined,
-			"https://{profile}.controller.example/proxy",
-			"linux-desktop",
-		),
-		null,
-	);
-	assert.equal(
-		runtimeAdapterControlPlaneForProfile(undefined, "https://{profile}/proxy", "linux-desktop"),
-		null,
-	);
-	assert.equal(
-		runtimeAdapterControlPlaneForProfile(
-			undefined,
-			"https://controller.example/{profile}/proxy?tenant=fleet",
-			"linux-desktop",
-		),
-		null,
-	);
-	assert.equal(
-		runtimeAdapterControlPlaneForProfile(
-			undefined,
-			"https://controller.example/{profile}/{profile}",
-			"linux-desktop",
-		),
-		null,
-	);
-	assert.equal(
-		runtimeAdapterControlPlaneForProfile(
-			undefined,
-			"https://controller.example/{profile}/proxy",
-			"macos_desktop",
-		),
-		null,
-	);
+  assert.equal(
+    runtimeAdapterControlPlaneForProfile(
+      undefined,
+      "https://controller.example/v1/adapters/{profile}/proxy/",
+      "linux-desktop",
+    ),
+    "https://controller.example/v1/adapters/linux-desktop/proxy",
+  );
+  assert.equal(
+    runtimeAdapterControlPlaneForProfile(
+      undefined,
+      "https://controller.example/v1/adapters/{profile}/proxy",
+      "macos-desktop",
+    ),
+    "https://controller.example/v1/adapters/macos-desktop/proxy",
+  );
+  assert.equal(
+    runtimeAdapterControlPlaneForProfile(
+      "https://controller.example/default",
+      undefined,
+      "legacy.profile",
+    ),
+    "https://controller.example/default",
+  );
+  assert.equal(
+    runtimeAdapterControlPlaneForProfile(
+      "https://controller.example/default",
+      "https://controller.example/{profile}",
+      "linux-desktop",
+    ),
+    null,
+  );
+  assert.equal(
+    runtimeAdapterControlPlaneForProfile(
+      undefined,
+      "https://{profile}.controller.example/proxy",
+      "linux-desktop",
+    ),
+    null,
+  );
+  assert.equal(
+    runtimeAdapterControlPlaneForProfile(undefined, "https://{profile}/proxy", "linux-desktop"),
+    null,
+  );
+  assert.equal(
+    runtimeAdapterControlPlaneForProfile(
+      undefined,
+      "https://controller.example/{profile}/proxy?tenant=fleet",
+      "linux-desktop",
+    ),
+    null,
+  );
+  assert.equal(
+    runtimeAdapterControlPlaneForProfile(
+      undefined,
+      "https://controller.example/{profile}/{profile}",
+      "linux-desktop",
+    ),
+    null,
+  );
+  assert.equal(
+    runtimeAdapterControlPlaneForProfile(
+      undefined,
+      "https://controller.example/{profile}/proxy",
+      "macos_desktop",
+    ),
+    null,
+  );
 });
 
 test("adapter bodies share the bounded stream reader", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const ranges = [
-		["async function provisionWithRuntimeAdapter", "function persistedRuntimeAdapterSeconds"],
-		[
-			"async function inspectRuntimeAdapterWorkspace",
-			"async function reconcileStoppingRuntimeAdapterWorkspace",
-		],
-		[
-			"async function replayStoppingRuntimeAdapterCreate",
-			"async function stopRuntimeAdapterWorkspace(",
-		],
-		["async function stopRuntimeAdapterWorkspace(", "type RuntimeAdapterStopResult"],
-		["async function interactiveSessionVnc", "function interactiveTerminalTarget"],
-	] as const;
-	for (const [startMarker, endMarker] of ranges) {
-		const start = source.indexOf(startMarker);
-		const end = source.indexOf(endMarker, start + startMarker.length);
-		const operation = source.slice(start, end);
-		assert.match(operation, /readRuntimeAdapterResponseBody\(response\)/);
-		assert.doesNotMatch(operation, /response\.(?:json|text)\(/);
-	}
-	const readerStart = source.indexOf("async function readRuntimeAdapterResponseBody");
-	const readerEnd = source.indexOf("function runtimeAdapterToken", readerStart);
-	const readerSource = source.slice(readerStart, readerEnd);
-	assert.match(readerSource, /readBoundedResponseText\(response\)/);
-	assert.doesNotMatch(readerSource, /response\.(?:json|text)\(/);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const ranges = [
+    ["async function provisionWithRuntimeAdapter", "function persistedRuntimeAdapterSeconds"],
+    [
+      "async function inspectRuntimeAdapterWorkspace",
+      "async function reconcileStoppingRuntimeAdapterWorkspace",
+    ],
+    [
+      "async function replayStoppingRuntimeAdapterCreate",
+      "async function stopRuntimeAdapterWorkspace(",
+    ],
+    ["async function stopRuntimeAdapterWorkspace(", "type RuntimeAdapterStopResult"],
+    ["async function interactiveSessionVnc", "function interactiveTerminalTarget"],
+  ] as const;
+  for (const [startMarker, endMarker] of ranges) {
+    const start = source.indexOf(startMarker);
+    const end = source.indexOf(endMarker, start + startMarker.length);
+    const operation = source.slice(start, end);
+    assert.match(operation, /readRuntimeAdapterResponseBody\(response\)/);
+    assert.doesNotMatch(operation, /response\.(?:json|text)\(/);
+  }
+  const readerStart = source.indexOf("async function readRuntimeAdapterResponseBody");
+  const readerEnd = source.indexOf("function runtimeAdapterToken", readerStart);
+  const readerSource = source.slice(readerStart, readerEnd);
+  assert.match(readerSource, /readBoundedResponseText\(response\)/);
+  assert.doesNotMatch(readerSource, /response\.(?:json|text)\(/);
 });
 
 test("desktop mint revalidates current ownership before redirect", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const vncStart = source.indexOf("async function interactiveSessionVnc");
-	const vncEnd = source.indexOf("function interactiveTerminalTarget", vncStart);
-	const vncSource = source.slice(vncStart, vncEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const vncStart = source.indexOf("async function interactiveSessionVnc");
+  const vncEnd = source.indexOf("function interactiveTerminalTarget", vncStart);
+  const vncSource = source.slice(vncStart, vncEnd);
 
-	assert.ok(
-		vncSource.indexOf("currentAdapterDesktopConnection") <
-			vncSource.indexOf("currentRuntimeAdapterDesktopAccess"),
-	);
-	assert.ok(
-		vncSource.indexOf("currentRuntimeAdapterDesktopAccess") <
-			vncSource.indexOf("target = connection.url"),
-	);
-	assert.match(vncSource, /selectFrom\("interactive_sessions"\)/);
-	assert.match(vncSource, /adapter_workspace_id/);
-	assert.match(vncSource, /adapter_control_plane/);
-	assert.match(vncSource, /provider_resource_id/);
-	assert.match(vncSource, /adapter_create_pending/);
-	assert.match(vncSource, /\["ready", "attached", "detached"\]/);
-	assert.match(vncSource, /current\.capabilities\.vnc/);
-	assert.match(vncSource, /current\.capabilities\.desktop/);
-	assert.match(vncSource, /canControlInteractiveSession/);
-	assert.match(vncSource, /desktop authorization changed; retry/);
-	assert.doesNotMatch(vncSource, /body:\s*JSON\.stringify\(\{\}\)/);
+  assert.ok(
+    vncSource.indexOf("currentAdapterDesktopConnection") <
+      vncSource.indexOf("currentRuntimeAdapterDesktopAccess"),
+  );
+  assert.ok(
+    vncSource.indexOf("currentRuntimeAdapterDesktopAccess") <
+      vncSource.indexOf("target = connection.url"),
+  );
+  assert.match(vncSource, /selectFrom\("interactive_sessions"\)/);
+  assert.match(vncSource, /adapter_workspace_id/);
+  assert.match(vncSource, /adapter_control_plane/);
+  assert.match(vncSource, /provider_resource_id/);
+  assert.match(vncSource, /adapter_create_pending/);
+  assert.match(vncSource, /\["ready", "attached", "detached"\]/);
+  assert.match(vncSource, /current\.capabilities\.vnc/);
+  assert.match(vncSource, /current\.capabilities\.desktop/);
+  assert.match(vncSource, /canControlInteractiveSession/);
+  assert.match(vncSource, /desktop authorization changed; retry/);
+  assert.doesNotMatch(vncSource, /body:\s*JSON\.stringify\(\{\}\)/);
 });
 
 test("runtime adapter terminals use the server-side adapter bearer", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-	const targetStart = source.indexOf("function interactiveTerminalTarget");
-	const targetEnd = source.indexOf("function interactivePtyRouteKind", targetStart);
-	const targetSource = source.slice(targetStart, targetEnd);
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const targetStart = source.indexOf("function interactiveTerminalTarget");
+  const targetEnd = source.indexOf("function interactivePtyRouteKind", targetStart);
+  const targetSource = source.slice(targetStart, targetEnd);
 
-	assert.match(targetSource, /session\.adapter === runtimeAdapterName/);
-	assert.match(targetSource, /session\[interactiveSessionAdapterControlPlane\]/);
-	assert.match(targetSource, /runtimeAdapterTerminalAuthorization/);
-	assert.match(targetSource, /requireRegisteredRuntimeAdapterControlPlane/);
-	assert.match(targetSource, /runtimeAdapterTerminalOriginMatches\(controlPlane, attachUrl\)/);
-	assert.match(targetSource, /bearer\(runtimeAdapterToken\(env\)\)/);
-	assert.doesNotMatch(targetSource, /searchParams\.set\([^)]*(?:token|ticket)/u);
-	const decorateStart = source.indexOf("function decorateInteractiveSession");
-	const decorateEnd = source.indexOf(
-		"function canChangeInteractiveSessionMultiplayer",
-		decorateStart,
-	);
-	const decorateSource = source.slice(decorateStart, decorateEnd);
-	assert.match(decorateSource, /interactiveTerminalTarget\(env, session, routeKind\)/);
-	assert.match(decorateSource, /routeAvailable/);
+  assert.match(targetSource, /session\.adapter === runtimeAdapterName/);
+  assert.match(targetSource, /session\[interactiveSessionAdapterControlPlane\]/);
+  assert.match(targetSource, /runtimeAdapterTerminalAuthorization/);
+  assert.match(targetSource, /requireRegisteredRuntimeAdapterControlPlane/);
+  assert.match(targetSource, /runtimeAdapterTerminalOriginMatches\(controlPlane, attachUrl\)/);
+  assert.match(targetSource, /bearer\(runtimeAdapterToken\(env\)\)/);
+  assert.doesNotMatch(targetSource, /searchParams\.set\([^)]*(?:token|ticket)/u);
+  const decorateStart = source.indexOf("function decorateInteractiveSession");
+  const decorateEnd = source.indexOf(
+    "function canChangeInteractiveSessionMultiplayer",
+    decorateStart,
+  );
+  const decorateSource = source.slice(decorateStart, decorateEnd);
+  assert.match(decorateSource, /interactiveTerminalTarget\(env, session, routeKind\)/);
+  assert.match(decorateSource, /routeAvailable/);
 });
 
 test("runtime adapter terminal flow control stays explicit and end-to-end", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
 
-	assert.match(source, /frame\.type === TerminalMessageType\.Ack/);
-	assert.match(source, /subscription\.outputAcknowledgements/);
-	assert.match(source, /bytes <= subscription\.outputAcknowledgementBytes/);
-	assert.match(source, /acknowledgedBytes <= rightOutputAcknowledgementBytes/);
-	assert.match(source, /TerminalSubscribeFlags\.OutputAcknowledgements/);
-	assert.match(source, /searchParams\.get\("flow"\) === "ack-v1"/);
-	assert.match(source, /JSON\.stringify\(\{ type: "ack", bytes \}\)/);
-	assert.match(source, /terminalOutputAcknowledgement\(forwarded\)/);
-	assert.match(source, /else if \(upstreamConnection\.outputAcknowledgements\)/);
+  assert.match(source, /frame\.type === TerminalMessageType\.Ack/);
+  assert.match(source, /subscription\.outputAcknowledgements/);
+  assert.match(source, /bytes <= subscription\.outputAcknowledgementBytes/);
+  assert.match(source, /acknowledgedBytes <= rightOutputAcknowledgementBytes/);
+  assert.match(source, /TerminalSubscribeFlags\.OutputAcknowledgements/);
+  assert.match(source, /searchParams\.get\("flow"\) === "ack-v1"/);
+  assert.match(source, /JSON\.stringify\(\{ type: "ack", bytes \}\)/);
+  assert.match(source, /terminalOutputAcknowledgement\(forwarded\)/);
+  assert.match(source, /else if \(upstreamConnection\.outputAcknowledgements\)/);
 });
 
 test("runtime adapter terminal bearer stays on the registered origin", () => {
-	assert.equal(
-		runtimeAdapterTerminalOriginMatches(
-			"https://controller.example/adapter",
-			"wss://controller.example/v1/workspaces/fleet-is-101/terminal",
-		),
-		true,
-	);
-	assert.equal(
-		runtimeAdapterTerminalOriginMatches(
-			"http://127.0.0.1:8788/adapter",
-			"ws://127.0.0.1:8788/v1/workspaces/fleet-is-101/terminal",
-		),
-		true,
-	);
-	assert.equal(
-		runtimeAdapterTerminalOriginMatches(
-			"https://controller.example/adapter",
-			"wss://terminal.example/v1/workspaces/fleet-is-101/terminal",
-		),
-		false,
-	);
-	assert.equal(
-		runtimeAdapterTerminalOriginMatches(
-			"https://controller.example/adapter",
-			"wss://controller.example:8443/v1/workspaces/fleet-is-101/terminal",
-		),
-		false,
-	);
+  assert.equal(
+    runtimeAdapterTerminalOriginMatches(
+      "https://controller.example/adapter",
+      "wss://controller.example/v1/workspaces/fleet-is-101/terminal",
+    ),
+    true,
+  );
+  assert.equal(
+    runtimeAdapterTerminalOriginMatches(
+      "http://127.0.0.1:8788/adapter",
+      "ws://127.0.0.1:8788/v1/workspaces/fleet-is-101/terminal",
+    ),
+    true,
+  );
+  assert.equal(
+    runtimeAdapterTerminalOriginMatches(
+      "https://controller.example/adapter",
+      "wss://terminal.example/v1/workspaces/fleet-is-101/terminal",
+    ),
+    false,
+  );
+  assert.equal(
+    runtimeAdapterTerminalOriginMatches(
+      "https://controller.example/adapter",
+      "wss://controller.example:8443/v1/workspaces/fleet-is-101/terminal",
+    ),
+    false,
+  );
 });
 
 test("desktop redirects require HTTPS or literal loopback HTTP", () => {
-	assert.equal(
-		safeDesktopUrl("https://desktop.example/session"),
-		"https://desktop.example/session",
-	);
-	assert.equal(safeDesktopUrl("http://127.0.0.1:6080/vnc"), "http://127.0.0.1:6080/vnc");
-	assert.equal(safeDesktopUrl("http://localhost:6080/vnc"), "http://localhost:6080/vnc");
-	assert.equal(safeDesktopUrl("http://desktop.example/vnc"), null);
-	assert.equal(safeDesktopUrl("http://2130706433:6080/vnc"), null);
-	assert.equal(safeDesktopUrl("https://user:secret@desktop.example/vnc"), null);
-	assert.equal(safeDesktopUrl("javascript:alert(1)"), null);
-	assert.equal(safeDesktopUrl(" https://desktop.example/vnc"), null);
-	const signed = "https://Desktop.Example:443/%7Edesktop?signature=a%2Bb%2Fc%3D&dup=1&dup=2";
-	assert.equal(safeDesktopUrl(signed), signed);
-	assert.equal(parseAdapterDesktopConnection({ url: signed })?.url, signed);
+  assert.equal(
+    safeDesktopUrl("https://desktop.example/session"),
+    "https://desktop.example/session",
+  );
+  assert.equal(safeDesktopUrl("http://127.0.0.1:6080/vnc"), "http://127.0.0.1:6080/vnc");
+  assert.equal(safeDesktopUrl("http://localhost:6080/vnc"), "http://localhost:6080/vnc");
+  assert.equal(safeDesktopUrl("http://desktop.example/vnc"), null);
+  assert.equal(safeDesktopUrl("http://2130706433:6080/vnc"), null);
+  assert.equal(safeDesktopUrl("https://user:secret@desktop.example/vnc"), null);
+  assert.equal(safeDesktopUrl("javascript:alert(1)"), null);
+  assert.equal(safeDesktopUrl(" https://desktop.example/vnc"), null);
+  const signed = "https://Desktop.Example:443/%7Edesktop?signature=a%2Bb%2Fc%3D&dup=1&dup=2";
+  assert.equal(safeDesktopUrl(signed), signed);
+  assert.equal(parseAdapterDesktopConnection({ url: signed })?.url, signed);
 });
 
 test("terminal URLs require WSS except literal loopback WS", () => {
-	assert.equal(
-		safeWebSocketUrl("wss://terminal.example/session"),
-		"wss://terminal.example/session",
-	);
-	assert.equal(safeWebSocketUrl("ws://localhost:8787/session"), "ws://localhost:8787/session");
-	assert.equal(safeWebSocketUrl("ws://127.0.0.1:8787/session"), "ws://127.0.0.1:8787/session");
-	assert.equal(safeWebSocketUrl("ws://terminal.example/session"), null);
-	assert.equal(safeWebSocketUrl("ws://127.1:8787/session"), null);
-	assert.equal(safeWebSocketUrl("wss://terminal.example/session\n"), null);
-	const signed = "wss://Terminal.Example:443/%7Epty?signature=a%2Bb%2Fc%3D&dup=1&dup=2";
-	assert.equal(safeWebSocketUrl(signed), signed);
-	assert.equal(
-		parseAdapterWorkspaceResult({ status: "ready", attachUrl: signed })?.terminalUrl,
-		signed,
-	);
-	const message = parseAdapterWorkspaceResult({
-		id: "fleet-a-is-101",
-		status: "ready",
-		attachUrl: signed,
-		message: `attach ${signed}; Authorization: Bearer bearer-secret; token=query-secret`,
-	})?.message;
-	assert.equal(message, "attach [connection] [credential]");
-	assert.doesNotMatch(message ?? "", /bearer-secret|query-secret|signature=/u);
-	const slashEscaped = signed.replaceAll("/", "\\/");
-	const nestedEscaped = JSON.stringify(slashEscaped).slice(1, -1);
-	for (const escaped of [slashEscaped, nestedEscaped]) {
-		const redacted = redactedAdapterMessage(`provider terminal ${escaped}`, "failed", [], [signed]);
-		assert.equal(redacted, "provider terminal [connection]");
-		assert.doesNotMatch(redacted, /signature|Terminal\.Example/iu);
-	}
-	for (const arbitrary of [
-		String.raw`failed https:\/\/host.example\/pty?bearer=path-secret`,
-		String.raw`nested {\"detail\":\"wss:\\/\\/host.example\\/pty?token=nested-secret\"}`,
-		String.raw`mixed ws:\/\/host.example\/pty?authorization=Bearer-query-secret`,
-	]) {
-		const redacted = redactedAdapterMessage(arbitrary, "failed");
-		assert.match(redacted, /\[connection\]/u);
-		assert.doesNotMatch(redacted, /host\.example|path-secret|nested-secret|query-secret/iu);
-	}
-	assert.equal(
-		redactedAdapterResponseMessage(
-			{
-				message: `desktop ${slashEscaped}`,
-				desktopUrl: signed.replace("wss://", "https://"),
-				terminalUrl: signed,
-			},
-			"fallback",
-		),
-		"desktop [connection]",
-	);
-	assert.equal(
-		redactedAdapterMessage(
-			"desktop https://desktop.example/vnc?ticket=secret and sig=second-secret",
-			"ready",
-		),
-		"desktop [connection] and [credential]",
-	);
-	const structured = redactedAdapterMessage(
-		`provider {"token":"json-secret","ticket":"ticket-secret","safe":"ok"}; Authorization: Basic dXNlcjpwYXNz`,
-		"failed",
-	);
-	assert.doesNotMatch(
-		structured,
-		/json-secret|ticket-secret|dXNlcjpwYXNz|access_token|refresh_token/iu,
-	);
-	assert.match(structured, /\[credential\]/u);
-	for (const providerMessage of [
-		`X-Api-Key: colon-secret`,
-		`access_token: quoted-secret`,
-		String.raw`escaped {\"refresh_token\":\"escaped-secret\"}`,
-		`password=pass-secret; code: code-secret`,
-	]) {
-		const redacted = redactedAdapterMessage(providerMessage, "failed");
-		assert.doesNotMatch(
-			redacted,
-			/colon-secret|quoted-secret|escaped-secret|pass-secret|code-secret/iu,
-		);
-	}
-	const opaqueIdentifierCollision = redactedAdapterMessage(
-		"provider token=identifier-hidden-secret",
-		"failed",
-		["token"],
-	);
-	assert.equal(opaqueIdentifierCollision, "provider [credential]");
-	assert.doesNotMatch(opaqueIdentifierCollision, /identifier-hidden-secret/u);
+  assert.equal(
+    safeWebSocketUrl("wss://terminal.example/session"),
+    "wss://terminal.example/session",
+  );
+  assert.equal(safeWebSocketUrl("ws://localhost:8787/session"), "ws://localhost:8787/session");
+  assert.equal(safeWebSocketUrl("ws://127.0.0.1:8787/session"), "ws://127.0.0.1:8787/session");
+  assert.equal(safeWebSocketUrl("ws://terminal.example/session"), null);
+  assert.equal(safeWebSocketUrl("ws://127.1:8787/session"), null);
+  assert.equal(safeWebSocketUrl("wss://terminal.example/session\n"), null);
+  const signed = "wss://Terminal.Example:443/%7Epty?signature=a%2Bb%2Fc%3D&dup=1&dup=2";
+  assert.equal(safeWebSocketUrl(signed), signed);
+  assert.equal(
+    parseAdapterWorkspaceResult({ status: "ready", attachUrl: signed })?.terminalUrl,
+    signed,
+  );
+  const message = parseAdapterWorkspaceResult({
+    id: "fleet-a-is-101",
+    status: "ready",
+    attachUrl: signed,
+    message: `attach ${signed}; Authorization: Bearer bearer-secret; token=query-secret`,
+  })?.message;
+  assert.equal(message, "attach [connection] [credential]");
+  assert.doesNotMatch(message ?? "", /bearer-secret|query-secret|signature=/u);
+  const slashEscaped = signed.replaceAll("/", "\\/");
+  const nestedEscaped = JSON.stringify(slashEscaped).slice(1, -1);
+  for (const escaped of [slashEscaped, nestedEscaped]) {
+    const redacted = redactedAdapterMessage(`provider terminal ${escaped}`, "failed", [], [signed]);
+    assert.equal(redacted, "provider terminal [connection]");
+    assert.doesNotMatch(redacted, /signature|Terminal\.Example/iu);
+  }
+  for (const arbitrary of [
+    String.raw`failed https:\/\/host.example\/pty?bearer=path-secret`,
+    String.raw`nested {\"detail\":\"wss:\\/\\/host.example\\/pty?token=nested-secret\"}`,
+    String.raw`mixed ws:\/\/host.example\/pty?authorization=Bearer-query-secret`,
+  ]) {
+    const redacted = redactedAdapterMessage(arbitrary, "failed");
+    assert.match(redacted, /\[connection\]/u);
+    assert.doesNotMatch(redacted, /host\.example|path-secret|nested-secret|query-secret/iu);
+  }
+  assert.equal(
+    redactedAdapterResponseMessage(
+      {
+        message: `desktop ${slashEscaped}`,
+        desktopUrl: signed.replace("wss://", "https://"),
+        terminalUrl: signed,
+      },
+      "fallback",
+    ),
+    "desktop [connection]",
+  );
+  assert.equal(
+    redactedAdapterMessage(
+      "desktop https://desktop.example/vnc?ticket=secret and sig=second-secret",
+      "ready",
+    ),
+    "desktop [connection] and [credential]",
+  );
+  const structured = redactedAdapterMessage(
+    `provider {"token":"json-secret","ticket":"ticket-secret","safe":"ok"}; Authorization: Basic dXNlcjpwYXNz`,
+    "failed",
+  );
+  assert.doesNotMatch(
+    structured,
+    /json-secret|ticket-secret|dXNlcjpwYXNz|access_token|refresh_token/iu,
+  );
+  assert.match(structured, /\[credential\]/u);
+  for (const providerMessage of [
+    `X-Api-Key: colon-secret`,
+    `access_token: quoted-secret`,
+    String.raw`escaped {\"refresh_token\":\"escaped-secret\"}`,
+    `password=pass-secret; code: code-secret`,
+  ]) {
+    const redacted = redactedAdapterMessage(providerMessage, "failed");
+    assert.doesNotMatch(
+      redacted,
+      /colon-secret|quoted-secret|escaped-secret|pass-secret|code-secret/iu,
+    );
+  }
+  const opaqueIdentifierCollision = redactedAdapterMessage(
+    "provider token=identifier-hidden-secret",
+    "failed",
+    ["token"],
+  );
+  assert.equal(opaqueIdentifierCollision, "provider [credential]");
+  assert.doesNotMatch(opaqueIdentifierCollision, /identifier-hidden-secret/u);
 });
 
 test("desktop connection parser accepts current controller response aliases", () => {
-	assert.deepEqual(
-		parseAdapterDesktopConnection({
-			vncUrl: "https://desktop.example/session?ticket=short-lived",
-			expiresAt: 1_800_000_000,
-		}),
-		{
-			url: "https://desktop.example/session?ticket=short-lived",
-			expiresAt: 1_800_000_000_000,
-			expiresAtPresent: true,
-		},
-	);
+  assert.deepEqual(
+    parseAdapterDesktopConnection({
+      vncUrl: "https://desktop.example/session?ticket=short-lived",
+      expiresAt: 1_800_000_000,
+    }),
+    {
+      url: "https://desktop.example/session?ticket=short-lived",
+      expiresAt: 1_800_000_000_000,
+      expiresAtPresent: true,
+    },
+  );
 });
 
 test("desktop connection expiry is optional but bounded when present", () => {
-	const now = 1_800_000_000_000;
-	const url = "https://desktop.example/session?ticket=transient";
-	assert.equal(currentAdapterDesktopConnection({ url }, now)?.url, url);
-	assert.equal(
-		currentAdapterDesktopConnection({ url, expiresAt: now + 60_000 }, now)?.expiresAt,
-		now + 60_000,
-	);
-	assert.equal(currentAdapterDesktopConnection({ url, expiresAt: now }, now), null);
-	assert.equal(currentAdapterDesktopConnection({ url, expiresAt: now + 16 * 60_000 }, now), null);
-	assert.equal(currentAdapterDesktopConnection({ url, expiresAt: "not-a-date" }, now), null);
-	assert.equal(parseAdapterDesktopConnection({ url, expiresAt: "" }), null);
-	assert.equal(parseAdapterDesktopConnection({ url, expiresAt: null })?.expiresAtPresent, false);
+  const now = 1_800_000_000_000;
+  const url = "https://desktop.example/session?ticket=transient";
+  assert.equal(currentAdapterDesktopConnection({ url }, now)?.url, url);
+  assert.equal(
+    currentAdapterDesktopConnection({ url, expiresAt: now + 60_000 }, now)?.expiresAt,
+    now + 60_000,
+  );
+  assert.equal(currentAdapterDesktopConnection({ url, expiresAt: now }, now), null);
+  assert.equal(currentAdapterDesktopConnection({ url, expiresAt: now + 16 * 60_000 }, now), null);
+  assert.equal(currentAdapterDesktopConnection({ url, expiresAt: "not-a-date" }, now), null);
+  assert.equal(parseAdapterDesktopConnection({ url, expiresAt: "" }), null);
+  assert.equal(parseAdapterDesktopConnection({ url, expiresAt: null })?.expiresAtPresent, false);
 });

--- a/tests/runtime-adapter.test.ts
+++ b/tests/runtime-adapter.test.ts
@@ -767,6 +767,12 @@ test("strict session rows and cleanup preserve terminal finalization anchors", a
   assert.match(cleanupSource, /deleteFrom\("interactive_session_log_archives"\)/);
   assert.match(cleanupSource, /deleteFrom\("interactive_sessions"\)/);
   assert.match(cleanupSource, /FROM interactive_session_credential_policies/);
+  assert.equal(
+    cleanupSource.match(/FROM interactive_sessions AS descendant/g)?.length,
+    2,
+  );
+  assert.match(cleanupSource, /descendant\.root_session_id = interactive_sessions\.id/);
+  assert.match(cleanupSource, /descendant\.root_session_id = \$\{row\.id\}/);
   assert.match(source, /terminalFinalizationPendingQuery/);
   assert.match(source, /executeBatch\(env, \[[\s\S]*interactive_session_events/);
   assert.match(source, /COALESCE\([\s\S]*event_count[\s\S]*count\(\*\)/);

--- a/tests/runtime-adapter.test.ts
+++ b/tests/runtime-adapter.test.ts
@@ -773,6 +773,10 @@ test("strict session rows and cleanup preserve terminal finalization anchors", a
   );
   assert.match(cleanupSource, /descendant\.root_session_id = interactive_sessions\.id/);
   assert.match(cleanupSource, /descendant\.root_session_id = \$\{row\.id\}/);
+  assert.equal(
+    cleanupSource.match(/descendant\.status NOT IN \('stopped', 'expired', 'failed'\)/g)?.length,
+    2,
+  );
   assert.match(source, /terminalFinalizationPendingQuery/);
   assert.match(source, /executeBatch\(env, \[[\s\S]*interactive_session_events/);
   assert.match(source, /COALESCE\([\s\S]*event_count[\s\S]*count\(\*\)/);

--- a/tests/runtime-adapter.test.ts
+++ b/tests/runtime-adapter.test.ts
@@ -768,19 +768,13 @@ test("strict session rows and cleanup preserve terminal finalization anchors", a
   assert.match(cleanupSource, /deleteFrom\("interactive_sessions"\)/);
   assert.match(cleanupSource, /FROM interactive_session_credential_policies/);
   assert.equal(
-    cleanupSource.match(/FROM interactive_sessions AS active_tree_session/g)?.length,
+    cleanupSource.match(/WITH RECURSIVE active_ancestor\(id\)/g)?.length,
     2,
   );
-  assert.match(
-    cleanupSource,
-    /COALESCE\(active_tree_session\.root_session_id, active_tree_session\.id\)[\s\S]*COALESCE\(interactive_sessions\.root_session_id, interactive_sessions\.id\)/,
-  );
-  assert.match(cleanupSource, /= \$\{row\.root_session_id \?\? row\.id\}/);
-  assert.equal(
-    cleanupSource.match(/active_tree_session\.status NOT IN \('stopped', 'expired', 'failed'\)/g)
-      ?.length,
-    2,
-  );
+  assert.match(cleanupSource, /SELECT parent_session_id[\s\S]*FROM interactive_sessions/);
+  assert.match(cleanupSource, /JOIN active_ancestor ON session\.id = active_ancestor\.id/);
+  assert.match(cleanupSource, /WHERE id = interactive_sessions\.id/);
+  assert.match(cleanupSource, /WHERE id = \$\{row\.id\}/);
   assert.match(source, /terminalFinalizationPendingQuery/);
   assert.match(source, /executeBatch\(env, \[[\s\S]*interactive_session_events/);
   assert.match(source, /COALESCE\([\s\S]*event_count[\s\S]*count\(\*\)/);

--- a/tests/runtime-adapter.test.ts
+++ b/tests/runtime-adapter.test.ts
@@ -768,13 +768,17 @@ test("strict session rows and cleanup preserve terminal finalization anchors", a
   assert.match(cleanupSource, /deleteFrom\("interactive_sessions"\)/);
   assert.match(cleanupSource, /FROM interactive_session_credential_policies/);
   assert.equal(
-    cleanupSource.match(/FROM interactive_sessions AS descendant/g)?.length,
+    cleanupSource.match(/FROM interactive_sessions AS active_tree_session/g)?.length,
     2,
   );
-  assert.match(cleanupSource, /descendant\.root_session_id = interactive_sessions\.id/);
-  assert.match(cleanupSource, /descendant\.root_session_id = \$\{row\.id\}/);
+  assert.match(
+    cleanupSource,
+    /COALESCE\(active_tree_session\.root_session_id, active_tree_session\.id\)[\s\S]*COALESCE\(interactive_sessions\.root_session_id, interactive_sessions\.id\)/,
+  );
+  assert.match(cleanupSource, /= \$\{row\.root_session_id \?\? row\.id\}/);
   assert.equal(
-    cleanupSource.match(/descendant\.status NOT IN \('stopped', 'expired', 'failed'\)/g)?.length,
+    cleanupSource.match(/active_tree_session\.status NOT IN \('stopped', 'expired', 'failed'\)/g)
+      ?.length,
     2,
   );
   assert.match(source, /terminalFinalizationPendingQuery/);

--- a/tests/runtime-adapter.test.ts
+++ b/tests/runtime-adapter.test.ts
@@ -3,2294 +3,2294 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
-  adapterFailureReleaseState,
-  adapterWorkspaceIdMatches,
-  clearedAdapterCapabilities,
-  createOnlyAdapterStatus,
-  definitiveRuntimeAdapterCreateFailure,
-  effectiveAdapterCapabilities,
-  currentAdapterDesktopConnection,
-  legacyLeaseIdForAdapter,
-  namespacedAdapterWorkspaceId,
-  normalizeAdapterNamespace,
-  normalizeAdapterWorkspaceId,
-  parseAdapterDesktopConnection,
-  parseAdapterWorkspaceResult,
-  redactedAdapterMessage,
-  redactedAdapterResponseMessage,
-  runtimeAdapterControlPlaneForProfile,
-  runtimeAdapterControlPlaneIdentity,
-  runtimeAdapterCreatePayload,
-  runtimeAdapterBrowserVncUrl,
-  runtimeAdapterDesktopUrl,
-  runtimeAdapterReplayRequest,
-  retainedRuntimeAdapterFailureMessage,
-  runtimeAdapterStopOutcome,
-  runtimeAdapterTerminalFailureStatus,
-  runtimeAdapterTerminalOriginMatches,
-  runtimeAdapterWorkspaceIdConflict,
-  runtimeAdapterWorkspaceUrl,
-  resolveCreateAfterStopRace,
-  safeDesktopUrl,
-  safeWebSocketUrl,
-  shouldReplayRuntimeAdapterCreate,
-  validatedRuntimeAdapterCreatePayloadJson,
+	adapterFailureReleaseState,
+	adapterWorkspaceIdMatches,
+	clearedAdapterCapabilities,
+	createOnlyAdapterStatus,
+	definitiveRuntimeAdapterCreateFailure,
+	effectiveAdapterCapabilities,
+	currentAdapterDesktopConnection,
+	legacyLeaseIdForAdapter,
+	namespacedAdapterWorkspaceId,
+	normalizeAdapterNamespace,
+	normalizeAdapterWorkspaceId,
+	parseAdapterDesktopConnection,
+	parseAdapterWorkspaceResult,
+	redactedAdapterMessage,
+	redactedAdapterResponseMessage,
+	runtimeAdapterControlPlaneForProfile,
+	runtimeAdapterControlPlaneIdentity,
+	runtimeAdapterCreatePayload,
+	runtimeAdapterBrowserVncUrl,
+	runtimeAdapterDesktopUrl,
+	runtimeAdapterReplayRequest,
+	retainedRuntimeAdapterFailureMessage,
+	runtimeAdapterStopOutcome,
+	runtimeAdapterTerminalFailureStatus,
+	runtimeAdapterTerminalOriginMatches,
+	runtimeAdapterWorkspaceIdConflict,
+	runtimeAdapterWorkspaceUrl,
+	resolveCreateAfterStopRace,
+	safeDesktopUrl,
+	safeWebSocketUrl,
+	shouldReplayRuntimeAdapterCreate,
+	validatedRuntimeAdapterCreatePayloadJson,
 } from "../src/runtime-adapter.ts";
 
 test("adapter create payload matches the strict controller contract", () => {
-  const payload = runtimeAdapterCreatePayload({
-    namespace: "fleet-a",
-    id: "IS-101",
-    parentSessionId: null,
-    rootSessionId: "IS-101",
-    repo: "example/project",
-    branch: "main",
-    runtime: "crabbox",
-    profile: "default",
-    command: "codex --yolo",
-    prompt: "investigate the failure",
-    purpose: "investigate",
-    summary: "starting",
-    owner: "operator",
-    createdBy: "operator",
-    ttlSeconds: 14_400,
-    idleTimeoutSeconds: 1_800,
-    desktop: true,
-  });
+	const payload = runtimeAdapterCreatePayload({
+		namespace: "fleet-a",
+		id: "IS-101",
+		parentSessionId: null,
+		rootSessionId: "IS-101",
+		repo: "example/project",
+		branch: "main",
+		runtime: "crabbox",
+		profile: "default",
+		command: "codex --yolo",
+		prompt: "investigate the failure",
+		purpose: "investigate",
+		summary: "starting",
+		owner: "operator",
+		createdBy: "operator",
+		ttlSeconds: 14_400,
+		idleTimeoutSeconds: 1_800,
+		desktop: true,
+	});
 
-  assert.deepEqual(payload, {
-    id: "fleet-a-is-101",
-    parentSessionId: null,
-    rootSessionId: "IS-101",
-    repo: "example/project",
-    branch: "main",
-    runtime: "crabbox",
-    profile: "default",
-    command: "codex --yolo",
-    prompt: "investigate the failure",
-    purpose: "investigate",
-    summary: "starting",
-    owner: "operator",
-    createdBy: "operator",
-    ttlSeconds: 14_400,
-    idleTimeoutSeconds: 1_800,
-    capabilities: { desktop: true },
-  });
-  assert.equal("apiVersion" in (payload ?? {}), false);
-  assert.equal("sessionId" in (payload ?? {}), false);
-  assert.equal("idempotencyKey" in (payload ?? {}), false);
-  assert.equal(
-    runtimeAdapterCreatePayload(
-      {
-        namespace: "different-config",
-        id: "IS-101",
-        parentSessionId: null,
-        rootSessionId: "IS-101",
-        repo: "example/project",
-        branch: "main",
-        runtime: "crabbox",
-        profile: "default",
-        command: "codex --yolo",
-        prompt: "investigate the failure",
-        purpose: "investigate",
-        summary: "starting",
-        owner: "operator",
-        createdBy: "operator",
-        ttlSeconds: 14_400,
-        idleTimeoutSeconds: 1_800,
-        desktop: true,
-      },
-      "fleet-a-is-101",
-    )?.id,
-    "fleet-a-is-101",
-  );
+	assert.deepEqual(payload, {
+		id: "fleet-a-is-101",
+		parentSessionId: null,
+		rootSessionId: "IS-101",
+		repo: "example/project",
+		branch: "main",
+		runtime: "crabbox",
+		profile: "default",
+		command: "codex --yolo",
+		prompt: "investigate the failure",
+		purpose: "investigate",
+		summary: "starting",
+		owner: "operator",
+		createdBy: "operator",
+		ttlSeconds: 14_400,
+		idleTimeoutSeconds: 1_800,
+		capabilities: { desktop: true },
+	});
+	assert.equal("apiVersion" in (payload ?? {}), false);
+	assert.equal("sessionId" in (payload ?? {}), false);
+	assert.equal("idempotencyKey" in (payload ?? {}), false);
+	assert.equal(
+		runtimeAdapterCreatePayload(
+			{
+				namespace: "different-config",
+				id: "IS-101",
+				parentSessionId: null,
+				rootSessionId: "IS-101",
+				repo: "example/project",
+				branch: "main",
+				runtime: "crabbox",
+				profile: "default",
+				command: "codex --yolo",
+				prompt: "investigate the failure",
+				purpose: "investigate",
+				summary: "starting",
+				owner: "operator",
+				createdBy: "operator",
+				ttlSeconds: 14_400,
+				idleTimeoutSeconds: 1_800,
+				desktop: true,
+			},
+			"fleet-a-is-101",
+		)?.id,
+		"fleet-a-is-101",
+	);
 });
 
 test("configured profiles fence every adapter runtime and preserve requested capabilities", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const createStart = source.indexOf("async function createInteractiveSessionFromInput");
-  const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
-  const createSource = source.slice(createStart, createEnd);
-  const profileStart = source.indexOf("function selectedRuntimeProfile");
-  const profileEnd = source.indexOf("function publicDeploymentConfig", profileStart);
-  const profileSource = source.slice(profileStart, profileEnd);
-  const resultStart = source.indexOf("function runtimeAdapterProvisionResult");
-  const resultEnd = source.indexOf(
-    "async function reconcileStoppingRuntimeAdapterWorkspace",
-    resultStart,
-  );
-  const resultSource = source.slice(resultStart, resultEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
+	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
+	const createSource = source.slice(createStart, createEnd);
+	const profileStart = source.indexOf("function selectedRuntimeProfile");
+	const profileEnd = source.indexOf("function publicDeploymentConfig", profileStart);
+	const profileSource = source.slice(profileStart, profileEnd);
+	const resultStart = source.indexOf("function runtimeAdapterProvisionResult");
+	const resultEnd = source.indexOf(
+		"async function reconcileStoppingRuntimeAdapterWorkspace",
+		resultStart,
+	);
+	const resultSource = source.slice(resultStart, resultEnd);
 
-  assert.match(createSource, /selectedRuntimeProfile\(deployment, body\.profile\)/);
-  assert.match(profileSource, /deployment\.runtimeProfiles\.length > 0 && !descriptor/);
-  assert.match(resultSource, /session\.adapterRequestedCapabilities \?\?/);
-  assert.match(resultSource, /profile: session\.profile/);
-  assert.doesNotMatch(resultSource, /profile: result\.profile/);
+	assert.match(createSource, /selectedRuntimeProfile\(deployment, body\.profile\)/);
+	assert.match(profileSource, /deployment\.runtimeProfiles\.length > 0 && !descriptor/);
+	assert.match(resultSource, /session\.adapterRequestedCapabilities \?\?/);
+	assert.match(resultSource, /profile: session\.profile/);
+	assert.doesNotMatch(resultSource, /profile: result\.profile/);
 });
 
 test("profile-routed adapter responses cannot rewrite their lifecycle route", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const createStart = source.indexOf("async function provisionWithRuntimeAdapter");
-  const createEnd = source.indexOf("function persistedRuntimeAdapterSeconds", createStart);
-  const createSource = source.slice(createStart, createEnd);
-  const inspectStart = source.indexOf("async function inspectRuntimeAdapterWorkspace");
-  const inspectEnd = source.indexOf(
-    "async function reconcileStoppingRuntimeAdapterWorkspace",
-    inspectStart,
-  );
-  const inspectSource = source.slice(inspectStart, inspectEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const createStart = source.indexOf("async function provisionWithRuntimeAdapter");
+	const createEnd = source.indexOf("function persistedRuntimeAdapterSeconds", createStart);
+	const createSource = source.slice(createStart, createEnd);
+	const inspectStart = source.indexOf("async function inspectRuntimeAdapterWorkspace");
+	const inspectEnd = source.indexOf(
+		"async function reconcileStoppingRuntimeAdapterWorkspace",
+		inspectStart,
+	);
+	const inspectSource = source.slice(inspectStart, inspectEnd);
 
-  assert.match(createSource, /parsed\.profile !== session\.profile/);
-  assert.match(createSource, /workspace profile mismatch/);
-  assert.match(inspectSource, /parsed\.profile !== session\.profile/);
-  assert.match(inspectSource, /different workspace profile/);
+	assert.match(createSource, /parsed\.profile !== session\.profile/);
+	assert.match(createSource, /workspace profile mismatch/);
+	assert.match(inspectSource, /parsed\.profile !== session\.profile/);
+	assert.match(inspectSource, /different workspace profile/);
 });
 
 test("adapter workspace id stays distinct from provider resource id", () => {
-  const result = parseAdapterWorkspaceResult({
-    id: "fleet-a-is-101",
-    providerResourceId: "cloud/project/box-42",
-    status: "ready",
-    attachUrl: "wss://controller.example/terminal/is-101",
-    capabilities: {
-      terminal: true,
-      takeover: false,
-      vnc: true,
-      desktop: true,
-      logs: false,
-      artifacts: false,
-      browser: true,
-      code: true,
-    },
-    expiresAt: "2026-06-12T12:00:00Z",
-    message: "cloud/project/box-42 is ready as fleet-a-is-101",
-  });
+	const result = parseAdapterWorkspaceResult({
+		id: "fleet-a-is-101",
+		providerResourceId: "cloud/project/box-42",
+		status: "ready",
+		attachUrl: "wss://controller.example/terminal/is-101",
+		capabilities: {
+			terminal: true,
+			takeover: false,
+			vnc: true,
+			desktop: true,
+			logs: false,
+			artifacts: false,
+			browser: true,
+			code: true,
+		},
+		expiresAt: "2026-06-12T12:00:00Z",
+		message: "cloud/project/box-42 is ready as fleet-a-is-101",
+	});
 
-  assert.equal(result?.workspaceId, "fleet-a-is-101");
-  assert.equal(result?.providerResourceId, "cloud/project/box-42");
-  assert.equal(result?.terminalUrl, "wss://controller.example/terminal/is-101");
-  assert.equal(result?.terminalUrlPresent, true);
-  assert.equal(result?.capabilities?.terminal, true);
-  assert.equal(result?.capabilities?.desktop, true);
-  assert.equal(result?.capabilities?.vnc, true);
-  assert.equal(result?.terminalCapabilityInferred, false);
-  assert.equal(result?.message, "[workspace] is ready as [workspace]");
-  assert.deepEqual(
-    effectiveAdapterCapabilities(
-      result!,
-      {
-        ...clearedAdapterCapabilities,
-        takeover: true,
-        logs: true,
-        artifacts: true,
-      },
-      false,
-    ),
-    {
-      terminal: true,
-      takeover: false,
-      vnc: true,
-      desktop: true,
-      logs: false,
-      artifacts: false,
-    },
-  );
+	assert.equal(result?.workspaceId, "fleet-a-is-101");
+	assert.equal(result?.providerResourceId, "cloud/project/box-42");
+	assert.equal(result?.terminalUrl, "wss://controller.example/terminal/is-101");
+	assert.equal(result?.terminalUrlPresent, true);
+	assert.equal(result?.capabilities?.terminal, true);
+	assert.equal(result?.capabilities?.desktop, true);
+	assert.equal(result?.capabilities?.vnc, true);
+	assert.equal(result?.terminalCapabilityInferred, false);
+	assert.equal(result?.message, "[workspace] is ready as [workspace]");
+	assert.deepEqual(
+		effectiveAdapterCapabilities(
+			result!,
+			{
+				...clearedAdapterCapabilities,
+				takeover: true,
+				logs: true,
+				artifacts: true,
+			},
+			false,
+		),
+		{
+			terminal: true,
+			takeover: false,
+			vnc: true,
+			desktop: true,
+			logs: false,
+			artifacts: false,
+		},
+	);
 
-  const explicitlyDisabled = parseAdapterWorkspaceResult({
-    id: "fleet-a-is-102",
-    status: "ready",
-    attachUrl: "wss://controller.example/terminal/is-102",
-    capabilities: { terminal: false, desktop: true },
-  });
-  assert.equal(explicitlyDisabled?.capabilities?.terminal, false);
-  assert.equal(explicitlyDisabled?.terminalCapabilityInferred, false);
-  assert.equal(
-    effectiveAdapterCapabilities(
-      explicitlyDisabled!,
-      { ...clearedAdapterCapabilities, terminal: true, takeover: true, artifacts: true },
-      true,
-    )?.terminal,
-    false,
-  );
+	const explicitlyDisabled = parseAdapterWorkspaceResult({
+		id: "fleet-a-is-102",
+		status: "ready",
+		attachUrl: "wss://controller.example/terminal/is-102",
+		capabilities: { terminal: false, desktop: true },
+	});
+	assert.equal(explicitlyDisabled?.capabilities?.terminal, false);
+	assert.equal(explicitlyDisabled?.terminalCapabilityInferred, false);
+	assert.equal(
+		effectiveAdapterCapabilities(
+			explicitlyDisabled!,
+			{ ...clearedAdapterCapabilities, terminal: true, takeover: true, artifacts: true },
+			true,
+		)?.terminal,
+		false,
+	);
 
-  const explicitlyNull = parseAdapterWorkspaceResult({
-    id: "fleet-a-is-102-null",
-    status: "ready",
-    attachUrl: "wss://controller.example/terminal/is-102-null",
-    capabilities: { terminal: null, desktop: true },
-  });
-  assert.equal(explicitlyNull?.capabilities?.terminal, false);
-  assert.equal(explicitlyNull?.terminalCapabilityInferred, false);
-  assert.equal(
-    effectiveAdapterCapabilities(
-      explicitlyNull!,
-      { ...clearedAdapterCapabilities, terminal: true, artifacts: true },
-      false,
-    )?.terminal,
-    false,
-  );
+	const explicitlyNull = parseAdapterWorkspaceResult({
+		id: "fleet-a-is-102-null",
+		status: "ready",
+		attachUrl: "wss://controller.example/terminal/is-102-null",
+		capabilities: { terminal: null, desktop: true },
+	});
+	assert.equal(explicitlyNull?.capabilities?.terminal, false);
+	assert.equal(explicitlyNull?.terminalCapabilityInferred, false);
+	assert.equal(
+		effectiveAdapterCapabilities(
+			explicitlyNull!,
+			{ ...clearedAdapterCapabilities, terminal: true, artifacts: true },
+			false,
+		)?.terminal,
+		false,
+	);
 
-  const authoritativeList = parseAdapterWorkspaceResult({
-    id: "fleet-a-is-103",
-    status: "ready",
-    attachUrl: "wss://controller.example/terminal/is-103",
-    capabilities: ["desktop"],
-  });
-  assert.equal(authoritativeList?.capabilities?.terminal, false);
-  assert.equal(authoritativeList?.terminalCapabilityInferred, false);
+	const authoritativeList = parseAdapterWorkspaceResult({
+		id: "fleet-a-is-103",
+		status: "ready",
+		attachUrl: "wss://controller.example/terminal/is-103",
+		capabilities: ["desktop"],
+	});
+	assert.equal(authoritativeList?.capabilities?.terminal, false);
+	assert.equal(authoritativeList?.terminalCapabilityInferred, false);
 
-  const omittedCapabilities = parseAdapterWorkspaceResult({
-    id: "fleet-a-is-104",
-    status: "ready",
-    attachUrl: "wss://controller.example/terminal/is-104",
-  });
-  assert.equal(omittedCapabilities?.capabilitiesPresent, false);
-  assert.equal(omittedCapabilities?.terminalCapabilityInferred, true);
-  assert.equal(omittedCapabilities?.capabilities, null);
-  assert.deepEqual(
-    effectiveAdapterCapabilities(
-      omittedCapabilities!,
-      { ...clearedAdapterCapabilities, desktop: true, vnc: true, logs: true, artifacts: true },
-      false,
-    ),
-    {
-      ...clearedAdapterCapabilities,
-      terminal: true,
-      desktop: true,
-      vnc: true,
-      logs: true,
-      artifacts: true,
-    },
-  );
+	const omittedCapabilities = parseAdapterWorkspaceResult({
+		id: "fleet-a-is-104",
+		status: "ready",
+		attachUrl: "wss://controller.example/terminal/is-104",
+	});
+	assert.equal(omittedCapabilities?.capabilitiesPresent, false);
+	assert.equal(omittedCapabilities?.terminalCapabilityInferred, true);
+	assert.equal(omittedCapabilities?.capabilities, null);
+	assert.deepEqual(
+		effectiveAdapterCapabilities(
+			omittedCapabilities!,
+			{ ...clearedAdapterCapabilities, desktop: true, vnc: true, logs: true, artifacts: true },
+			false,
+		),
+		{
+			...clearedAdapterCapabilities,
+			terminal: true,
+			desktop: true,
+			vnc: true,
+			logs: true,
+			artifacts: true,
+		},
+	);
 
-  const overlapping = parseAdapterWorkspaceResult({
-    id: "fleet-a-is-101",
-    providerResourceId: "fleet-a-is-101-provider-suffix",
-    status: "ready",
-    message: "fleet-a-is-101-provider-suffix is ready for fleet-a-is-101",
-  });
-  assert.equal(overlapping?.message, "[workspace] is ready for [workspace]");
+	const overlapping = parseAdapterWorkspaceResult({
+		id: "fleet-a-is-101",
+		providerResourceId: "fleet-a-is-101-provider-suffix",
+		status: "ready",
+		message: "fleet-a-is-101-provider-suffix is ready for fleet-a-is-101",
+	});
+	assert.equal(overlapping?.message, "[workspace] is ready for [workspace]");
 });
 
 test("adapter workspace identity is namespaced, bounded, and exact", () => {
-  assert.equal(normalizeAdapterNamespace("Fleet-A"), "fleet-a");
-  assert.equal(normalizeAdapterNamespace("fleet_a"), null);
-  assert.equal(namespacedAdapterWorkspaceId("Fleet-A", "IS-101"), "fleet-a-is-101");
-  assert.equal(namespacedAdapterWorkspaceId("a".repeat(32), "b".repeat(31)), null);
+	assert.equal(normalizeAdapterNamespace("Fleet-A"), "fleet-a");
+	assert.equal(normalizeAdapterNamespace("fleet_a"), null);
+	assert.equal(namespacedAdapterWorkspaceId("Fleet-A", "IS-101"), "fleet-a-is-101");
+	assert.equal(namespacedAdapterWorkspaceId("a".repeat(32), "b".repeat(31)), null);
 
-  const exact = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "ready" });
-  const wrong = parseAdapterWorkspaceResult({ id: "fleet-b-is-101", status: "ready" });
-  const missing = parseAdapterWorkspaceResult(
-    { status: "ready" },
-    { workspaceId: "fleet-a-is-101" },
-  );
-  assert.equal(adapterWorkspaceIdMatches(exact!, "fleet-a-is-101"), true);
-  assert.equal(adapterWorkspaceIdMatches(wrong!, "fleet-a-is-101"), false);
-  assert.equal(adapterWorkspaceIdMatches(missing!, "fleet-a-is-101"), false);
-  assert.equal(exact?.providerResourceId, null);
-  assert.equal(parseAdapterWorkspaceResult({ id: " fleet-a-is-101", status: "ready" }), null);
-  assert.equal(parseAdapterWorkspaceResult({ id: "Fleet-A-Is-101", status: "ready" }), null);
-  assert.equal(
-    parseAdapterWorkspaceResult({
-      id: "fleet-a-is-101",
-      workspaceId: "fleet-a-is-102",
-      status: "ready",
-    }),
-    null,
-  );
+	const exact = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "ready" });
+	const wrong = parseAdapterWorkspaceResult({ id: "fleet-b-is-101", status: "ready" });
+	const missing = parseAdapterWorkspaceResult(
+		{ status: "ready" },
+		{ workspaceId: "fleet-a-is-101" },
+	);
+	assert.equal(adapterWorkspaceIdMatches(exact!, "fleet-a-is-101"), true);
+	assert.equal(adapterWorkspaceIdMatches(wrong!, "fleet-a-is-101"), false);
+	assert.equal(adapterWorkspaceIdMatches(missing!, "fleet-a-is-101"), false);
+	assert.equal(exact?.providerResourceId, null);
+	assert.equal(parseAdapterWorkspaceResult({ id: " fleet-a-is-101", status: "ready" }), null);
+	assert.equal(parseAdapterWorkspaceResult({ id: "Fleet-A-Is-101", status: "ready" }), null);
+	assert.equal(
+		parseAdapterWorkspaceResult({
+			id: "fleet-a-is-101",
+			workspaceId: "fleet-a-is-102",
+			status: "ready",
+		}),
+		null,
+	);
 });
 
 test("create-only adapters cannot return an unowned stopping lifecycle", () => {
-  assert.equal(createOnlyAdapterStatus("ready"), "ready");
-  assert.equal(createOnlyAdapterStatus("failed"), "failed");
-  assert.equal(createOnlyAdapterStatus("stopping"), null);
-  assert.equal(createOnlyAdapterStatus(" ready "), null);
+	assert.equal(createOnlyAdapterStatus("ready"), "ready");
+	assert.equal(createOnlyAdapterStatus("failed"), "failed");
+	assert.equal(createOnlyAdapterStatus("stopping"), null);
+	assert.equal(createOnlyAdapterStatus(" ready "), null);
 });
 
 test("status-only inspect preserves omitted capability and expiry fields", () => {
-  const omitted = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "ready" });
-  assert.equal(omitted?.capabilitiesPresent, false);
-  assert.equal(omitted?.capabilities, null);
-  assert.equal(omitted?.expiresAtPresent, false);
-  assert.equal(omitted?.expiresAt, null);
-  assert.equal(omitted?.terminalUrlPresent, false);
+	const omitted = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "ready" });
+	assert.equal(omitted?.capabilitiesPresent, false);
+	assert.equal(omitted?.capabilities, null);
+	assert.equal(omitted?.expiresAtPresent, false);
+	assert.equal(omitted?.expiresAt, null);
+	assert.equal(omitted?.terminalUrlPresent, false);
 
-  const cleared = parseAdapterWorkspaceResult({
-    id: "fleet-a-is-101",
-    status: "ready",
-    capabilities: null,
-    expiresAt: null,
-    attachUrl: null,
-  });
-  assert.equal(cleared?.capabilitiesPresent, true);
-  assert.equal(cleared?.capabilities, null);
-  assert.equal(cleared?.expiresAtPresent, true);
-  assert.equal(cleared?.expiresAt, null);
-  assert.equal(cleared?.terminalUrlPresent, true);
-  assert.equal(cleared?.terminalUrl, null);
-  assert.equal(
-    parseAdapterWorkspaceResult({
-      id: "fleet-a-is-101",
-      status: "ready",
-      expiresAt: "not-a-date",
-    }),
-    null,
-  );
-  assert.equal(
-    parseAdapterWorkspaceResult({
-      id: "fleet-a-is-101",
-      status: "ready",
-      expiresAt: "",
-    }),
-    null,
-  );
-  assert.deepEqual(clearedAdapterCapabilities, {
-    terminal: false,
-    takeover: false,
-    vnc: false,
-    desktop: false,
-    logs: false,
-    artifacts: false,
-  });
-  assert.deepEqual(
-    effectiveAdapterCapabilities(
-      cleared!,
-      { ...clearedAdapterCapabilities, vnc: true, desktop: true },
-      true,
-    ),
-    clearedAdapterCapabilities,
-  );
-  assert.equal(
-    effectiveAdapterCapabilities(omitted!, clearedAdapterCapabilities, false),
-    undefined,
-  );
+	const cleared = parseAdapterWorkspaceResult({
+		id: "fleet-a-is-101",
+		status: "ready",
+		capabilities: null,
+		expiresAt: null,
+		attachUrl: null,
+	});
+	assert.equal(cleared?.capabilitiesPresent, true);
+	assert.equal(cleared?.capabilities, null);
+	assert.equal(cleared?.expiresAtPresent, true);
+	assert.equal(cleared?.expiresAt, null);
+	assert.equal(cleared?.terminalUrlPresent, true);
+	assert.equal(cleared?.terminalUrl, null);
+	assert.equal(
+		parseAdapterWorkspaceResult({
+			id: "fleet-a-is-101",
+			status: "ready",
+			expiresAt: "not-a-date",
+		}),
+		null,
+	);
+	assert.equal(
+		parseAdapterWorkspaceResult({
+			id: "fleet-a-is-101",
+			status: "ready",
+			expiresAt: "",
+		}),
+		null,
+	);
+	assert.deepEqual(clearedAdapterCapabilities, {
+		terminal: false,
+		takeover: false,
+		vnc: false,
+		desktop: false,
+		logs: false,
+		artifacts: false,
+	});
+	assert.deepEqual(
+		effectiveAdapterCapabilities(
+			cleared!,
+			{ ...clearedAdapterCapabilities, vnc: true, desktop: true },
+			true,
+		),
+		clearedAdapterCapabilities,
+	);
+	assert.equal(
+		effectiveAdapterCapabilities(omitted!, clearedAdapterCapabilities, false),
+		undefined,
+	);
 });
 
 test("missing ambiguous workspaces replay the complete persisted request", () => {
-  const createPayloadJson = JSON.stringify({
-    id: "fleet-a-is-101",
-    purpose: "immutable original purpose",
-    summary: "immutable original summary",
-    profile: "desktop-large",
-    ttlSeconds: 14_400,
-    idleTimeoutSeconds: 1_800,
-    capabilities: { desktop: true },
-  });
-  const request = runtimeAdapterReplayRequest({
-    id: "IS-101",
-    adapter_workspace_id: "fleet-a-is-101",
-    adapter_control_plane: "https://controller.example/api",
-    parent_session_id: "IS-100",
-    root_session_id: "IS-99",
-    repo: "example/project",
-    branch: "feature/retry",
-    runtime: "crabbox",
-    profile: "desktop-large",
-    command: "codex --yolo",
-    prompt: "continue after timeout",
-    purpose: "repair create",
-    summary: "create outcome unknown",
-    owner: "operator",
-    created_by: "service",
-    adapter_ttl_seconds: 14_400,
-    adapter_idle_timeout_seconds: 1_800,
-    adapter_requested_capabilities_json: JSON.stringify({
-      terminal: true,
-      takeover: true,
-      vnc: true,
-      desktop: true,
-      logs: true,
-      artifacts: true,
-    }),
-    adapter_create_payload_json: createPayloadJson,
-  });
+	const createPayloadJson = JSON.stringify({
+		id: "fleet-a-is-101",
+		purpose: "immutable original purpose",
+		summary: "immutable original summary",
+		profile: "desktop-large",
+		ttlSeconds: 14_400,
+		idleTimeoutSeconds: 1_800,
+		capabilities: { desktop: true },
+	});
+	const request = runtimeAdapterReplayRequest({
+		id: "IS-101",
+		adapter_workspace_id: "fleet-a-is-101",
+		adapter_control_plane: "https://controller.example/api",
+		parent_session_id: "IS-100",
+		root_session_id: "IS-99",
+		repo: "example/project",
+		branch: "feature/retry",
+		runtime: "crabbox",
+		profile: "desktop-large",
+		command: "codex --yolo",
+		prompt: "continue after timeout",
+		purpose: "repair create",
+		summary: "create outcome unknown",
+		owner: "operator",
+		created_by: "service",
+		adapter_ttl_seconds: 14_400,
+		adapter_idle_timeout_seconds: 1_800,
+		adapter_requested_capabilities_json: JSON.stringify({
+			terminal: true,
+			takeover: true,
+			vnc: true,
+			desktop: true,
+			logs: true,
+			artifacts: true,
+		}),
+		adapter_create_payload_json: createPayloadJson,
+	});
 
-  assert.deepEqual(request, {
-    id: "IS-101",
-    adapterWorkspaceId: "fleet-a-is-101",
-    adapterControlPlane: "https://controller.example/api",
-    parentSessionId: "IS-100",
-    rootSessionId: "IS-99",
-    repo: "example/project",
-    branch: "feature/retry",
-    runtime: "crabbox",
-    profile: "desktop-large",
-    command: "codex --yolo",
-    prompt: "continue after timeout",
-    purpose: "repair create",
-    summary: "create outcome unknown",
-    owner: "operator",
-    createdBy: "service",
-    adapterTtlSeconds: 14_400,
-    adapterIdleTimeoutSeconds: 1_800,
-    adapterRequestedCapabilities: {
-      terminal: true,
-      takeover: true,
-      vnc: true,
-      desktop: true,
-      logs: true,
-      artifacts: true,
-    },
-    adapterCreatePayloadJson: createPayloadJson,
-  });
-  assert.equal(shouldReplayRuntimeAdapterCreate("provisioning", true), true);
-  assert.equal(shouldReplayRuntimeAdapterCreate("pending_adapter", true), true);
-  assert.equal(shouldReplayRuntimeAdapterCreate("provisioning", false), false);
-  assert.equal(shouldReplayRuntimeAdapterCreate("ready", true), false);
-  assert.equal(shouldReplayRuntimeAdapterCreate("stopping", true), false);
-  assert.equal(
-    validatedRuntimeAdapterCreatePayloadJson(createPayloadJson, {
-      workspaceId: "fleet-a-is-101",
-      ttlSeconds: 14_400,
-      idleTimeoutSeconds: 1_800,
-      desktop: true,
-    }),
-    createPayloadJson,
-  );
+	assert.deepEqual(request, {
+		id: "IS-101",
+		adapterWorkspaceId: "fleet-a-is-101",
+		adapterControlPlane: "https://controller.example/api",
+		parentSessionId: "IS-100",
+		rootSessionId: "IS-99",
+		repo: "example/project",
+		branch: "feature/retry",
+		runtime: "crabbox",
+		profile: "desktop-large",
+		command: "codex --yolo",
+		prompt: "continue after timeout",
+		purpose: "repair create",
+		summary: "create outcome unknown",
+		owner: "operator",
+		createdBy: "service",
+		adapterTtlSeconds: 14_400,
+		adapterIdleTimeoutSeconds: 1_800,
+		adapterRequestedCapabilities: {
+			terminal: true,
+			takeover: true,
+			vnc: true,
+			desktop: true,
+			logs: true,
+			artifacts: true,
+		},
+		adapterCreatePayloadJson: createPayloadJson,
+	});
+	assert.equal(shouldReplayRuntimeAdapterCreate("provisioning", true), true);
+	assert.equal(shouldReplayRuntimeAdapterCreate("pending_adapter", true), true);
+	assert.equal(shouldReplayRuntimeAdapterCreate("provisioning", false), false);
+	assert.equal(shouldReplayRuntimeAdapterCreate("ready", true), false);
+	assert.equal(shouldReplayRuntimeAdapterCreate("stopping", true), false);
+	assert.equal(
+		validatedRuntimeAdapterCreatePayloadJson(createPayloadJson, {
+			workspaceId: "fleet-a-is-101",
+			ttlSeconds: 14_400,
+			idleTimeoutSeconds: 1_800,
+			desktop: true,
+		}),
+		createPayloadJson,
+	);
 });
 
 test("failed adapter workspaces become terminal only after release", () => {
-  assert.deepEqual(adapterFailureReleaseState("stopping"), {
-    status: "stopping",
-    terminalStatus: "failed",
-    message: "runtime workspace release pending",
-  });
-  assert.deepEqual(adapterFailureReleaseState("stopped"), {
-    status: "failed",
-    terminalStatus: null,
-    message: "runtime workspace released",
-  });
+	assert.deepEqual(adapterFailureReleaseState("stopping"), {
+		status: "stopping",
+		terminalStatus: "failed",
+		message: "runtime workspace release pending",
+	});
+	assert.deepEqual(adapterFailureReleaseState("stopped"), {
+		status: "failed",
+		terminalStatus: null,
+		message: "runtime workspace released",
+	});
 });
 
 test("adapter failure release retains the actual failure reason", () => {
-  assert.equal(
-    retainedRuntimeAdapterFailureMessage(
-      "runtime adapter provision failed: HTTP 422",
-      "release transport failed",
-      "generic release text",
-    ),
-    "runtime adapter provision failed: HTTP 422",
-  );
+	assert.equal(
+		retainedRuntimeAdapterFailureMessage(
+			"runtime adapter provision failed: HTTP 422",
+			"release transport failed",
+			"generic release text",
+		),
+		"runtime adapter provision failed: HTTP 422",
+	);
 });
 
 test("runtime adapter terminal failures stay retryable until lifecycle release", () => {
-  assert.equal(runtimeAdapterTerminalFailureStatus("runtime-v1"), "detached");
-  assert.equal(runtimeAdapterTerminalFailureStatus("legacy"), "expired");
-  assert.equal(runtimeAdapterTerminalFailureStatus(null), "expired");
+	assert.equal(runtimeAdapterTerminalFailureStatus("runtime-v1"), "detached");
+	assert.equal(runtimeAdapterTerminalFailureStatus("legacy"), "expired");
+	assert.equal(runtimeAdapterTerminalFailureStatus(null), "expired");
 });
 
 test("runtime adapter provider identities never become legacy lease ids", () => {
-  assert.equal(legacyLeaseIdForAdapter("runtime-v1", "sandbox:provider-owned"), null);
-  assert.equal(legacyLeaseIdForAdapter("runtime-v1", "cloudflare:provider-owned"), null);
-  assert.equal(legacyLeaseIdForAdapter("legacy", "sandbox:legacy-owned"), "sandbox:legacy-owned");
+	assert.equal(legacyLeaseIdForAdapter("runtime-v1", "sandbox:provider-owned"), null);
+	assert.equal(legacyLeaseIdForAdapter("runtime-v1", "cloudflare:provider-owned"), null);
+	assert.equal(legacyLeaseIdForAdapter("legacy", "sandbox:legacy-owned"), "sandbox:legacy-owned");
 });
 
 test("confirmed stop races terminalize only after create ambiguity clears", () => {
-  assert.deepEqual(resolveCreateAfterStopRace(true, "failed"), {
-    status: "stopping",
-    terminalStatus: "failed",
-  });
-  assert.deepEqual(resolveCreateAfterStopRace(false, "failed"), {
-    status: "failed",
-    terminalStatus: null,
-  });
-  assert.deepEqual(resolveCreateAfterStopRace(false, null), {
-    status: "stopped",
-    terminalStatus: null,
-  });
+	assert.deepEqual(resolveCreateAfterStopRace(true, "failed"), {
+		status: "stopping",
+		terminalStatus: "failed",
+	});
+	assert.deepEqual(resolveCreateAfterStopRace(false, "failed"), {
+		status: "failed",
+		terminalStatus: null,
+	});
+	assert.deepEqual(resolveCreateAfterStopRace(false, null), {
+		status: "stopped",
+		terminalStatus: null,
+	});
 });
 
 test("runtime adapter lifecycle cannot escape durable session ownership", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const stopStart = source.indexOf("async function stopSupersededRuntimeAdapterProvision");
-  const stopEnd = source.indexOf("async function resolveInteractiveSessionLineage", stopStart);
-  const stopSource = source.slice(stopStart, stopEnd);
-  const reconcileStart = source.indexOf("async function reconcileExternalInteractiveSession(");
-  const reconcileEnd = source.indexOf("function reconciledInteractiveStatus", reconcileStart);
-  const reconcileSource = source.slice(reconcileStart, reconcileEnd);
-  const releaseStart = source.indexOf("async function releaseFailedRuntimeAdapterProvision");
-  const releaseEnd = source.indexOf("function runtimeAdapterProvisionResult", releaseStart);
-  const releaseSource = source.slice(releaseStart, releaseEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const stopStart = source.indexOf("async function stopSupersededRuntimeAdapterProvision");
+	const stopEnd = source.indexOf("async function resolveInteractiveSessionLineage", stopStart);
+	const stopSource = source.slice(stopStart, stopEnd);
+	const reconcileStart = source.indexOf("async function reconcileExternalInteractiveSession(");
+	const reconcileEnd = source.indexOf("function reconciledInteractiveStatus", reconcileStart);
+	const reconcileSource = source.slice(reconcileStart, reconcileEnd);
+	const releaseStart = source.indexOf("async function releaseFailedRuntimeAdapterProvision");
+	const releaseEnd = source.indexOf("function runtimeAdapterProvisionResult", releaseStart);
+	const releaseSource = source.slice(releaseStart, releaseEnd);
 
-  assert.match(
-    source,
-    /versioned runtime adapter requires a durable interactive session lifecycle/,
-  );
-  assert.match(stopSource, /recordConfirmedRuntimeAdapterRelease/);
-  assert.match(stopSource, /select\(\[[\s\S]*"adapter_create_pending"[\s\S]*"terminal_status"/);
-  assert.match(stopSource, /AND adapter_create_pending = \$\{lifecycle\.adapter_create_pending\}/);
-  assert.match(stopSource, /terminal_status IS NULL/);
-  assert.match(stopSource, /AND updated_at = \$\{lifecycle\.updated_at\}/);
-  assert.match(stopSource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
-  assert.match(stopSource, /env\.DB\.batch/);
-  assert.match(stopSource, /INSERT INTO interactive_session_events/);
-  assert.match(stopSource, /finalizeTerminalInteractiveSession/);
-  assert.match(stopSource, /terminal_finalize_pending: 1/);
-  assert.ok(
-    stopSource.indexOf("clearRuntimeAdapterCreatePending") <
-      stopSource.indexOf("const release = await stopRuntimeAdapterWorkspaceForSession"),
-  );
-  assert.ok(
-    releaseSource.indexOf("stageFailedRuntimeAdapterRelease") <
-      releaseSource.indexOf("stopRuntimeAdapterWorkspace"),
-  );
-  assert.match(releaseSource, /status: "stopping"/);
-  assert.match(releaseSource, /release\.message/);
-  assert.match(releaseSource, /pendingMessage/);
-  assert.match(releaseSource, /terminal_status: "failed"/);
-  assert.match(releaseSource, /adapter_create_pending: 0/);
-  assert.match(reconcileSource, /current\.stoppedAt \?\? now/);
-  assert.match(reconcileSource, /finalizeTerminalInteractiveSession/);
-  assert.match(source, /AND NOT EXISTS \(/);
-  assert.match(source, /archiveInteractiveSessionLogs\(env, id, now, \{ force: true \}\)/);
+	assert.match(
+		source,
+		/versioned runtime adapter requires a durable interactive session lifecycle/,
+	);
+	assert.match(stopSource, /recordConfirmedRuntimeAdapterRelease/);
+	assert.match(stopSource, /select\(\[[\s\S]*"adapter_create_pending"[\s\S]*"terminal_status"/);
+	assert.match(stopSource, /AND adapter_create_pending = \$\{lifecycle\.adapter_create_pending\}/);
+	assert.match(stopSource, /terminal_status IS NULL/);
+	assert.match(stopSource, /AND updated_at = \$\{lifecycle\.updated_at\}/);
+	assert.match(stopSource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
+	assert.match(stopSource, /env\.DB\.batch/);
+	assert.match(stopSource, /INSERT INTO interactive_session_events/);
+	assert.match(stopSource, /finalizeTerminalInteractiveSession/);
+	assert.match(stopSource, /terminal_finalize_pending: 1/);
+	assert.ok(
+		stopSource.indexOf("clearRuntimeAdapterCreatePending") <
+			stopSource.indexOf("const release = await stopRuntimeAdapterWorkspaceForSession"),
+	);
+	assert.ok(
+		releaseSource.indexOf("stageFailedRuntimeAdapterRelease") <
+			releaseSource.indexOf("stopRuntimeAdapterWorkspace"),
+	);
+	assert.match(releaseSource, /status: "stopping"/);
+	assert.match(releaseSource, /release\.message/);
+	assert.match(releaseSource, /pendingMessage/);
+	assert.match(releaseSource, /terminal_status: "failed"/);
+	assert.match(releaseSource, /adapter_create_pending: 0/);
+	assert.match(reconcileSource, /current\.stoppedAt \?\? now/);
+	assert.match(reconcileSource, /finalizeTerminalInteractiveSession/);
+	assert.match(source, /AND NOT EXISTS \(/);
+	assert.match(source, /archiveInteractiveSessionLogs\(env, id, now, \{ force: true \}\)/);
 });
 
 test("confirmed adapter failure release keeps the original failure evidence", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const migration = await readFile(
-    new URL("../migrations/0021_runtime_adapter_hardening.sql", import.meta.url),
-    "utf8",
-  );
-  const releaseStart = source.indexOf("async function recordConfirmedRuntimeAdapterRelease");
-  const releaseEnd = source.indexOf(
-    "async function clearRuntimeAdapterCreatePending",
-    releaseStart,
-  );
-  const releaseSource = source.slice(releaseStart, releaseEnd);
-  const finalizeStart = source.indexOf("async function finalizeTerminalInteractiveSession");
-  const finalizeEnd = source.indexOf("async function archiveInteractiveSessionLogs", finalizeStart);
-  const finalizeSource = source.slice(finalizeStart, finalizeEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const migration = await readFile(
+		new URL("../migrations/0021_runtime_adapter_hardening.sql", import.meta.url),
+		"utf8",
+	);
+	const releaseStart = source.indexOf("async function recordConfirmedRuntimeAdapterRelease");
+	const releaseEnd = source.indexOf(
+		"async function clearRuntimeAdapterCreatePending",
+		releaseStart,
+	);
+	const releaseSource = source.slice(releaseStart, releaseEnd);
+	const finalizeStart = source.indexOf("async function finalizeTerminalInteractiveSession");
+	const finalizeEnd = source.indexOf("async function archiveInteractiveSessionLogs", finalizeStart);
+	const finalizeSource = source.slice(finalizeStart, finalizeEnd);
 
-  assert.match(releaseSource, /"terminal_failure_reason"/);
-  assert.match(releaseSource, /retainedRuntimeAdapterFailureMessage/);
-  assert.match(
-    releaseSource,
-    /terminal_failure_reason: resolved\.status === "failed" \? failureMessage/,
-  );
-  assert.match(releaseSource, /reconcile_error: resolved\.status === "failed" \? failureMessage/);
-  assert.match(releaseSource, /\? failureMessage/);
-  assert.match(finalizeSource, /retainedRuntimeAdapterFailureMessage/);
-  assert.match(finalizeSource, /INSERT INTO interactive_session_events/);
-  assert.match(finalizeSource, /SELECT \$\{id\}, 'system', \$\{message\}/);
-  assert.match(migration, /ADD COLUMN terminal_failure_reason TEXT/);
+	assert.match(releaseSource, /"terminal_failure_reason"/);
+	assert.match(releaseSource, /retainedRuntimeAdapterFailureMessage/);
+	assert.match(
+		releaseSource,
+		/terminal_failure_reason: resolved\.status === "failed" \? failureMessage/,
+	);
+	assert.match(releaseSource, /reconcile_error: resolved\.status === "failed" \? failureMessage/);
+	assert.match(releaseSource, /\? failureMessage/);
+	assert.match(finalizeSource, /retainedRuntimeAdapterFailureMessage/);
+	assert.match(finalizeSource, /INSERT INTO interactive_session_events/);
+	assert.match(finalizeSource, /SELECT \$\{id\}, 'system', \$\{message\}/);
+	assert.match(migration, /ADD COLUMN terminal_failure_reason TEXT/);
 });
 
 test("terminal archive finalization remains durably retryable", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const migration = await readFile(
-    new URL("../migrations/0021_runtime_adapter_hardening.sql", import.meta.url),
-    "utf8",
-  );
-  const appendStart = source.indexOf("async function appendInteractiveSessionEvent");
-  const appendEnd = source.indexOf(
-    "async function finalizeTerminalInteractiveSession",
-    appendStart,
-  );
-  const appendSource = source.slice(appendStart, appendEnd);
-  const finalizeStart = source.indexOf("async function finalizeTerminalInteractiveSession");
-  const finalizeEnd = source.indexOf("async function archiveInteractiveSessionLogs", finalizeStart);
-  const finalizeSource = source.slice(finalizeStart, finalizeEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const migration = await readFile(
+		new URL("../migrations/0021_runtime_adapter_hardening.sql", import.meta.url),
+		"utf8",
+	);
+	const appendStart = source.indexOf("async function appendInteractiveSessionEvent");
+	const appendEnd = source.indexOf(
+		"async function finalizeTerminalInteractiveSession",
+		appendStart,
+	);
+	const appendSource = source.slice(appendStart, appendEnd);
+	const finalizeStart = source.indexOf("async function finalizeTerminalInteractiveSession");
+	const finalizeEnd = source.indexOf("async function archiveInteractiveSessionLogs", finalizeStart);
+	const finalizeSource = source.slice(finalizeStart, finalizeEnd);
 
-  assert.match(source, /expression\("terminal_finalize_pending", "=", 1\)/);
-  assert.match(source, /row\.terminal_finalize_pending === 1/);
-  assert.match(source, /const terminalCleanupDeletePending = 2/);
-  assert.match(source, /completeTerminalFinalization/);
-  assert.match(source, /SET terminal_finalize_pending = 0/);
-  assert.match(source, /interactive_session_log_archives\.events_key IS NULL/);
-  assert.match(source, /interactive_session_log_archives\.transcript_key IS NULL/);
-  assert.match(source, /interactive_session_log_archives\.summary_key IS NULL/);
-  assert.match(source, /archive\.session_updated_at = interactive_sessions\.updated_at/);
-  assert.match(
-    source,
-    /excluded\.session_updated_at > interactive_session_log_archives\.session_updated_at/,
-  );
-  assert.match(
-    source,
-    /excluded\.session_updated_at IS interactive_session_log_archives\.session_updated_at/,
-  );
-  assert.doesNotMatch(
-    source,
-    /session_updated_at IS NOT excluded\.session_updated_at[\s\S]*excluded\.updated_at >=/,
-  );
-  assert.match(appendSource, /executeBatch\(env, \[/);
-  assert.match(appendSource, /insertInto\("interactive_session_events"\)/);
-  assert.match(appendSource, /terminalFinalizationPendingQuery\(db, id\)/);
-  assert.match(finalizeSource, /executeBatch\(env, \[/);
-  assert.match(finalizeSource, /INSERT INTO interactive_session_events/);
-  assert.match(finalizeSource, /terminalFinalizationPendingQuery\(db, id\)/);
-  assert.match(migration, /ADD COLUMN terminal_finalize_pending INTEGER NOT NULL DEFAULT 0/);
-  assert.match(migration, /ADD COLUMN session_updated_at INTEGER/);
-  assert.match(migration, /status IN \('stopped', 'expired', 'failed'\)/);
+	assert.match(source, /expression\("terminal_finalize_pending", "=", 1\)/);
+	assert.match(source, /row\.terminal_finalize_pending === 1/);
+	assert.match(source, /const terminalCleanupDeletePending = 2/);
+	assert.match(source, /completeTerminalFinalization/);
+	assert.match(source, /SET terminal_finalize_pending = 0/);
+	assert.match(source, /interactive_session_log_archives\.events_key IS NULL/);
+	assert.match(source, /interactive_session_log_archives\.transcript_key IS NULL/);
+	assert.match(source, /interactive_session_log_archives\.summary_key IS NULL/);
+	assert.match(source, /archive\.session_updated_at = interactive_sessions\.updated_at/);
+	assert.match(
+		source,
+		/excluded\.session_updated_at > interactive_session_log_archives\.session_updated_at/,
+	);
+	assert.match(
+		source,
+		/excluded\.session_updated_at IS interactive_session_log_archives\.session_updated_at/,
+	);
+	assert.doesNotMatch(
+		source,
+		/session_updated_at IS NOT excluded\.session_updated_at[\s\S]*excluded\.updated_at >=/,
+	);
+	assert.match(appendSource, /executeBatch\(env, \[/);
+	assert.match(appendSource, /insertInto\("interactive_session_events"\)/);
+	assert.match(appendSource, /terminalFinalizationPendingQuery\(db, id\)/);
+	assert.match(finalizeSource, /executeBatch\(env, \[/);
+	assert.match(finalizeSource, /INSERT INTO interactive_session_events/);
+	assert.match(finalizeSource, /terminalFinalizationPendingQuery\(db, id\)/);
+	assert.match(migration, /ADD COLUMN terminal_finalize_pending INTEGER NOT NULL DEFAULT 0/);
+	assert.match(migration, /ADD COLUMN session_updated_at INTEGER/);
+	assert.match(migration, /status IN \('stopped', 'expired', 'failed'\)/);
 });
 
 test("enabling R2 requeues D1-only terminal archives for object backfill", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const backfillStart = source.indexOf("async function requeueTerminalArchiveObjectBackfill");
-  const batchStart = source.indexOf(
-    "async function reconcileExternalInteractiveSessionBatch",
-    backfillStart,
-  );
-  const targetedStart = source.indexOf(
-    "async function reconcileExternalInteractiveSessionById",
-    batchStart,
-  );
-  const reconcileStart = source.indexOf(
-    "async function reconcileExternalInteractiveSession(",
-    targetedStart,
-  );
-  const backfillSource = source.slice(backfillStart, batchStart);
-  const batchSource = source.slice(batchStart, targetedStart);
-  const targetedSource = source.slice(targetedStart, reconcileStart);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const backfillStart = source.indexOf("async function requeueTerminalArchiveObjectBackfill");
+	const batchStart = source.indexOf(
+		"async function reconcileExternalInteractiveSessionBatch",
+		backfillStart,
+	);
+	const targetedStart = source.indexOf(
+		"async function reconcileExternalInteractiveSessionById",
+		batchStart,
+	);
+	const reconcileStart = source.indexOf(
+		"async function reconcileExternalInteractiveSession(",
+		targetedStart,
+	);
+	const backfillSource = source.slice(backfillStart, batchStart);
+	const batchSource = source.slice(batchStart, targetedStart);
+	const targetedSource = source.slice(targetedStart, reconcileStart);
 
-  assert.match(backfillSource, /if \(!env\.SESSION_LOGS\) return/);
-  assert.match(backfillSource, /session\.terminal_finalize_pending = 0/);
-  assert.match(backfillSource, /archive\.events_key IS NULL/);
-  assert.match(backfillSource, /archive\.transcript_key IS NULL/);
-  assert.match(backfillSource, /archive\.summary_key IS NULL/);
-  assert.match(backfillSource, /SET terminal_finalize_pending = 1/);
-  assert.match(backfillSource, /last_reconciled_at = NULL/);
-  assert.match(batchSource, /await requeueTerminalArchiveObjectBackfill\(env\)/);
-  assert.match(targetedSource, /await requeueTerminalArchiveObjectBackfill\(env, id\)/);
+	assert.match(backfillSource, /if \(!env\.SESSION_LOGS\) return/);
+	assert.match(backfillSource, /session\.terminal_finalize_pending = 0/);
+	assert.match(backfillSource, /archive\.events_key IS NULL/);
+	assert.match(backfillSource, /archive\.transcript_key IS NULL/);
+	assert.match(backfillSource, /archive\.summary_key IS NULL/);
+	assert.match(backfillSource, /SET terminal_finalize_pending = 1/);
+	assert.match(backfillSource, /last_reconciled_at = NULL/);
+	assert.match(batchSource, /await requeueTerminalArchiveObjectBackfill\(env\)/);
+	assert.match(targetedSource, /await requeueTerminalArchiveObjectBackfill\(env, id\)/);
 });
 
 test("runtime reconciliation has scheduled and targeted lifecycle clocks", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const config = await readFile(new URL("../wrangler.jsonc", import.meta.url), "utf8");
-  const targetedStart = source.indexOf("async function reconcileExternalInteractiveSessionById");
-  const targetedEnd = source.indexOf(
-    "async function reconcileExternalInteractiveSession(",
-    targetedStart,
-  );
-  const targetedSource = source.slice(targetedStart, targetedEnd);
-  const batchStart = source.indexOf("async function reconcileExternalInteractiveSessionBatch");
-  const batchEnd = source.indexOf("async function reconcileExternalInteractiveSessionById");
-  const batchSource = source.slice(batchStart, batchEnd);
-  const reconcileStart = source.indexOf("async function reconcileExternalInteractiveSession(");
-  const reconcileEnd = source.indexOf("function reconciledInteractiveStatus", reconcileStart);
-  const reconcileSource = source.slice(reconcileStart, reconcileEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const config = await readFile(new URL("../wrangler.jsonc", import.meta.url), "utf8");
+	const targetedStart = source.indexOf("async function reconcileExternalInteractiveSessionById");
+	const targetedEnd = source.indexOf(
+		"async function reconcileExternalInteractiveSession(",
+		targetedStart,
+	);
+	const targetedSource = source.slice(targetedStart, targetedEnd);
+	const batchStart = source.indexOf("async function reconcileExternalInteractiveSessionBatch");
+	const batchEnd = source.indexOf("async function reconcileExternalInteractiveSessionById");
+	const batchSource = source.slice(batchStart, batchEnd);
+	const reconcileStart = source.indexOf("async function reconcileExternalInteractiveSession(");
+	const reconcileEnd = source.indexOf("function reconciledInteractiveStatus", reconcileStart);
+	const reconcileSource = source.slice(reconcileStart, reconcileEnd);
 
-  assert.match(source, /async scheduled\(/);
-  assert.match(source, /context\.waitUntil\(\s*reconcileInteractiveSessionLifecycleBatch/);
-  assert.match(config, /"crons": \["\* \* \* \* \*"\]/);
-  assert.match(batchSource, /expression\("terminal_finalize_pending", "=", 1\)/);
-  assert.match(batchSource, /expression\("adapter", "=", runtimeAdapterName\)/);
-  assert.match(targetedSource, /reconcileCredentialPolicyCleanupBatch\(env, now, id\)/);
-  assert.match(targetedSource, /row\.terminal_finalize_pending === 1/);
-  assert.match(targetedSource, /row\.adapter !== runtimeAdapterName/);
-  assert.match(targetedSource, /runtimeAdapterReconcileIntervalMs/);
-  assert.match(targetedSource, /reconcileExternalInteractiveSession\(env, row, now\)/);
-  assert.ok(
-    reconcileSource.indexOf("if (terminalFinalizationStatus)") <
-      reconcileSource.indexOf("inspectRuntimeAdapterWorkspace"),
-  );
-  assert.match(source, /async function readFreshInteractiveSession/);
-  assert.match(source, /async function interactiveSessionPty[\s\S]*readFreshInteractiveSession/);
-  assert.match(source, /async function interactiveSessionVnc[\s\S]*readFreshInteractiveSession/);
-  assert.match(source, /scheduled interactive session reconciliation failed/);
-  assert.match(
-    source,
-    /async function reconcileInteractiveSessionLifecycleBatch[\s\S]*reconcileCredentialPolicyCleanupBatch[\s\S]*reconcileExternalInteractiveSessionBatch/,
-  );
-  assert.match(reconcileSource, /const claimAt = Math\.max/);
-  assert.match(reconcileSource, /where\("updated_at", "=", row\.updated_at\)/);
-  assert.match(reconcileSource, /const completedAt = Math\.max\(Date\.now\(\), claimAt\)/);
-  assert.match(
-    reconcileSource,
-    /const completionVersion = Math\.max\(completedAt, row\.updated_at \+ 1\)/,
-  );
-  assert.match(reconcileSource, /last_reconciled_at: completedAt/);
-  assert.match(reconcileSource, /updated_at: completionVersion/);
-  assert.match(reconcileSource, /INSERT INTO interactive_session_events/);
-  assert.match(reconcileSource, /env\.DB\.batch/);
-  assert.match(reconcileSource, /reconcile_error: safeProviderError/);
-  assert.doesNotMatch(reconcileSource, /updated_at: now/);
+	assert.match(source, /async scheduled\(/);
+	assert.match(source, /context\.waitUntil\(\s*reconcileInteractiveSessionLifecycleBatch/);
+	assert.match(config, /"crons": \["\* \* \* \* \*"\]/);
+	assert.match(batchSource, /expression\("terminal_finalize_pending", "=", 1\)/);
+	assert.match(batchSource, /expression\("adapter", "=", runtimeAdapterName\)/);
+	assert.match(targetedSource, /reconcileCredentialPolicyCleanupBatch\(env, now, id\)/);
+	assert.match(targetedSource, /row\.terminal_finalize_pending === 1/);
+	assert.match(targetedSource, /row\.adapter !== runtimeAdapterName/);
+	assert.match(targetedSource, /runtimeAdapterReconcileIntervalMs/);
+	assert.match(targetedSource, /reconcileExternalInteractiveSession\(env, row, now\)/);
+	assert.ok(
+		reconcileSource.indexOf("if (terminalFinalizationStatus)") <
+			reconcileSource.indexOf("inspectRuntimeAdapterWorkspace"),
+	);
+	assert.match(source, /async function readFreshInteractiveSession/);
+	assert.match(source, /async function interactiveSessionPty[\s\S]*readFreshInteractiveSession/);
+	assert.match(source, /async function interactiveSessionVnc[\s\S]*readFreshInteractiveSession/);
+	assert.match(source, /scheduled interactive session reconciliation failed/);
+	assert.match(
+		source,
+		/async function reconcileInteractiveSessionLifecycleBatch[\s\S]*reconcileCredentialPolicyCleanupBatch[\s\S]*reconcileExternalInteractiveSessionBatch/,
+	);
+	assert.match(reconcileSource, /const claimAt = Math\.max/);
+	assert.match(reconcileSource, /where\("updated_at", "=", row\.updated_at\)/);
+	assert.match(reconcileSource, /const completedAt = Math\.max\(Date\.now\(\), claimAt\)/);
+	assert.match(
+		reconcileSource,
+		/const completionVersion = Math\.max\(completedAt, row\.updated_at \+ 1\)/,
+	);
+	assert.match(reconcileSource, /last_reconciled_at: completedAt/);
+	assert.match(reconcileSource, /updated_at: completionVersion/);
+	assert.match(reconcileSource, /INSERT INTO interactive_session_events/);
+	assert.match(reconcileSource, /env\.DB\.batch/);
+	assert.match(reconcileSource, /reconcile_error: safeProviderError/);
+	assert.doesNotMatch(reconcileSource, /updated_at: now/);
 });
 
 test("recurring terminal authorization never awaits provider reconciliation", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const grantStart = source.indexOf("function terminalInputGrant");
-  const grantEnd = source.indexOf("function sendTerminalFrame", grantStart);
-  const grantSource = source.slice(grantStart, grantEnd);
-  const controlStart = source.indexOf("async function canControlInteractiveSessionById");
-  const controlEnd = source.indexOf("function canGrantDelegatedControl", controlStart);
-  const controlSource = source.slice(controlStart, controlEnd);
-  const shareStart = source.indexOf("async function isSharedSessionToken");
-  const shareEnd = source.indexOf("function sendTerminalFrame", shareStart);
-  const shareSource = source.slice(shareStart, shareEnd);
-  const bridgeStart = source.indexOf("function bridgeWebSockets");
-  const bridgeEnd = source.indexOf("async function webSocketMessageData", bridgeStart);
-  const bridgeSource = source.slice(bridgeStart, bridgeEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const grantStart = source.indexOf("function terminalInputGrant");
+	const grantEnd = source.indexOf("function sendTerminalFrame", grantStart);
+	const grantSource = source.slice(grantStart, grantEnd);
+	const controlStart = source.indexOf("async function canControlInteractiveSessionById");
+	const controlEnd = source.indexOf("function canGrantDelegatedControl", controlStart);
+	const controlSource = source.slice(controlStart, controlEnd);
+	const shareStart = source.indexOf("async function isSharedSessionToken");
+	const shareEnd = source.indexOf("function sendTerminalFrame", shareStart);
+	const shareSource = source.slice(shareStart, shareEnd);
+	const bridgeStart = source.indexOf("function bridgeWebSockets");
+	const bridgeEnd = source.indexOf("async function webSocketMessageData", bridgeStart);
+	const bridgeSource = source.slice(bridgeStart, bridgeEnd);
 
-  assert.match(grantSource, /cachedBooleanGrant/);
-  assert.match(grantSource, /terminalSubscriptionReconciler/);
-  assert.match(grantSource, /void reconcileExternalInteractiveSessionById/);
-  assert.doesNotMatch(controlSource, /reconcileExternalInteractiveSessionById/);
-  assert.doesNotMatch(controlSource, /reconcileCredentialPolicyCleanupBatch|runtimeAdapterFetch/);
-  assert.doesNotMatch(shareSource, /reconcileExternalInteractiveSessionById/);
-  assert.doesNotMatch(shareSource, /reconcileCredentialPolicyCleanupBatch|runtimeAdapterFetch/);
-  assert.match(bridgeSource, /reconcileSubscription\?\.\(\)/);
-  assert.doesNotMatch(bridgeSource, /await reconcileSubscription/);
+	assert.match(grantSource, /cachedBooleanGrant/);
+	assert.match(grantSource, /terminalSubscriptionReconciler/);
+	assert.match(grantSource, /void reconcileExternalInteractiveSessionById/);
+	assert.doesNotMatch(controlSource, /reconcileExternalInteractiveSessionById/);
+	assert.doesNotMatch(controlSource, /reconcileCredentialPolicyCleanupBatch|runtimeAdapterFetch/);
+	assert.doesNotMatch(shareSource, /reconcileExternalInteractiveSessionById/);
+	assert.doesNotMatch(shareSource, /reconcileCredentialPolicyCleanupBatch|runtimeAdapterFetch/);
+	assert.match(bridgeSource, /reconcileSubscription\?\.\(\)/);
+	assert.doesNotMatch(bridgeSource, /await reconcileSubscription/);
 });
 
 test("public auth deployment metadata excludes runtime routing", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const publicStart = source.indexOf("function publicDeploymentConfig");
-  const publicEnd = source.indexOf("class D1Dialect", publicStart);
-  const publicSource = source.slice(publicStart, publicEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const publicStart = source.indexOf("function publicDeploymentConfig");
+	const publicEnd = source.indexOf("class D1Dialect", publicStart);
+	const publicSource = source.slice(publicStart, publicEnd);
 
-  assert.match(source, /deployment: publicDeploymentConfig\(env\)/);
-  assert.match(publicSource, /label, canonicalUrl, productUrl, sshHost/);
-  assert.doesNotMatch(publicSource, /preferredRepo|defaultRuntime|defaultProfile|RUNTIME_ADAPTER/);
+	assert.match(source, /deployment: publicDeploymentConfig\(env\)/);
+	assert.match(publicSource, /label, canonicalUrl, productUrl, sshHost/);
+	assert.doesNotMatch(publicSource, /preferredRepo|defaultRuntime|defaultProfile|RUNTIME_ADAPTER/);
 });
 
 test("strict session rows and cleanup preserve terminal finalization anchors", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const cleanupStart = source.indexOf("async function cleanupInteractiveSessions");
-  const cleanupEnd = source.indexOf("async function mutateInteractiveSession", cleanupStart);
-  const cleanupSource = source.slice(cleanupStart, cleanupEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const cleanupStart = source.indexOf("async function cleanupInteractiveSessions");
+	const cleanupEnd = source.indexOf("async function mutateInteractiveSession", cleanupStart);
+	const cleanupSource = source.slice(cleanupStart, cleanupEnd);
 
-  assert.match(source, /type InteractiveSessionRow = Selectable<InteractiveSessionTable>/);
-  assert.match(cleanupSource, /where\("terminal_finalize_pending", "=", 0\)/);
-  assert.match(cleanupSource, /deleteFinalizedInteractiveSession\(env, row, archive\)/);
-  assert.match(cleanupSource, /terminalCleanupDeletePending/);
-  assert.match(cleanupSource, /updated_at", "=", row\.updated_at/);
-  assert.match(cleanupSource, /executeBatch\(env, \[/);
-  const archiveIndex = cleanupSource.indexOf('.selectFrom("interactive_session_log_archives")');
-  const deleteIndex = cleanupSource.indexOf("deleteFinalizedInteractiveSession(env, row, archive)");
-  const objectCleanupIndex = cleanupSource.indexOf("cleanupSessionLogArchiveObjects(env, archive)");
-  assert.ok(archiveIndex >= 0 && deleteIndex > archiveIndex && objectCleanupIndex > deleteIndex);
-  assert.match(cleanupSource, /session archive object cleanup leaked/);
-  assert.match(cleanupSource, /events_key IS \$\{archive\?\.events_key/);
-  assert.match(cleanupSource, /transcript_key IS \$\{archive\?\.transcript_key/);
-  assert.match(cleanupSource, /summary_key IS \$\{archive\?\.summary_key/);
-  assert.match(cleanupSource, /deleteFrom\("interactive_session_events"\)/);
-  assert.match(cleanupSource, /deleteFrom\("interactive_session_log_archives"\)/);
-  assert.match(cleanupSource, /deleteFrom\("interactive_sessions"\)/);
-  assert.match(cleanupSource, /FROM interactive_session_credential_policies/);
-  assert.equal(
-    cleanupSource.match(/WITH RECURSIVE active_ancestor\(id\)/g)?.length,
-    2,
-  );
-  assert.match(cleanupSource, /SELECT parent_session_id[\s\S]*FROM interactive_sessions/);
-  assert.match(cleanupSource, /JOIN active_ancestor ON session\.id = active_ancestor\.id/);
-  assert.match(cleanupSource, /WHERE id = interactive_sessions\.id/);
-  assert.match(cleanupSource, /WHERE id = \$\{row\.id\}/);
-  assert.match(source, /terminalFinalizationPendingQuery/);
-  assert.match(source, /executeBatch\(env, \[[\s\S]*interactive_session_events/);
-  assert.match(source, /COALESCE\([\s\S]*event_count[\s\S]*count\(\*\)/);
-  assert.match(source, /events_key IS NOT NULL/);
+	assert.match(source, /type InteractiveSessionRow = Selectable<InteractiveSessionTable>/);
+	assert.match(cleanupSource, /where\("terminal_finalize_pending", "=", 0\)/);
+	assert.match(cleanupSource, /deleteFinalizedInteractiveSession\(env, row, archive\)/);
+	assert.match(cleanupSource, /terminalCleanupDeletePending/);
+	assert.match(cleanupSource, /updated_at", "=", row\.updated_at/);
+	assert.match(cleanupSource, /executeBatch\(env, \[/);
+	const archiveIndex = cleanupSource.indexOf('.selectFrom("interactive_session_log_archives")');
+	const deleteIndex = cleanupSource.indexOf("deleteFinalizedInteractiveSession(env, row, archive)");
+	const objectCleanupIndex = cleanupSource.indexOf("cleanupSessionLogArchiveObjects(env, archive)");
+	assert.ok(archiveIndex >= 0 && deleteIndex > archiveIndex && objectCleanupIndex > deleteIndex);
+	assert.match(cleanupSource, /session archive object cleanup leaked/);
+	assert.match(cleanupSource, /events_key IS \$\{archive\?\.events_key/);
+	assert.match(cleanupSource, /transcript_key IS \$\{archive\?\.transcript_key/);
+	assert.match(cleanupSource, /summary_key IS \$\{archive\?\.summary_key/);
+	assert.match(cleanupSource, /deleteFrom\("interactive_session_events"\)/);
+	assert.match(cleanupSource, /deleteFrom\("interactive_session_log_archives"\)/);
+	assert.match(cleanupSource, /deleteFrom\("interactive_sessions"\)/);
+	assert.match(cleanupSource, /FROM interactive_session_credential_policies/);
+	assert.equal(cleanupSource.match(/WITH RECURSIVE active_ancestor\(id\)/g)?.length, 2);
+	assert.match(cleanupSource, /SELECT parent_session_id[\s\S]*FROM interactive_sessions/);
+	assert.match(cleanupSource, /JOIN active_ancestor ON session\.id = active_ancestor\.id/);
+	assert.match(cleanupSource, /WHERE id = interactive_sessions\.id/);
+	assert.match(cleanupSource, /WHERE id = \$\{row\.id\}/);
+	assert.match(source, /terminalFinalizationPendingQuery/);
+	assert.match(source, /executeBatch\(env, \[[\s\S]*interactive_session_events/);
+	assert.match(source, /COALESCE\([\s\S]*event_count[\s\S]*count\(\*\)/);
+	assert.match(source, /events_key IS NOT NULL/);
 });
 
 test("summary and sharing events invalidate terminal cleanup snapshots", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const cleanupStart = source.indexOf("async function deleteFinalizedInteractiveSession");
-  const cleanupEnd = source.indexOf("async function mutateInteractiveSession", cleanupStart);
-  const cleanupSource = source.slice(cleanupStart, cleanupEnd);
-  const shareStart = source.indexOf('if (action === "share_link")');
-  const shareEnd = source.indexOf('if (action === "enable_multiplayer")', shareStart);
-  const shareSource = source.slice(shareStart, shareEnd);
-  const summaryStart = source.indexOf("async function updateInteractiveSessionSummary");
-  const summaryEnd = source.indexOf("async function readInteractiveSessionLogs", summaryStart);
-  const summarySource = source.slice(summaryStart, summaryEnd);
-  const metadataStart = source.indexOf("async function mutateInteractiveSessionMetadataAtomically");
-  const metadataEnd = source.indexOf("async function mutateInteractiveSession(", metadataStart);
-  const metadataSource = source.slice(metadataStart, metadataEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const cleanupStart = source.indexOf("async function deleteFinalizedInteractiveSession");
+	const cleanupEnd = source.indexOf("async function mutateInteractiveSession", cleanupStart);
+	const cleanupSource = source.slice(cleanupStart, cleanupEnd);
+	const shareStart = source.indexOf('if (action === "share_link")');
+	const shareEnd = source.indexOf('if (action === "enable_multiplayer")', shareStart);
+	const shareSource = source.slice(shareStart, shareEnd);
+	const summaryStart = source.indexOf("async function updateInteractiveSessionSummary");
+	const summaryEnd = source.indexOf("async function readInteractiveSessionLogs", summaryStart);
+	const summarySource = source.slice(summaryStart, summaryEnd);
+	const metadataStart = source.indexOf("async function mutateInteractiveSessionMetadataAtomically");
+	const metadataEnd = source.indexOf("async function mutateInteractiveSession(", metadataStart);
+	const metadataSource = source.slice(metadataStart, metadataEnd);
 
-  assert.match(cleanupSource, /where\("updated_at", "=", row\.updated_at\)/);
-  assert.match(cleanupSource, /terminal_finalize_pending: terminalCleanupDeletePending/);
-  assert.match(cleanupSource, /event_count = \$\{archive\?\.event_count/);
-  assert.match(cleanupSource, /archived_at = \$\{archive\?\.archived_at/);
-  assert.match(cleanupSource, /count\(\*\)/);
-  assert.match(shareSource, /mutateInteractiveSessionMetadataAtomically/);
-  assert.match(summarySource, /mutateInteractiveSessionMetadataAtomically/);
-  assert.match(metadataSource, /INSERT INTO interactive_session_events/);
-  assert.match(metadataSource, /terminal_finalize_pending: sql<number>`CASE/);
-  assert.match(metadataSource, /WHEN status IN \('stopped', 'expired', 'failed'\) THEN 1/);
-  assert.match(metadataSource, /updated_at = \$\{session\.updatedAt\}/);
-  assert.match(metadataSource, /\.returning\("updated_at"\)/);
-  assert.match(metadataSource, /env\.DB\.batch/);
-  assert.ok(metadataSource.indexOf("eventQuery") < metadataSource.indexOf("updateQuery"));
+	assert.match(cleanupSource, /where\("updated_at", "=", row\.updated_at\)/);
+	assert.match(cleanupSource, /terminal_finalize_pending: terminalCleanupDeletePending/);
+	assert.match(cleanupSource, /event_count = \$\{archive\?\.event_count/);
+	assert.match(cleanupSource, /archived_at = \$\{archive\?\.archived_at/);
+	assert.match(cleanupSource, /count\(\*\)/);
+	assert.match(shareSource, /mutateInteractiveSessionMetadataAtomically/);
+	assert.match(summarySource, /mutateInteractiveSessionMetadataAtomically/);
+	assert.match(metadataSource, /INSERT INTO interactive_session_events/);
+	assert.match(metadataSource, /terminal_finalize_pending: sql<number>`CASE/);
+	assert.match(metadataSource, /WHEN status IN \('stopped', 'expired', 'failed'\) THEN 1/);
+	assert.match(metadataSource, /updated_at = \$\{session\.updatedAt\}/);
+	assert.match(metadataSource, /\.returning\("updated_at"\)/);
+	assert.match(metadataSource, /env\.DB\.batch/);
+	assert.ok(metadataSource.indexOf("eventQuery") < metadataSource.indexOf("updateQuery"));
 });
 
 test("development identity login requires an explicit local gate", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const config = await readFile(new URL("../wrangler.jsonc", import.meta.url), "utf8");
-  const loginSource = source.slice(
-    source.indexOf("async function devIdentityLogin"),
-    source.indexOf("async function githubLogin"),
-  );
-  const requireSource = source.slice(
-    source.indexOf("async function requireUser"),
-    source.indexOf("async function optionalUser"),
-  );
-  const authStart = source.indexOf("function authMethods");
-  const authSource = source.slice(authStart, source.indexOf("function actor", authStart));
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const config = await readFile(new URL("../wrangler.jsonc", import.meta.url), "utf8");
+	const loginSource = source.slice(
+		source.indexOf("async function devIdentityLogin"),
+		source.indexOf("async function githubLogin"),
+	);
+	const requireSource = source.slice(
+		source.indexOf("async function requireUser"),
+		source.indexOf("async function optionalUser"),
+	);
+	const authStart = source.indexOf("function authMethods");
+	const authSource = source.slice(authStart, source.indexOf("function actor", authStart));
 
-  assert.match(source, /function devIdentityEnabled\(env: RuntimeEnv, request: Request\)/);
-  assert.match(loginSource, /devIdentityEnabled\(env, request\)/);
-  assert.match(requireSource, /devIdentityEnabled\(env, request\)/);
-  assert.match(requireSource, /deleteFrom\("sessions"\)/);
-  assert.match(authSource, /devIdentityEnabled\(env, request\)/);
-  assert.match(
-    authSource,
-    /developmentIdentityEnabled\(env\.CRABFLEET_DEV_LOGIN_ENABLED, request\.url\)/,
-  );
-  assert.match(config, /"CRABFLEET_DEV_LOGIN_ENABLED": "false"/);
+	assert.match(source, /function devIdentityEnabled\(env: RuntimeEnv, request: Request\)/);
+	assert.match(loginSource, /devIdentityEnabled\(env, request\)/);
+	assert.match(requireSource, /devIdentityEnabled\(env, request\)/);
+	assert.match(requireSource, /deleteFrom\("sessions"\)/);
+	assert.match(authSource, /devIdentityEnabled\(env, request\)/);
+	assert.match(
+		authSource,
+		/developmentIdentityEnabled\(env\.CRABFLEET_DEV_LOGIN_ENABLED, request\.url\)/,
+	);
+	assert.match(config, /"CRABFLEET_DEV_LOGIN_ENABLED": "false"/);
 });
 
 test("runtime adapter credentials are preflighted before session allocation", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const createStart = source.indexOf("async function createInteractiveSessionFromInput");
-  const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
-  const createSource = source.slice(createStart, createEnd);
-  const preflightStart = source.indexOf("function requireRuntimeAdapterCreatePreflight");
-  const preflightEnd = source.indexOf(
-    "async function stopSupersededRuntimeAdapterProvision",
-    preflightStart,
-  );
-  const preflightSource = source.slice(preflightStart, preflightEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
+	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
+	const createSource = source.slice(createStart, createEnd);
+	const preflightStart = source.indexOf("function requireRuntimeAdapterCreatePreflight");
+	const preflightEnd = source.indexOf(
+		"async function stopSupersededRuntimeAdapterProvision",
+		preflightStart,
+	);
+	const preflightSource = source.slice(preflightStart, preflightEnd);
 
-  assert.ok(
-    createSource.indexOf("requireRuntimeAdapterCreatePreflight(env, runtime, profile)") <
-      createSource.indexOf("nextInteractiveSessionId(env)"),
-  );
-  assert.ok(
-    createSource.indexOf("requireRuntimeAdapterCreatePreflight(env, runtime, profile)") <
-      createSource.indexOf('.insertInto("interactive_sessions")'),
-  );
-  assert.match(preflightSource, /runtime === "container" && env\.SANDBOX/);
-  assert.match(preflightSource, /runtimeAdapterToken\(env\)/);
-  assert.match(preflightSource, /configuredRuntimeAdapterControlPlane\(env, profile\)/);
-  assert.match(preflightSource, /runtimeAdapterControlPlaneForProfile/);
-  assert.match(preflightSource, /runtime adapter token is not configured/);
+	assert.ok(
+		createSource.indexOf("requireRuntimeAdapterCreatePreflight(env, runtime, profile)") <
+			createSource.indexOf("nextInteractiveSessionId(env)"),
+	);
+	assert.ok(
+		createSource.indexOf("requireRuntimeAdapterCreatePreflight(env, runtime, profile)") <
+			createSource.indexOf('.insertInto("interactive_sessions")'),
+	);
+	assert.match(preflightSource, /runtime === "container" && env\.SANDBOX/);
+	assert.match(preflightSource, /runtimeAdapterToken\(env\)/);
+	assert.match(preflightSource, /configuredRuntimeAdapterControlPlane\(env, profile\)/);
+	assert.match(preflightSource, /runtimeAdapterControlPlaneForProfile/);
+	assert.match(preflightSource, /runtime adapter token is not configured/);
 });
 
 test("runtime adapter operations stay bound to the registered control plane", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const migration = await readFile(
-    new URL("../migrations/0020_runtime_adapter_lifecycle.sql", import.meta.url),
-    "utf8",
-  );
-  const bindingStart = source.indexOf("function configuredRuntimeAdapterControlPlane");
-  const bindingEnd = source.indexOf(
-    "async function stopSupersededRuntimeAdapterProvision",
-    bindingStart,
-  );
-  const bindingSource = source.slice(bindingStart, bindingEnd);
-  const provisionStart = source.indexOf("async function provisionWithRuntimeAdapter");
-  const provisionEnd = source.indexOf("function persistedRuntimeAdapterSeconds", provisionStart);
-  const provisionSource = source.slice(provisionStart, provisionEnd);
-  const inspectStart = source.indexOf("async function inspectRuntimeAdapterWorkspace");
-  const inspectEnd = source.indexOf(
-    "async function reconcileStoppingRuntimeAdapterWorkspace",
-    inspectStart,
-  );
-  const inspectSource = source.slice(inspectStart, inspectEnd);
-  const stopStart = source.indexOf("async function stopRuntimeAdapterWorkspace(");
-  const stopEnd = source.indexOf("async function runtimeAdapterFetch", stopStart);
-  const stopSource = source.slice(stopStart, stopEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const migration = await readFile(
+		new URL("../migrations/0020_runtime_adapter_lifecycle.sql", import.meta.url),
+		"utf8",
+	);
+	const bindingStart = source.indexOf("function configuredRuntimeAdapterControlPlane");
+	const bindingEnd = source.indexOf(
+		"async function stopSupersededRuntimeAdapterProvision",
+		bindingStart,
+	);
+	const bindingSource = source.slice(bindingStart, bindingEnd);
+	const provisionStart = source.indexOf("async function provisionWithRuntimeAdapter");
+	const provisionEnd = source.indexOf("function persistedRuntimeAdapterSeconds", provisionStart);
+	const provisionSource = source.slice(provisionStart, provisionEnd);
+	const inspectStart = source.indexOf("async function inspectRuntimeAdapterWorkspace");
+	const inspectEnd = source.indexOf(
+		"async function reconcileStoppingRuntimeAdapterWorkspace",
+		inspectStart,
+	);
+	const inspectSource = source.slice(inspectStart, inspectEnd);
+	const stopStart = source.indexOf("async function stopRuntimeAdapterWorkspace(");
+	const stopEnd = source.indexOf("async function runtimeAdapterFetch", stopStart);
+	const stopSource = source.slice(stopStart, stopEnd);
 
-  assert.match(migration, /ADD COLUMN adapter_control_plane TEXT/);
-  assert.match(source, /adapter_control_plane: adapterControlPlane/);
-  assert.match(bindingSource, /configuredControlPlane !== registeredControlPlane/);
-  assert.match(bindingSource, /configuredRuntimeAdapterControlPlane\(env, profile\)/);
-  assert.match(bindingSource, /control plane differs from workspace registration/);
-  assert.match(provisionSource, /requireRegisteredRuntimeAdapterControlPlane/);
-  assert.match(provisionSource, /runtimeAdapterCollectionUrl\(baseUrl\)/);
-  assert.match(inspectSource, /session\.adapter_control_plane/);
-  assert.match(inspectSource, /runtimeAdapterWorkspaceUrl\(controlPlane, adapterWorkspaceId\)/);
-  assert.match(stopSource, /requireRegisteredRuntimeAdapterControlPlane/);
-  assert.match(stopSource, /runtimeAdapterWorkspaceUrl\(controlPlane, adapterWorkspaceId\)/);
-  assert.doesNotMatch(
-    inspectSource,
-    /runtimeAdapterWorkspaceUrl\(env\.CRABBOX_RUNTIME_ADAPTER_URL/,
-  );
-  assert.doesNotMatch(stopSource, /response\.status === 404[\s\S]*CRABBOX_RUNTIME_ADAPTER_URL/);
+	assert.match(migration, /ADD COLUMN adapter_control_plane TEXT/);
+	assert.match(source, /adapter_control_plane: adapterControlPlane/);
+	assert.match(bindingSource, /configuredControlPlane !== registeredControlPlane/);
+	assert.match(bindingSource, /configuredRuntimeAdapterControlPlane\(env, profile\)/);
+	assert.match(bindingSource, /control plane differs from workspace registration/);
+	assert.match(provisionSource, /requireRegisteredRuntimeAdapterControlPlane/);
+	assert.match(provisionSource, /runtimeAdapterCollectionUrl\(baseUrl\)/);
+	assert.match(inspectSource, /session\.adapter_control_plane/);
+	assert.match(inspectSource, /runtimeAdapterWorkspaceUrl\(controlPlane, adapterWorkspaceId\)/);
+	assert.match(stopSource, /requireRegisteredRuntimeAdapterControlPlane/);
+	assert.match(stopSource, /runtimeAdapterWorkspaceUrl\(controlPlane, adapterWorkspaceId\)/);
+	assert.doesNotMatch(
+		inspectSource,
+		/runtimeAdapterWorkspaceUrl\(env\.CRABBOX_RUNTIME_ADAPTER_URL/,
+	);
+	assert.doesNotMatch(stopSource, /response\.status === 404[\s\S]*CRABBOX_RUNTIME_ADAPTER_URL/);
 });
 
 test("runtime adapter requests reject redirects with edge-supported fetch semantics", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const fetchStart = source.indexOf("async function runtimeAdapterFetch");
-  const fetchEnd = source.indexOf("async function readRuntimeAdapterResponseBody", fetchStart);
-  const fetchSource = source.slice(fetchStart, fetchEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const fetchStart = source.indexOf("async function runtimeAdapterFetch");
+	const fetchEnd = source.indexOf("async function readRuntimeAdapterResponseBody", fetchStart);
+	const fetchSource = source.slice(fetchStart, fetchEnd);
 
-  assert.match(fetchSource, /redirect: "manual"/);
-  assert.match(fetchSource, /response\.status >= 300 && response\.status < 400/);
-  assert.match(fetchSource, /runtime adapter redirect refused/);
-  assert.doesNotMatch(fetchSource, /redirect: "error"/);
+	assert.match(fetchSource, /redirect: "manual"/);
+	assert.match(fetchSource, /response\.status >= 300 && response\.status < 400/);
+	assert.match(fetchSource, /runtime adapter redirect refused/);
+	assert.doesNotMatch(fetchSource, /redirect: "error"/);
 });
 
 test("pending runtime adapter creates replay before any inspect", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const inspectStart = source.indexOf("async function inspectRuntimeAdapterWorkspace");
-  const inspectEnd = source.indexOf(
-    "async function reconcileStoppingRuntimeAdapterWorkspace",
-    inspectStart,
-  );
-  const inspectSource = source.slice(inspectStart, inspectEnd);
-  const provisionStart = source.indexOf("async function provisionWithRuntimeAdapter");
-  const provisionEnd = source.indexOf("function persistedRuntimeAdapterSeconds", provisionStart);
-  const provisionSource = source.slice(provisionStart, provisionEnd);
-  const replayIndex = inspectSource.indexOf(
-    "shouldReplayRuntimeAdapterCreate(session.status, session.adapter_create_pending === 1)",
-  );
-  const inspectFetchIndex = inspectSource.indexOf("const response = await runtimeAdapterFetch(");
-  const missingIndex = inspectSource.indexOf("if (response.status === 404)");
-  const missingSource = inspectSource.slice(missingIndex);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const inspectStart = source.indexOf("async function inspectRuntimeAdapterWorkspace");
+	const inspectEnd = source.indexOf(
+		"async function reconcileStoppingRuntimeAdapterWorkspace",
+		inspectStart,
+	);
+	const inspectSource = source.slice(inspectStart, inspectEnd);
+	const provisionStart = source.indexOf("async function provisionWithRuntimeAdapter");
+	const provisionEnd = source.indexOf("function persistedRuntimeAdapterSeconds", provisionStart);
+	const provisionSource = source.slice(provisionStart, provisionEnd);
+	const replayIndex = inspectSource.indexOf(
+		"shouldReplayRuntimeAdapterCreate(session.status, session.adapter_create_pending === 1)",
+	);
+	const inspectFetchIndex = inspectSource.indexOf("const response = await runtimeAdapterFetch(");
+	const missingIndex = inspectSource.indexOf("if (response.status === 404)");
+	const missingSource = inspectSource.slice(missingIndex);
 
-  assert.ok(replayIndex >= 0);
-  assert.ok(inspectFetchIndex >= 0);
-  assert.ok(replayIndex < inspectFetchIndex);
-  assert.match(inspectSource, /runtimeAdapterReplayRequest\(runtimeAdapterRecord\(session\)\)/);
-  assert.ok(missingIndex >= 0);
-  assert.doesNotMatch(missingSource, /provisionWithRuntimeAdapter/);
-  assert.match(provisionSource, /const replayingPendingCreate = reconciliationOwner !== undefined/);
-  assert.match(
-    provisionSource,
-    /!replayingPendingCreate && definitiveRuntimeAdapterCreateFailure\(response\.status\)/,
-  );
-  assert.match(provisionSource, /runtime adapter create replay blocked/);
+	assert.ok(replayIndex >= 0);
+	assert.ok(inspectFetchIndex >= 0);
+	assert.ok(replayIndex < inspectFetchIndex);
+	assert.match(inspectSource, /runtimeAdapterReplayRequest\(runtimeAdapterRecord\(session\)\)/);
+	assert.ok(missingIndex >= 0);
+	assert.doesNotMatch(missingSource, /provisionWithRuntimeAdapter/);
+	assert.match(provisionSource, /const replayingPendingCreate = reconciliationOwner !== undefined/);
+	assert.match(
+		provisionSource,
+		/!replayingPendingCreate && definitiveRuntimeAdapterCreateFailure\(response\.status\)/,
+	);
+	assert.match(provisionSource, /runtime adapter create replay blocked/);
 });
 
 test("stopping create replay owns the exact persisted lifecycle", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const reconcileStart = source.indexOf("async function reconcileStoppingRuntimeAdapterWorkspace");
-  const replayStart = source.indexOf("async function replayStoppingRuntimeAdapterCreate");
-  const replayEnd = source.indexOf("async function stopRuntimeAdapterWorkspace(", replayStart);
-  const reconcileSource = source.slice(reconcileStart, replayStart);
-  const replaySource = source.slice(replayStart, replayEnd);
-  const unresolvedIndex = reconcileSource.indexOf("if (!replay.resolved)");
-  const deleteIndex = reconcileSource.indexOf("stopRuntimeAdapterWorkspace(");
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const reconcileStart = source.indexOf("async function reconcileStoppingRuntimeAdapterWorkspace");
+	const replayStart = source.indexOf("async function replayStoppingRuntimeAdapterCreate");
+	const replayEnd = source.indexOf("async function stopRuntimeAdapterWorkspace(", replayStart);
+	const reconcileSource = source.slice(reconcileStart, replayStart);
+	const replaySource = source.slice(replayStart, replayEnd);
+	const unresolvedIndex = reconcileSource.indexOf("if (!replay.resolved)");
+	const deleteIndex = reconcileSource.indexOf("stopRuntimeAdapterWorkspace(");
 
-  assert.match(reconcileSource, /replayStoppingRuntimeAdapterCreate\([\s\S]*env,[\s\S]*session,/);
-  assert.doesNotMatch(reconcileSource, /provisionWithRuntimeAdapter/);
-  assert.ok(unresolvedIndex >= 0);
-  assert.ok(deleteIndex >= 0);
-  assert.ok(unresolvedIndex < deleteIndex);
-  assert.match(reconcileSource, /reconcileError: replay\.message/);
-  assert.match(reconcileSource, /createPending: true/);
-  assert.match(replaySource, /AND adapter_control_plane = \$\{controlPlane\}/);
-  assert.match(replaySource, /AND adapter_create_payload_json = \$\{createPayloadJson\}/);
-  assert.match(replaySource, /AND adapter_create_pending = 1/);
-  assert.match(replaySource, /AND status = 'stopping'/);
-  assert.match(replaySource, /AND updated_at = \$\{session\.updated_at\}/);
-  assert.match(replaySource, /AND last_reconciled_at = \$\{reconciliationClaimAt\}/);
-  assert.match(replaySource, /runtimeAdapterCollectionUrl\(controlPlane\)/);
-  assert.match(replaySource, /idempotency-key": adapterWorkspaceId/);
-  assert.match(replaySource, /adapter_create_pending: 0/);
-  assert.match(replaySource, /reconcile_error: message/);
-  assert.match(replaySource, /INSERT INTO interactive_session_events/);
-  assert.match(replaySource, /env\.DB\.batch/);
+	assert.match(reconcileSource, /replayStoppingRuntimeAdapterCreate\([\s\S]*env,[\s\S]*session,/);
+	assert.doesNotMatch(reconcileSource, /provisionWithRuntimeAdapter/);
+	assert.ok(unresolvedIndex >= 0);
+	assert.ok(deleteIndex >= 0);
+	assert.ok(unresolvedIndex < deleteIndex);
+	assert.match(reconcileSource, /reconcileError: replay\.message/);
+	assert.match(reconcileSource, /createPending: true/);
+	assert.match(replaySource, /AND adapter_control_plane = \$\{controlPlane\}/);
+	assert.match(replaySource, /AND adapter_create_payload_json = \$\{createPayloadJson\}/);
+	assert.match(replaySource, /AND adapter_create_pending = 1/);
+	assert.match(replaySource, /AND status = 'stopping'/);
+	assert.match(replaySource, /AND updated_at = \$\{session\.updated_at\}/);
+	assert.match(replaySource, /AND last_reconciled_at = \$\{reconciliationClaimAt\}/);
+	assert.match(replaySource, /runtimeAdapterCollectionUrl\(controlPlane\)/);
+	assert.match(replaySource, /idempotency-key": adapterWorkspaceId/);
+	assert.match(replaySource, /adapter_create_pending: 0/);
+	assert.match(replaySource, /reconcile_error: message/);
+	assert.match(replaySource, /INSERT INTO interactive_session_events/);
+	assert.match(replaySource, /env\.DB\.batch/);
 });
 
 test("every session-bound adapter delete waits for create ambiguity to clear", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const releaseStart = source.indexOf("async function stopRuntimeAdapterWorkspaceForSession");
-  const releaseEnd = source.indexOf("async function runtimeAdapterFetch", releaseStart);
-  const releaseSource = source.slice(releaseStart, releaseEnd);
-  const pendingGateIndex = releaseSource.indexOf("if (registration?.adapter_create_pending !== 0)");
-  const providerDeleteIndex = releaseSource.indexOf("return stopRuntimeAdapterWorkspace(");
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const releaseStart = source.indexOf("async function stopRuntimeAdapterWorkspaceForSession");
+	const releaseEnd = source.indexOf("async function runtimeAdapterFetch", releaseStart);
+	const releaseSource = source.slice(releaseStart, releaseEnd);
+	const pendingGateIndex = releaseSource.indexOf("if (registration?.adapter_create_pending !== 0)");
+	const providerDeleteIndex = releaseSource.indexOf("return stopRuntimeAdapterWorkspace(");
 
-  assert.match(
-    releaseSource,
-    /select\(\["adapter_control_plane", "adapter_create_pending", "profile"\]\)/,
-  );
-  assert.ok(pendingGateIndex >= 0);
-  assert.ok(providerDeleteIndex >= 0);
-  assert.ok(pendingGateIndex < providerDeleteIndex);
-  assert.match(releaseSource, /status: "stopping"/);
-  assert.match(releaseSource, /runtime adapter stop waiting for create resolution/);
+	assert.match(
+		releaseSource,
+		/select\(\["adapter_control_plane", "adapter_create_pending", "profile"\]\)/,
+	);
+	assert.ok(pendingGateIndex >= 0);
+	assert.ok(providerDeleteIndex >= 0);
+	assert.ok(pendingGateIndex < providerDeleteIndex);
+	assert.match(releaseSource, /status: "stopping"/);
+	assert.match(releaseSource, /runtime adapter stop waiting for create resolution/);
 });
 
 test("stateless Sandbox provision hook acquires durable standalone ownership", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const migration = await readFile(
-    new URL("../migrations/0022_credential_policy_cleanup.sql", import.meta.url),
-    "utf8",
-  );
-  const expiryMigration = await readFile(
-    new URL("../migrations/0023_standalone_sandbox_expiry.sql", import.meta.url),
-    "utf8",
-  );
-  const endpointStart = source.indexOf("async function provisionInteractiveEndpoint");
-  const endpointEnd = source.indexOf("function isBuiltInInteractiveProvisionUrl", endpointStart);
-  const endpointSource = source.slice(endpointStart, endpointEnd);
-  const ownershipStart = source.indexOf("function sandboxCredentialPolicyOwnerCondition");
-  const ownershipEnd = source.indexOf(
-    "function sandboxCredentialPolicyRegistrationQueries",
-    ownershipStart,
-  );
-  const ownershipSource = source.slice(ownershipStart, ownershipEnd);
-  const managedStart = source.indexOf("async function provisionManagedSandboxEndpoint");
-  const managedEnd = source.indexOf("async function provisionStandaloneSandbox", managedStart);
-  const managedSource = source.slice(managedStart, managedEnd);
-  const managedCommitSource = managedSource.slice(managedSource.indexOf("const commitRevision"));
-  const ptyStart = source.indexOf("async function standaloneSandboxPty");
-  const ptyEnd = source.indexOf("function isBuiltInInteractiveProvisionUrl", ptyStart);
-  const ptySource = source.slice(ptyStart, ptyEnd);
-  const sandboxStart = source.indexOf("async function provisionWithSandbox");
-  const sandboxEnd = source.indexOf("function sandboxManagedOwnershipCondition", sandboxStart);
-  const sandboxSource = source.slice(sandboxStart, sandboxEnd);
-  const activationSource = endpointSource.slice(endpointSource.indexOf("const activationVersion"));
-  const stopStart = source.indexOf("async function stopStandaloneSandboxProvision");
-  const stopEnd = source.indexOf("function standaloneSandboxAttachUrl", stopStart);
-  const stopSource = source.slice(stopStart, stopEnd);
-  const expiryStart = source.indexOf("async function expireStandaloneSandboxProvisions");
-  const expirySource = source.slice(expiryStart, stopStart);
-  const standaloneCleanupStart = source.indexOf(
-    "async function completeStandaloneSandboxProvisionCleanup",
-  );
-  const standaloneCleanupEnd = source.indexOf(
-    "async function completeCredentialPolicyCleanupSession",
-    standaloneCleanupStart,
-  );
-  const standaloneCleanupSource = source.slice(standaloneCleanupStart, standaloneCleanupEnd);
-  const strictAuthStart = source.indexOf("function authorizeProvisionBearerToken");
-  const strictAuthEnd = source.indexOf("function sandboxProvisionPreflightError", strictAuthStart);
-  const strictAuthSource = source.slice(strictAuthStart, strictAuthEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const migration = await readFile(
+		new URL("../migrations/0022_credential_policy_cleanup.sql", import.meta.url),
+		"utf8",
+	);
+	const expiryMigration = await readFile(
+		new URL("../migrations/0023_standalone_sandbox_expiry.sql", import.meta.url),
+		"utf8",
+	);
+	const endpointStart = source.indexOf("async function provisionInteractiveEndpoint");
+	const endpointEnd = source.indexOf("function isBuiltInInteractiveProvisionUrl", endpointStart);
+	const endpointSource = source.slice(endpointStart, endpointEnd);
+	const ownershipStart = source.indexOf("function sandboxCredentialPolicyOwnerCondition");
+	const ownershipEnd = source.indexOf(
+		"function sandboxCredentialPolicyRegistrationQueries",
+		ownershipStart,
+	);
+	const ownershipSource = source.slice(ownershipStart, ownershipEnd);
+	const managedStart = source.indexOf("async function provisionManagedSandboxEndpoint");
+	const managedEnd = source.indexOf("async function provisionStandaloneSandbox", managedStart);
+	const managedSource = source.slice(managedStart, managedEnd);
+	const managedCommitSource = managedSource.slice(managedSource.indexOf("const commitRevision"));
+	const ptyStart = source.indexOf("async function standaloneSandboxPty");
+	const ptyEnd = source.indexOf("function isBuiltInInteractiveProvisionUrl", ptyStart);
+	const ptySource = source.slice(ptyStart, ptyEnd);
+	const sandboxStart = source.indexOf("async function provisionWithSandbox");
+	const sandboxEnd = source.indexOf("function sandboxManagedOwnershipCondition", sandboxStart);
+	const sandboxSource = source.slice(sandboxStart, sandboxEnd);
+	const activationSource = endpointSource.slice(endpointSource.indexOf("const activationVersion"));
+	const stopStart = source.indexOf("async function stopStandaloneSandboxProvision");
+	const stopEnd = source.indexOf("function standaloneSandboxAttachUrl", stopStart);
+	const stopSource = source.slice(stopStart, stopEnd);
+	const expiryStart = source.indexOf("async function expireStandaloneSandboxProvisions");
+	const expirySource = source.slice(expiryStart, stopStart);
+	const standaloneCleanupStart = source.indexOf(
+		"async function completeStandaloneSandboxProvisionCleanup",
+	);
+	const standaloneCleanupEnd = source.indexOf(
+		"async function completeCredentialPolicyCleanupSession",
+		standaloneCleanupStart,
+	);
+	const standaloneCleanupSource = source.slice(standaloneCleanupStart, standaloneCleanupEnd);
+	const strictAuthStart = source.indexOf("function authorizeProvisionBearerToken");
+	const strictAuthEnd = source.indexOf("function sandboxProvisionPreflightError", strictAuthStart);
+	const strictAuthSource = source.slice(strictAuthStart, strictAuthEnd);
 
-  assert.match(endpointSource, /selectFrom\("interactive_sessions"\)/);
-  assert.match(endpointSource, /if \(managed\)/);
-  assert.ok(
-    endpointSource.indexOf("if (managed)") <
-      endpointSource.indexOf("return provisionStandaloneSandbox(env, payload)"),
-  );
-  assert.match(endpointSource, /provisionManagedSandboxEndpoint\(env, payload, managed\)/);
-  assert.match(endpointSource, /managedInteractiveSessionId\(payload\.id\)/);
-  assert.match(endpointSource, /managed session namespace/);
-  assert.match(endpointSource, /INSERT INTO standalone_sandbox_provisions/);
-  assert.match(endpointSource, /ownership_claim_expires_at/);
-  assert.match(endpointSource, /\$\{sandboxLeaseId\(lease\)\}/);
-  assert.match(endpointSource, /lease_id = excluded\.lease_id/);
-  assert.match(endpointSource, /provisionWithSandbox\([\s\S]*fence/);
-  assert.match(endpointSource, /state: "active"/);
-  assert.match(ownershipSource, /FROM standalone_sandbox_provisions AS owner/);
-  assert.match(ownershipSource, /owner\.ownership_claim = \$\{ownershipFence\.claim\}/);
-  assert.match(managedSource, /managedSandboxProvisionPayloadMatches/);
-  assert.ok(
-    managedSource.indexOf("managedSandboxProvisionPayloadMatches") <
-      managedSource.indexOf("newSandboxLease(payload.id)"),
-  );
-  assert.match(managedSource, /where\("updated_at", "=", session\.updated_at\)/);
-  assert.match(managedSource, /sandbox_refresh_claim: fence\.claim/);
-  assert.match(managedSource, /const agentToken = newAgentToken\(\)/);
-  assert.match(managedSource, /const agentTokenHash = await sha256\(agentToken\)/);
-  assert.match(managedSource, /agent_token_hash: agentTokenHash/);
-  assert.match(managedSource, /agent_token_hash IS \$\{session\.agent_token_hash\}/);
-  assert.match(managedSource, /provisionWithSandbox\(env, payload, agentToken, lease, fence\)/);
-  assert.ok(
-    managedSource.indexOf("sandboxProvisionPreflightError(env, payload)") <
-      managedSource.indexOf("const agentToken = newAgentToken()"),
-  );
-  assert.match(managedSource, /stageFailedManagedSandboxProvision/);
-  assert.match(managedSource, /where\("agent_token_hash", "=", agentTokenHash\)/);
-  assert.doesNotMatch(managedSource, /provisionWithSandbox\(env, payload, undefined/);
-  assert.match(managedSource, /executeBatch\(env, commitQueries\)/);
-  assert.match(managedCommitSource, /MAX\(updated_at \+ 1, \$\{commitRevision\}\)/);
-  assert.doesNotMatch(managedCommitSource, /where\("updated_at", "=", now\)/);
-  assert.match(managedCommitSource, /lease_id IS \$\{fence\.refreshLeaseId\}/);
-  assert.match(managedCommitSource, /sandbox_refresh_claim", "=", fence\.claim/);
-  assert.match(managedCommitSource, /sandbox_refresh_claim_expires_at", "=", fence\.expiresAt/);
-  assert.match(managedSource, /previousSandboxId/);
-  assert.match(managedSource, /state: "cleanup_pending"/);
-  assert.match(managedSource, /claimed\.numUpdatedRows/);
-  assert.match(ptySource, /authorizeProvisionEndpoint\(request, env\)/);
-  assert.match(ptySource, /standalone_sandbox_provisions/);
-  assert.match(ptySource, /where\("state", "=", "active"\)/);
-  assert.match(ptySource, /owner\.expires_at <= Date\.now\(\)/);
-  assert.match(ptySource, /stageStandaloneSandboxProvisionCleanup/);
-  assert.match(ptySource, /activeSandboxCredentialPolicyGeneration/);
-  assert.match(ptySource, /terminalHeaders\.delete\("authorization"\)/);
-  assert.match(ptySource, /const pair = new WebSocketPair\(\)/);
-  assert.match(ptySource, /response\.webSocket\.accept\(\)/);
-  assert.match(ptySource, /bridgeWebSockets\(/);
-  assert.match(ptySource, /standaloneSandboxTerminalGrant/);
-  assert.match(ptySource, /cachedBooleanGrant/);
-  assert.match(ptySource, /where\("request_hash", "=", ownership\.requestHash\)/);
-  assert.match(ptySource, /where\("expires_at", ">", now\)/);
-  assert.match(ptySource, /where\("updated_at", "=", ownership\.updatedAt\)/);
-  assert.match(ptySource, /activeSandboxCredentialPolicyCondition/);
-  assert.match(ptySource, /return new Response\(null, \{ status: 101, webSocket: client \}\)/);
-  assert.doesNotMatch(ptySource, /return response;/);
-  assert.match(standaloneCleanupSource, /deleteSession\(lease\.terminalSessionId\)/);
-  assert.match(standaloneCleanupSource, /isSandboxSessionAlreadyGone/);
-  assert.ok(
-    standaloneCleanupSource.indexOf("deleteSession(lease.terminalSessionId)") <
-      standaloneCleanupSource.indexOf('.deleteFrom("standalone_sandbox_provisions")'),
-  );
-  assert.match(standaloneCleanupSource, /where\("updated_at", "=", owner\.updated_at\)/);
-  assert.match(sandboxSource, /standaloneSandboxAttachUrl\(env, session\.id\)/);
-  assert.match(
-    endpointSource,
-    /const activationVersion = Math\.max\(Date\.now\(\), finishedAt \+ 1\)/,
-  );
-  assert.match(activationSource, /executeBatch\(env, \[/);
-  assert.ok(
-    activationSource.indexOf('.updateTable("interactive_session_credential_policies")') <
-      activationSource.indexOf('.updateTable("standalone_sandbox_provisions")'),
-  );
-  assert.match(activationSource, /set\(\{ updated_at: activationVersion \}\)/);
-  assert.match(
-    endpointSource,
-    /activeSandboxCredentialPolicyCondition\([\s\S]*policyGeneration,[\s\S]*activationVersion/,
-  );
-  assert.match(migration, /CREATE TABLE IF NOT EXISTS standalone_sandbox_provisions/);
-  assert.match(migration, /request_hash TEXT NOT NULL/);
-  assert.match(migration, /sandbox_id TEXT NOT NULL UNIQUE/);
-  assert.match(expiryMigration, /ADD COLUMN expires_at INTEGER/);
-  assert.match(expiryMigration, /substr\(lower\(id\), 4\) NOT GLOB '\*\[\^0-9\]\*'/);
-  assert.match(expiryMigration, /idx_standalone_sandbox_provision_expiry/);
-  assert.match(expirySource, /state = 'active'/);
-  assert.match(expirySource, /expires_at <= \$\{now\}/);
-  assert.match(expirySource, /substr\(lower\(id\), 4\) NOT GLOB '\*\[\^0-9\]\*'/);
-  assert.match(stopSource, /authorizeProvisionBearerToken\(request, env\)/);
-  assert.match(strictAuthSource, /if \(!env\.CRABBOX_INTERACTIVE_PROVISION_TOKEN\)/);
-  assert.match(strictAuthSource, /throw serviceUnavailable/);
-  assert.doesNotMatch(strictAuthSource, /hasBackend/);
-  assert.match(stopSource, /stageStandaloneSandboxProvisionCleanup/);
-  assert.match(stopSource, /reconcileCredentialPolicyCleanupBatch/);
-  assert.match(stopSource, /status: remaining \? "stopping" : "stopped"/);
-  assert.match(source, /CRABBOX_STANDALONE_SANDBOX_TTL_SECONDS/);
-  assert.match(source, /function managedInteractiveSessionId/);
-  assert.match(source, /standaloneProvisionStopMatch/);
-  assert.match(source, /stopStandaloneSandboxProvision/);
-  assert.match(source, /policy\?\.expiresAt !== undefined && policy\.expiresAt <= Date\.now\(\)/);
-  assert.match(source, /standaloneSandboxPolicyExpiresAt/);
-  assert.match(
-    source,
-    /selectFrom\("standalone_sandbox_provisions"\)[\s\S]*failed to allocate an unreserved interactive session id/,
-  );
-  assert.match(source, /id = \$\{id\} COLLATE NOCASE/);
-  assert.match(expiryMigration, /UPDATE id_sequences/);
-  assert.match(expiryMigration, /MAX\(CAST\(substr\(lower\(id\), 4\) AS INTEGER\)\)/);
+	assert.match(endpointSource, /selectFrom\("interactive_sessions"\)/);
+	assert.match(endpointSource, /managed && managed\.preparation_pending !== 0/);
+	assert.match(endpointSource, /if \(managed\)/);
+	assert.ok(
+		endpointSource.indexOf("if (managed)") <
+			endpointSource.indexOf("return provisionStandaloneSandbox(env, payload)"),
+	);
+	assert.match(endpointSource, /provisionManagedSandboxEndpoint\(env, payload, managed\)/);
+	assert.match(endpointSource, /managedInteractiveSessionId\(payload\.id\)/);
+	assert.match(endpointSource, /managed session namespace/);
+	assert.match(endpointSource, /INSERT INTO standalone_sandbox_provisions/);
+	assert.match(endpointSource, /ownership_claim_expires_at/);
+	assert.match(endpointSource, /\$\{sandboxLeaseId\(lease\)\}/);
+	assert.match(endpointSource, /lease_id = excluded\.lease_id/);
+	assert.match(endpointSource, /provisionWithSandbox\([\s\S]*fence/);
+	assert.match(endpointSource, /state: "active"/);
+	assert.match(ownershipSource, /FROM standalone_sandbox_provisions AS owner/);
+	assert.match(ownershipSource, /owner\.ownership_claim = \$\{ownershipFence\.claim\}/);
+	assert.match(managedSource, /managedSandboxProvisionPayloadMatches/);
+	assert.ok(
+		managedSource.indexOf("managedSandboxProvisionPayloadMatches") <
+			managedSource.indexOf("newSandboxLease(payload.id)"),
+	);
+	assert.match(managedSource, /where\("updated_at", "=", session\.updated_at\)/);
+	assert.match(managedSource, /session\.preparation_pending !== 0/);
+	assert.match(managedSource, /\.where\("preparation_pending", "=", 0\)/);
+	assert.match(managedSource, /sandbox_refresh_claim: fence\.claim/);
+	assert.match(managedSource, /const agentToken = newAgentToken\(\)/);
+	assert.match(managedSource, /const agentTokenHash = await sha256\(agentToken\)/);
+	assert.match(managedSource, /agent_token_hash: agentTokenHash/);
+	assert.match(managedSource, /agent_token_hash IS \$\{session\.agent_token_hash\}/);
+	assert.match(managedSource, /provisionWithSandbox\(env, payload, agentToken, lease, fence\)/);
+	assert.ok(
+		managedSource.indexOf("sandboxProvisionPreflightError(env, payload)") <
+			managedSource.indexOf("const agentToken = newAgentToken()"),
+	);
+	assert.match(managedSource, /stageFailedManagedSandboxProvision/);
+	assert.match(managedSource, /where\("agent_token_hash", "=", agentTokenHash\)/);
+	assert.doesNotMatch(managedSource, /provisionWithSandbox\(env, payload, undefined/);
+	assert.match(managedSource, /executeBatch\(env, commitQueries\)/);
+	assert.match(managedCommitSource, /MAX\(updated_at \+ 1, \$\{commitRevision\}\)/);
+	assert.doesNotMatch(managedCommitSource, /where\("updated_at", "=", now\)/);
+	assert.match(managedCommitSource, /lease_id IS \$\{fence\.refreshLeaseId\}/);
+	assert.match(managedCommitSource, /sandbox_refresh_claim", "=", fence\.claim/);
+	assert.match(managedCommitSource, /sandbox_refresh_claim_expires_at", "=", fence\.expiresAt/);
+	assert.match(managedSource, /previousSandboxId/);
+	assert.match(managedSource, /state: "cleanup_pending"/);
+	assert.match(managedSource, /claimed\.numUpdatedRows/);
+	assert.match(ptySource, /authorizeProvisionEndpoint\(request, env\)/);
+	assert.match(ptySource, /standalone_sandbox_provisions/);
+	assert.match(ptySource, /where\("state", "=", "active"\)/);
+	assert.match(ptySource, /owner\.expires_at <= Date\.now\(\)/);
+	assert.match(ptySource, /stageStandaloneSandboxProvisionCleanup/);
+	assert.match(ptySource, /activeSandboxCredentialPolicyGeneration/);
+	assert.match(ptySource, /terminalHeaders\.delete\("authorization"\)/);
+	assert.match(ptySource, /const pair = new WebSocketPair\(\)/);
+	assert.match(ptySource, /response\.webSocket\.accept\(\)/);
+	assert.match(ptySource, /bridgeWebSockets\(/);
+	assert.match(ptySource, /standaloneSandboxTerminalGrant/);
+	assert.match(ptySource, /cachedBooleanGrant/);
+	assert.match(ptySource, /where\("request_hash", "=", ownership\.requestHash\)/);
+	assert.match(ptySource, /where\("expires_at", ">", now\)/);
+	assert.match(ptySource, /where\("updated_at", "=", ownership\.updatedAt\)/);
+	assert.match(ptySource, /activeSandboxCredentialPolicyCondition/);
+	assert.match(ptySource, /return new Response\(null, \{ status: 101, webSocket: client \}\)/);
+	assert.doesNotMatch(ptySource, /return response;/);
+	assert.match(standaloneCleanupSource, /deleteSession\(lease\.terminalSessionId\)/);
+	assert.match(standaloneCleanupSource, /isSandboxSessionAlreadyGone/);
+	assert.ok(
+		standaloneCleanupSource.indexOf("deleteSession(lease.terminalSessionId)") <
+			standaloneCleanupSource.indexOf('.deleteFrom("standalone_sandbox_provisions")'),
+	);
+	assert.match(standaloneCleanupSource, /where\("updated_at", "=", owner\.updated_at\)/);
+	assert.match(sandboxSource, /standaloneSandboxAttachUrl\(env, session\.id\)/);
+	assert.match(
+		endpointSource,
+		/const activationVersion = Math\.max\(Date\.now\(\), finishedAt \+ 1\)/,
+	);
+	assert.match(activationSource, /executeBatch\(env, \[/);
+	assert.ok(
+		activationSource.indexOf('.updateTable("interactive_session_credential_policies")') <
+			activationSource.indexOf('.updateTable("standalone_sandbox_provisions")'),
+	);
+	assert.match(activationSource, /set\(\{ updated_at: activationVersion \}\)/);
+	assert.match(
+		endpointSource,
+		/activeSandboxCredentialPolicyCondition\([\s\S]*policyGeneration,[\s\S]*activationVersion/,
+	);
+	assert.match(migration, /CREATE TABLE IF NOT EXISTS standalone_sandbox_provisions/);
+	assert.match(migration, /request_hash TEXT NOT NULL/);
+	assert.match(migration, /sandbox_id TEXT NOT NULL UNIQUE/);
+	assert.match(expiryMigration, /ADD COLUMN expires_at INTEGER/);
+	assert.match(expiryMigration, /substr\(lower\(id\), 4\) NOT GLOB '\*\[\^0-9\]\*'/);
+	assert.match(expiryMigration, /idx_standalone_sandbox_provision_expiry/);
+	assert.match(expirySource, /state = 'active'/);
+	assert.match(expirySource, /expires_at <= \$\{now\}/);
+	assert.match(expirySource, /substr\(lower\(id\), 4\) NOT GLOB '\*\[\^0-9\]\*'/);
+	assert.match(stopSource, /authorizeProvisionBearerToken\(request, env\)/);
+	assert.match(strictAuthSource, /if \(!env\.CRABBOX_INTERACTIVE_PROVISION_TOKEN\)/);
+	assert.match(strictAuthSource, /throw serviceUnavailable/);
+	assert.doesNotMatch(strictAuthSource, /hasBackend/);
+	assert.match(stopSource, /stageStandaloneSandboxProvisionCleanup/);
+	assert.match(stopSource, /reconcileCredentialPolicyCleanupBatch/);
+	assert.match(stopSource, /status: remaining \? "stopping" : "stopped"/);
+	assert.match(source, /CRABBOX_STANDALONE_SANDBOX_TTL_SECONDS/);
+	assert.match(source, /function managedInteractiveSessionId/);
+	assert.match(source, /standaloneProvisionStopMatch/);
+	assert.match(source, /stopStandaloneSandboxProvision/);
+	assert.match(source, /policy\?\.expiresAt !== undefined && policy\.expiresAt <= Date\.now\(\)/);
+	assert.match(source, /standaloneSandboxPolicyExpiresAt/);
+	assert.match(
+		source,
+		/selectFrom\("standalone_sandbox_provisions"\)[\s\S]*failed to allocate an unreserved interactive session id/,
+	);
+	assert.match(source, /id = \$\{id\} COLLATE NOCASE/);
+	assert.match(expiryMigration, /UPDATE id_sequences/);
+	assert.match(expiryMigration, /MAX\(CAST\(substr\(lower\(id\), 4\) AS INTEGER\)\)/);
 });
 
 test("Sandbox credential egress proves the durable generation and owner", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const readStart = source.indexOf("async function sandboxCredentialPolicy(");
-  const readEnd = source.indexOf("async function sandboxOutbound", readStart);
-  const readSource = source.slice(readStart, readEnd);
-  const controlStart = source.indexOf("export class SessionControlDO");
-  const controlEnd = source.indexOf(
-    "function validSandboxCredentialPolicyRegistration",
-    controlStart,
-  );
-  const controlSource = source.slice(controlStart, controlEnd);
-  const egressStart = controlSource.indexOf("const egressMatch");
-  const egressEnd = controlSource.indexOf("const sandboxMatch", egressStart);
-  const egressSource = controlSource.slice(egressStart, egressEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const readStart = source.indexOf("async function sandboxCredentialPolicy(");
+	const readEnd = source.indexOf("async function sandboxOutbound", readStart);
+	const readSource = source.slice(readStart, readEnd);
+	const controlStart = source.indexOf("export class SessionControlDO");
+	const controlEnd = source.indexOf(
+		"function validSandboxCredentialPolicyRegistration",
+		controlStart,
+	);
+	const controlSource = source.slice(controlStart, controlEnd);
+	const egressStart = controlSource.indexOf("const egressMatch");
+	const egressEnd = controlSource.indexOf("const sandboxMatch", egressStart);
+	const egressSource = controlSource.slice(egressStart, egressEnd);
 
-  assert.match(readSource, /x-crabfleet-policy-generation/);
-  assert.match(readSource, /response\.status === 409/);
-  assert.match(readSource, /repairLegacySandboxCredentialPolicyBatch/);
-  assert.match(readSource, /response = await stub\.fetch\(policyUrl\)/);
-  assert.match(readSource, /sandboxCredentialPolicyHasDurableOwner/);
-  assert.match(readSource, /interactive_session_credential_policies/);
-  assert.match(readSource, /activeSandboxCredentialPolicyGeneration/);
-  assert.match(readSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
-  assert.match(readSource, /policy\.expiresAt === standalone\.expires_at/);
-  assert.match(controlSource, /const current = storedSandboxCredentialPolicy\(stored\)/);
-  assert.match(controlSource, /if \(!current \|\| !policy\)/);
-  assert.doesNotMatch(egressSource, /storage\.delete/);
-  assert.match(egressSource, /legacy credential policy migration required/);
-  assert.match(egressSource, /status: 409/);
-  assert.match(controlSource, /return current\.policy/);
-  assert.doesNotMatch(
-    controlSource,
-    /storedSandboxCredentialPolicy\(value\)\?\.policy \?\? legacySandboxCredentialPolicy/,
-  );
+	assert.match(readSource, /x-crabfleet-policy-generation/);
+	assert.match(readSource, /response\.status === 409/);
+	assert.match(readSource, /repairLegacySandboxCredentialPolicyBatch/);
+	assert.match(readSource, /response = await stub\.fetch\(policyUrl\)/);
+	assert.match(readSource, /sandboxCredentialPolicyHasDurableOwner/);
+	assert.match(readSource, /interactive_session_credential_policies/);
+	assert.match(readSource, /activeSandboxCredentialPolicyGeneration/);
+	assert.match(readSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
+	assert.match(readSource, /policy\.expiresAt === standalone\.expires_at/);
+	assert.match(controlSource, /const current = storedSandboxCredentialPolicy\(stored\)/);
+	assert.match(controlSource, /if \(!current \|\| !policy\)/);
+	assert.doesNotMatch(egressSource, /storage\.delete/);
+	assert.match(egressSource, /legacy credential policy migration required/);
+	assert.match(egressSource, /status: 409/);
+	assert.match(controlSource, /return current\.policy/);
+	assert.doesNotMatch(
+		controlSource,
+		/storedSandboxCredentialPolicy\(value\)\?\.policy \?\? legacySandboxCredentialPolicy/,
+	);
 });
 
 test("cron generation-wraps migrated legacy policies under exact live ownership", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const batchStart = source.indexOf("async function reconcileCredentialPolicyCleanupBatch");
-  const batchEnd = source.indexOf("async function reconcileCredentialPolicyCleanup(", batchStart);
-  const batchSource = source.slice(batchStart, batchEnd);
-  const beginStart = source.indexOf("async function beginLegacySandboxCredentialPolicyRepair");
-  const renewStart = source.indexOf(
-    "async function renewSandboxCredentialPolicyRegistration",
-    beginStart,
-  );
-  const repairSource = source.slice(beginStart, renewStart);
-  const controlStart = source.indexOf("export class SessionControlDO");
-  const controlEnd = source.indexOf("function storedSandboxCredentialPolicy", controlStart);
-  const controlSource = source.slice(controlStart, controlEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const batchStart = source.indexOf("async function reconcileCredentialPolicyCleanupBatch");
+	const batchEnd = source.indexOf("async function reconcileCredentialPolicyCleanup(", batchStart);
+	const batchSource = source.slice(batchStart, batchEnd);
+	const beginStart = source.indexOf("async function beginLegacySandboxCredentialPolicyRepair");
+	const renewStart = source.indexOf(
+		"async function renewSandboxCredentialPolicyRegistration",
+		beginStart,
+	);
+	const repairSource = source.slice(beginStart, renewStart);
+	const controlStart = source.indexOf("export class SessionControlDO");
+	const controlEnd = source.indexOf("function storedSandboxCredentialPolicy", controlStart);
+	const controlSource = source.slice(controlStart, controlEnd);
 
-  assert.ok(
-    batchSource.indexOf("repairLegacySandboxCredentialPolicyBatch") <
-      batchSource.indexOf("scanCredentialPolicyCleanupPage"),
-  );
-  assert.match(repairSource, /credentialPolicyLegacyGenerationPrefix/);
-  assert.match(repairSource, /credentialPolicyLegacyRepairClaimPrefix/);
-  assert.match(repairSource, /sandboxCredentialPolicyRegistrationQueries/);
-  assert.match(repairSource, /const ownership: SandboxCurrentLeaseFence/);
-  assert.match(repairSource, /renewSandboxCredentialPolicyRegistration/);
-  assert.match(repairSource, /\/api\/session-control\/migrate-legacy/);
-  assert.match(repairSource, /sandboxIds: registration\.lookupIds/);
-  assert.match(repairSource, /finishSandboxCredentialPolicyRegistration/);
-  assert.match(repairSource, /registration_claim_expires_at", "<=", now/);
-  assert.match(controlSource, /migratedCredentialPolicyRecord/);
-  assert.match(controlSource, /const sourcePolicy = records/);
-  assert.match(controlSource, /migratedRecords/);
-  assert.match(controlSource, /credentialPolicyMigrationCleanupMatches/);
-  assert.match(controlSource, /this\.ctx\.storage\.transaction/);
+	assert.ok(
+		batchSource.indexOf("repairLegacySandboxCredentialPolicyBatch") <
+			batchSource.indexOf("scanCredentialPolicyCleanupPage"),
+	);
+	assert.match(repairSource, /credentialPolicyLegacyGenerationPrefix/);
+	assert.match(repairSource, /credentialPolicyLegacyRepairClaimPrefix/);
+	assert.match(repairSource, /sandboxCredentialPolicyRegistrationQueries/);
+	assert.match(repairSource, /const ownership: SandboxCurrentLeaseFence/);
+	assert.match(repairSource, /renewSandboxCredentialPolicyRegistration/);
+	assert.match(repairSource, /\/api\/session-control\/migrate-legacy/);
+	assert.match(repairSource, /sandboxIds: registration\.lookupIds/);
+	assert.match(repairSource, /finishSandboxCredentialPolicyRegistration/);
+	assert.match(repairSource, /registration_claim_expires_at", "<=", now/);
+	assert.match(controlSource, /migratedCredentialPolicyRecord/);
+	assert.match(controlSource, /const sourcePolicy = records/);
+	assert.match(controlSource, /migratedRecords/);
+	assert.match(controlSource, /credentialPolicyMigrationCleanupMatches/);
+	assert.match(controlSource, /this\.ctx\.storage\.transaction/);
 });
 
 test("active credential-policy generations recover after a post-DO crash", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const scanStart = source.indexOf("async function scanCredentialPolicyCleanupPage");
-  const scanEnd = source.indexOf("async function readCredentialPolicyScanPage", scanStart);
-  const scanSource = source.slice(scanStart, scanEnd);
-  const repairStart = source.indexOf(
-    "async function repairActiveSandboxCredentialPolicyRegistration",
-  );
-  const repairEnd = source.indexOf("function credentialPolicyScanRequiresCleanup", repairStart);
-  const repairSource = source.slice(repairStart, repairEnd);
-  const promoteStart = source.indexOf("async function promoteSandboxCredentialPolicyRegistration");
-  const promoteEnd = source.indexOf("async function sandboxCredentialPolicyExists", promoteStart);
-  const promoteSource = source.slice(promoteStart, promoteEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const scanStart = source.indexOf("async function scanCredentialPolicyCleanupPage");
+	const scanEnd = source.indexOf("async function readCredentialPolicyScanPage", scanStart);
+	const scanSource = source.slice(scanStart, scanEnd);
+	const repairStart = source.indexOf(
+		"async function repairActiveSandboxCredentialPolicyRegistration",
+	);
+	const repairEnd = source.indexOf("function credentialPolicyScanRequiresCleanup", repairStart);
+	const repairSource = source.slice(repairStart, repairEnd);
+	const promoteStart = source.indexOf("async function promoteSandboxCredentialPolicyRegistration");
+	const promoteEnd = source.indexOf("async function sandboxCredentialPolicyExists", promoteStart);
+	const promoteSource = source.slice(promoteStart, promoteEnd);
 
-  assert.ok(
-    scanSource.indexOf("repairActiveSandboxCredentialPolicyRegistration") <
-      scanSource.indexOf("credentialPolicyScanRequiresCleanup"),
-  );
-  assert.match(scanSource, /repairedRegistrations/);
-  assert.match(scanSource, /deferredRegistrations/);
-  assert.match(repairSource, /row\.policy_state !== "registering"/);
-  assert.match(repairSource, /row\.registration_claim_expires_at/);
-  assert.match(repairSource, /credentialPolicyScanOwnershipFence/);
-  assert.match(repairSource, /sandboxCredentialPolicyExists/);
-  assert.match(repairSource, /recordSandboxCredentialPolicyRefs\([\s\S]*"active"/);
-  assert.match(repairSource, /repair lost durable ownership/);
-  assert.match(promoteSource, /state: "active"/);
-  assert.match(promoteSource, /registration_claim: null/);
-  assert.match(promoteSource, /registration_claim_expires_at: null/);
-  assert.match(promoteSource, /where\("registration_generation", "=", generation\)/);
-  assert.match(promoteSource, /expression\("registration_claim_expires_at", "<=", now\)/);
-  assert.match(promoteSource, /sandboxCredentialPolicyOwnerCondition/);
+	assert.ok(
+		scanSource.indexOf("repairActiveSandboxCredentialPolicyRegistration") <
+			scanSource.indexOf("credentialPolicyScanRequiresCleanup"),
+	);
+	assert.match(scanSource, /repairedRegistrations/);
+	assert.match(scanSource, /deferredRegistrations/);
+	assert.match(repairSource, /row\.policy_state !== "registering"/);
+	assert.match(repairSource, /row\.registration_claim_expires_at/);
+	assert.match(repairSource, /credentialPolicyScanOwnershipFence/);
+	assert.match(repairSource, /sandboxCredentialPolicyExists/);
+	assert.match(repairSource, /recordSandboxCredentialPolicyRefs\([\s\S]*"active"/);
+	assert.match(repairSource, /repair lost durable ownership/);
+	assert.match(promoteSource, /state: "active"/);
+	assert.match(promoteSource, /registration_claim: null/);
+	assert.match(promoteSource, /registration_claim_expires_at: null/);
+	assert.match(promoteSource, /where\("registration_generation", "=", generation\)/);
+	assert.match(promoteSource, /expression\("registration_claim_expires_at", "<=", now\)/);
+	assert.match(promoteSource, /sandboxCredentialPolicyOwnerCondition/);
 });
 
 test("Sandbox credential registration always proves exact durable ownership", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const ownerStart = source.indexOf("function sandboxManagedOwnershipCondition");
-  const ownerEnd = source.indexOf("async function abandonSandboxCredentialPolicyRegistration");
-  const ownerSource = source.slice(ownerStart, ownerEnd);
-  const createStart = source.indexOf("async function createInteractiveSessionFromInput");
-  const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
-  const createSource = source.slice(createStart, createEnd);
-  const ensureStart = source.indexOf("async function ensureSandboxCredentialPolicy");
-  const ensureEnd = source.indexOf("async function recordSandboxCredentialPolicyRefs", ensureStart);
-  const ensureSource = source.slice(ensureStart, ensureEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const ownerStart = source.indexOf("function sandboxManagedOwnershipCondition");
+	const ownerEnd = source.indexOf("async function abandonSandboxCredentialPolicyRegistration");
+	const ownerSource = source.slice(ownerStart, ownerEnd);
+	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
+	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
+	const createSource = source.slice(createStart, createEnd);
+	const ensureStart = source.indexOf("async function ensureSandboxCredentialPolicy");
+	const ensureEnd = source.indexOf("async function recordSandboxCredentialPolicyRefs", ensureStart);
+	const ensureSource = source.slice(ensureStart, ensureEnd);
 
-  assert.doesNotMatch(ownerSource, /ownershipFence\?:/);
-  assert.doesNotMatch(
-    ownerSource,
-    /ownershipFence: SandboxCredentialPolicyOwnershipFence \| undefined/,
-  );
-  assert.doesNotMatch(ownerSource, /1 = 1/);
-  assert.match(ownerSource, /lease_id = \$\{ownershipFence\.leaseId\}/);
-  assert.match(ownerSource, /sandbox_refresh_claim = \$\{ownershipFence\.claim\}/);
-  assert.match(ownerSource, /AND \$\{sandboxId\} = \$\{ownershipFence\.sandboxId\}/);
-  assert.match(createSource, /const initialSandboxLease/);
-  assert.match(createSource, /const initialAgentTokenHash = await sha256\(agentToken\)/);
-  assert.match(createSource, /lease_id: initialSandboxOwnership\?\.leaseId/);
-  assert.match(createSource, /ownership: initialSandboxOwnership/);
-  assert.match(ensureSource, /sandboxCurrentLeaseFence|SandboxCurrentLeaseFence/);
-  assert.match(ensureSource, /credentialPolicyLegacyGenerationPrefix/);
-  assert.match(ensureSource, /repairLegacySandboxCredentialPolicy/);
-  assert.match(
-    ensureSource,
-    /registerSandboxCredentialPolicy\(env, session, sandboxId, ownership\)/,
-  );
+	assert.doesNotMatch(ownerSource, /ownershipFence\?:/);
+	assert.doesNotMatch(
+		ownerSource,
+		/ownershipFence: SandboxCredentialPolicyOwnershipFence \| undefined/,
+	);
+	assert.doesNotMatch(ownerSource, /1 = 1/);
+	assert.match(ownerSource, /lease_id = \$\{ownershipFence\.leaseId\}/);
+	assert.match(ownerSource, /sandbox_refresh_claim = \$\{ownershipFence\.claim\}/);
+	assert.match(ownerSource, /AND \$\{sandboxId\} = \$\{ownershipFence\.sandboxId\}/);
+	assert.match(createSource, /const initialSandboxLease/);
+	assert.match(createSource, /const initialAgentTokenHash = await sha256\(agentToken\)/);
+	assert.match(createSource, /lease_id: initialSandboxOwnership\?\.leaseId/);
+	assert.match(createSource, /ownership: initialSandboxOwnership/);
+	assert.match(ensureSource, /sandboxCurrentLeaseFence|SandboxCurrentLeaseFence/);
+	assert.match(ensureSource, /credentialPolicyLegacyGenerationPrefix/);
+	assert.match(ensureSource, /repairLegacySandboxCredentialPolicy/);
+	assert.match(
+		ensureSource,
+		/registerSandboxCredentialPolicy\(env, session, sandboxId, ownership\)/,
+	);
 });
 
 test("initial terminal adapter responses enter durable finalization", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const createStart = source.indexOf("async function createInteractiveSessionFromInput");
-  const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
-  const createSource = source.slice(createStart, createEnd);
-  const completionStart = createSource.indexOf("const provisionUpdate");
-  const completionEnd = createSource.indexOf(
-    "if ((provisionUpdate.numUpdatedRows",
-    completionStart,
-  );
-  const completionSource = createSource.slice(completionStart, completionEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
+	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
+	const createSource = source.slice(createStart, createEnd);
+	const completionStart = createSource.indexOf("const provisionUpdate");
+	const completionEnd = createSource.indexOf(
+		"if ((provisionUpdate.numUpdatedRows",
+		completionStart,
+	);
+	const completionSource = createSource.slice(completionStart, completionEnd);
 
-  assert.ok(createStart >= 0 && createEnd > createStart);
-  assert.match(createSource, /const initialTerminalStatus: "stopped" \| "expired" \| "failed"/);
-  assert.match(createSource, /terminal_finalize_pending: initialTerminalStatus \? 1 : 0/);
-  assert.match(createSource, /stopped_at: terminalAt/);
-  assert.match(createSource, /agent_token_hash: null/);
-  assert.match(createSource, /attach_url: initialTerminalStatus \? null/);
-  assert.match(createSource, /adapter_create_pending: initialTerminalStatus/);
-  assert.match(completionSource, /MAX\(updated_at \+ 1, \$\{completionVersionFloor\}\)/);
-  assert.doesNotMatch(completionSource, /where\("updated_at"/);
-  assert.match(createSource, /lease_id IS \$\{initialSandboxOwnership\?\.leaseId \?\? null\}/);
-  assert.match(createSource, /where\("agent_token_hash", "=", initialAgentTokenHash\)/);
-  assert.match(createSource, /where\("sandbox_refresh_sandbox_id", "is", null\)/);
-  assert.match(createSource, /where\("sandbox_refresh_claim", "is", null\)/);
-  assert.match(createSource, /where\("sandbox_refresh_claim_expires_at", "is", null\)/);
-  assert.match(createSource, /finalizeTerminalInteractiveSession/);
+	assert.ok(createStart >= 0 && createEnd > createStart);
+	assert.match(createSource, /const initialTerminalStatus: "stopped" \| "expired" \| "failed"/);
+	assert.match(createSource, /terminal_finalize_pending: initialTerminalStatus \? 1 : 0/);
+	assert.match(createSource, /stopped_at: terminalAt/);
+	assert.match(createSource, /agent_token_hash: null/);
+	assert.match(createSource, /attach_url: initialTerminalStatus \? null/);
+	assert.match(createSource, /adapter_create_pending: initialTerminalStatus/);
+	assert.match(completionSource, /MAX\(updated_at \+ 1, \$\{completionVersionFloor\}\)/);
+	assert.doesNotMatch(completionSource, /where\("updated_at"/);
+	assert.match(createSource, /lease_id IS \$\{initialSandboxOwnership\?\.leaseId \?\? null\}/);
+	assert.match(createSource, /where\("agent_token_hash", "=", initialAgentTokenHash\)/);
+	assert.match(createSource, /where\("sandbox_refresh_sandbox_id", "is", null\)/);
+	assert.match(createSource, /where\("sandbox_refresh_claim", "is", null\)/);
+	assert.match(createSource, /where\("sandbox_refresh_claim_expires_at", "is", null\)/);
+	assert.match(createSource, /finalizeTerminalInteractiveSession/);
 });
 
 test("create-only adapters reject stopping responses before persistence", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const externalStart = source.indexOf("async function provisionInteractiveSession");
-  const externalEnd = source.indexOf("async function provisionInteractiveEndpoint", externalStart);
-  const externalSource = source.slice(externalStart, externalEnd);
-  const forwardedStart = source.indexOf("function provisionResultFromBody");
-  const forwardedEnd = source.indexOf("function failedProvision", forwardedStart);
-  const forwardedSource = source.slice(forwardedStart, forwardedEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const externalStart = source.indexOf("async function provisionInteractiveSession");
+	const externalEnd = source.indexOf("async function provisionInteractiveEndpoint", externalStart);
+	const externalSource = source.slice(externalStart, externalEnd);
+	const forwardedStart = source.indexOf("function provisionResultFromBody");
+	const forwardedEnd = source.indexOf("function failedProvision", forwardedStart);
+	const forwardedSource = source.slice(forwardedStart, forwardedEnd);
 
-  assert.match(externalSource, /createOnlyAdapterStatus\(body\.status\)/);
-  assert.match(forwardedSource, /createOnlyAdapterStatus\(body\.status\)/);
-  assert.match(forwardedSource, /if \(!status\) return failedProvision/);
+	assert.match(externalSource, /createOnlyAdapterStatus\(body\.status\)/);
+	assert.match(forwardedSource, /createOnlyAdapterStatus\(body\.status\)/);
+	assert.match(forwardedSource, /if \(!status\) return failedProvision/);
 });
 
 test("Sandbox cleanup and legacy stops use durable terminal transitions", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const actionStart = source.indexOf('if (action === "stop")');
-  const actionEnd = source.indexOf('throw badRequest("unknown action")', actionStart);
-  const stopSource = source.slice(actionStart, actionEnd);
-  const legacyCompleteIndex = stopSource.indexOf("completeLegacyInteractiveSessionStop");
-  const cleanupIndex = stopSource.lastIndexOf(
-    "stageTerminalCredentialPolicyCleanupById",
-    legacyCompleteIndex,
-  );
-  const reconcileIndex = stopSource.indexOf("reconcileCredentialPolicyCleanupBatch", cleanupIndex);
-  const completeStart = source.indexOf("async function completeLegacyInteractiveSessionStop");
-  const completeEnd = source.indexOf("async function mutateInteractiveSession(", completeStart);
-  const completeSource = source.slice(completeStart, completeEnd);
-  const scheduledStart = source.indexOf(
-    "async function reconcileLegacyStoppingInteractiveSessionBatch",
-  );
-  const scheduledEnd = source.indexOf(
-    "async function requeueTerminalArchiveObjectBackfill",
-    scheduledStart,
-  );
-  const scheduledSource = source.slice(scheduledStart, scheduledEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const actionStart = source.indexOf('if (action === "stop")');
+	const actionEnd = source.indexOf('throw badRequest("unknown action")', actionStart);
+	const stopSource = source.slice(actionStart, actionEnd);
+	const legacyCompleteIndex = stopSource.indexOf("completeLegacyInteractiveSessionStop");
+	const cleanupIndex = stopSource.lastIndexOf(
+		"stageTerminalCredentialPolicyCleanupById",
+		legacyCompleteIndex,
+	);
+	const reconcileIndex = stopSource.indexOf("reconcileCredentialPolicyCleanupBatch", cleanupIndex);
+	const completeStart = source.indexOf("async function completeLegacyInteractiveSessionStop");
+	const completeEnd = source.indexOf("async function mutateInteractiveSession(", completeStart);
+	const completeSource = source.slice(completeStart, completeEnd);
+	const scheduledStart = source.indexOf(
+		"async function reconcileLegacyStoppingInteractiveSessionBatch",
+	);
+	const scheduledEnd = source.indexOf(
+		"async function requeueTerminalArchiveObjectBackfill",
+		scheduledStart,
+	);
+	const scheduledSource = source.slice(scheduledStart, scheduledEnd);
 
-  assert.ok(actionStart >= 0 && actionEnd > actionStart);
-  assert.ok(
-    cleanupIndex >= 0 && reconcileIndex > cleanupIndex && legacyCompleteIndex > reconcileIndex,
-  );
-  assert.match(stopSource, /const staged = await stageTerminalCredentialPolicyCleanupById/);
-  assert.match(stopSource, /if \(!staged\)/);
-  assert.match(stopSource, /credential_cleanup_terminal_status/);
-  assert.match(
-    stopSource,
-    /completeLegacyInteractiveSessionStop\(env, session, actor\(user\), now\)/,
-  );
-  assert.match(completeSource, /env\.DB\.batch/);
-  assert.match(completeSource, /interactive workspace stop requested/);
-  assert.match(completeSource, /interactive workspace stopped/);
-  assert.match(completeSource, /status: "stopped"/);
-  assert.match(completeSource, /terminal_finalize_pending: 1/);
-  assert.match(completeSource, /AND status = \$\{owner\.status\}/);
-  assert.match(completeSource, /AND updated_at = \$\{owner\.updatedAt\}/);
-  assert.match(completeSource, /finalizeTerminalInteractiveSession/);
-  assert.doesNotMatch(completeSource, /status: "stopping"/);
-  assert.match(scheduledSource, /where\("status", "=", "stopping"\)/);
-  assert.match(scheduledSource, /\.where\("runtime", "!=", githubActionsRuntime\)/);
-  assert.match(scheduledSource, /completeLegacyInteractiveSessionStop/);
-  assert.match(completeSource, /if \(owner\.runtime === githubActionsRuntime\) return false/);
-  assert.match(completeSource, /async function stopGitHubActionsSession/);
-  assert.match(completeSource, /work_state: ""/);
-  assert.match(completeSource, /work_phase: "session_ended"/);
-  assert.match(completeSource, /workflow run not canceled/);
-  assert.match(stopSource, /session\.runtime === githubActionsRuntime/);
-  assert.match(stopSource, /stopGitHubActionsSession\(env, session, userActor, now\)/);
-  assert.match(stopSource, /interactive session lifecycle changed; retry stop/);
-  assert.match(stopSource, /const current = await readInteractiveSession\(env, id\)/);
-  assert.match(stopSource, /current\.adapter !== runtimeAdapterName/);
-  assert.match(stopSource, /current\.adapterWorkspaceId !== session\.adapterWorkspaceId/);
-  assert.match(stopSource, /\["stopping", "stopped", "expired", "failed"\]\.includes/);
+	assert.ok(actionStart >= 0 && actionEnd > actionStart);
+	assert.ok(
+		cleanupIndex >= 0 && reconcileIndex > cleanupIndex && legacyCompleteIndex > reconcileIndex,
+	);
+	assert.match(stopSource, /const staged = await stageTerminalCredentialPolicyCleanupById/);
+	assert.match(stopSource, /if \(!staged\)/);
+	assert.match(stopSource, /credential_cleanup_terminal_status/);
+	assert.match(
+		stopSource,
+		/completeLegacyInteractiveSessionStop\(env, session, actor\(user\), now\)/,
+	);
+	assert.match(completeSource, /env\.DB\.batch/);
+	assert.match(completeSource, /interactive workspace stop requested/);
+	assert.match(completeSource, /interactive workspace stopped/);
+	assert.match(completeSource, /status: "stopped"/);
+	assert.match(completeSource, /terminal_finalize_pending: 1/);
+	assert.match(completeSource, /AND status = \$\{owner\.status\}/);
+	assert.match(completeSource, /AND updated_at = \$\{owner\.updatedAt\}/);
+	assert.match(completeSource, /finalizeTerminalInteractiveSession/);
+	assert.doesNotMatch(completeSource, /status: "stopping"/);
+	assert.match(scheduledSource, /where\("status", "=", "stopping"\)/);
+	assert.match(scheduledSource, /\.where\("runtime", "!=", githubActionsRuntime\)/);
+	assert.match(scheduledSource, /completeLegacyInteractiveSessionStop/);
+	assert.match(completeSource, /if \(owner\.runtime === githubActionsRuntime\) return false/);
+	assert.match(completeSource, /async function stopGitHubActionsSession/);
+	assert.match(completeSource, /work_state: ""/);
+	assert.match(completeSource, /work_phase: "session_ended"/);
+	assert.match(completeSource, /workflow run not canceled/);
+	assert.match(stopSource, /session\.runtime === githubActionsRuntime/);
+	assert.match(stopSource, /stopGitHubActionsSession\(env, session, userActor, now\)/);
+	assert.match(stopSource, /interactive session lifecycle changed; retry stop/);
+	assert.match(stopSource, /const current = await readInteractiveSession\(env, id\)/);
+	assert.match(stopSource, /current\.adapter !== runtimeAdapterName/);
+	assert.match(stopSource, /current\.adapterWorkspaceId !== session\.adapterWorkspaceId/);
+	assert.match(stopSource, /\["stopping", "stopped", "expired", "failed"\]\.includes/);
 });
 
 test("legacy expiry enters the shared retryable terminal finalizer", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const expiryStart = source.indexOf("async function markInteractiveTerminalUnavailable");
-  const expiryEnd = source.indexOf("async function uploadInteractiveSessionClipboard", expiryStart);
-  const expirySource = source.slice(expiryStart, expiryEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const expiryStart = source.indexOf("async function markInteractiveTerminalUnavailable");
+	const expiryEnd = source.indexOf("async function uploadInteractiveSessionClipboard", expiryStart);
+	const expirySource = source.slice(expiryStart, expiryEnd);
 
-  assert.match(expirySource, /status: "expired"/);
-  assert.match(expirySource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
-  assert.match(expirySource, /where\("updated_at", "=", existing\.updated_at\)/);
-  assert.match(expirySource, /terminal_finalize_pending: 1/);
-  assert.match(expirySource, /finalizeTerminalInteractiveSession\(env, id, "expired", now\)/);
-  assert.match(expirySource, /stageTerminalCredentialPolicyCleanupById/);
-  assert.match(
-    expirySource,
-    /stageTerminalCredentialPolicyCleanupById\([\s\S]*?"failed",\s*message,[\s\S]*?now,\s*message/,
-  );
-  assert.match(expirySource, /reconcileCredentialPolicyCleanupBatch\(env, now, id\)/);
-  assert.ok(
-    expirySource.indexOf("stageTerminalCredentialPolicyCleanup") <
-      expirySource.indexOf("reconcileCredentialPolicyCleanupBatch"),
-  );
+	assert.match(expirySource, /status: "expired"/);
+	assert.match(expirySource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
+	assert.match(expirySource, /where\("updated_at", "=", existing\.updated_at\)/);
+	assert.match(expirySource, /terminal_finalize_pending: 1/);
+	assert.match(expirySource, /finalizeTerminalInteractiveSession\(env, id, "expired", now\)/);
+	assert.match(expirySource, /stageTerminalCredentialPolicyCleanupById/);
+	assert.match(
+		expirySource,
+		/stageTerminalCredentialPolicyCleanupById\([\s\S]*?"failed",\s*message,[\s\S]*?now,\s*message/,
+	);
+	assert.match(expirySource, /reconcileCredentialPolicyCleanupBatch\(env, now, id\)/);
+	assert.ok(
+		expirySource.indexOf("stageTerminalCredentialPolicyCleanup") <
+			expirySource.indexOf("reconcileCredentialPolicyCleanupBatch"),
+	);
 });
 
 test("idempotent legacy terminal stop verifies credential cleanup", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const actionStart = source.indexOf('if (action === "stop")');
-  const legacyCompleteIndex = source.indexOf(
-    "completeLegacyInteractiveSessionStop(env, session",
-    actionStart,
-  );
-  const fastPathSource = source.slice(actionStart, legacyCompleteIndex);
-  const unregisterStart = source.indexOf("async function unregisterSandboxCredentialPolicyLookup");
-  const unregisterEnd = source.indexOf(
-    "function sandboxCredentialPolicyRefQueries",
-    unregisterStart,
-  );
-  const unregisterSource = source.slice(unregisterStart, unregisterEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const actionStart = source.indexOf('if (action === "stop")');
+	const legacyCompleteIndex = source.indexOf(
+		"completeLegacyInteractiveSessionStop(env, session",
+		actionStart,
+	);
+	const fastPathSource = source.slice(actionStart, legacyCompleteIndex);
+	const unregisterStart = source.indexOf("async function unregisterSandboxCredentialPolicyLookup");
+	const unregisterEnd = source.indexOf(
+		"function sandboxCredentialPolicyRefQueries",
+		unregisterStart,
+	);
+	const unregisterSource = source.slice(unregisterStart, unregisterEnd);
 
-  assert.match(fastPathSource, /isSandboxInteractiveSession\(session\)/);
-  assert.match(fastPathSource, /stageTerminalCredentialPolicyCleanup/);
-  assert.match(fastPathSource, /reconcileCredentialPolicyCleanupBatch/);
-  assert.match(unregisterSource, /if \(!stub\) throw serviceUnavailable/);
-  assert.match(unregisterSource, /if \(!response\.ok\)/);
-  assert.doesNotMatch(unregisterSource, /response\.status !== 404/);
-  assert.match(unregisterSource, /sandbox credential policy cleanup failed/);
+	assert.match(fastPathSource, /isSandboxInteractiveSession\(session\)/);
+	assert.match(fastPathSource, /stageTerminalCredentialPolicyCleanup/);
+	assert.match(fastPathSource, /reconcileCredentialPolicyCleanupBatch/);
+	assert.match(unregisterSource, /if \(!stub\) throw serviceUnavailable/);
+	assert.match(unregisterSource, /if \(!response\.ok\)/);
+	assert.doesNotMatch(unregisterSource, /response\.status !== 404/);
+	assert.match(unregisterSource, /sandbox credential policy cleanup failed/);
 });
 
 test("sandbox credential cleanup is durably staged and retried", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const migration = await readFile(
-    new URL("../migrations/0022_credential_policy_cleanup.sql", import.meta.url),
-    "utf8",
-  );
-  const stageStart = source.indexOf("async function stageTerminalCredentialPolicyCleanup");
-  const stageEnd = source.indexOf("type CredentialPolicyScanRow", stageStart);
-  const stageSource = source.slice(stageStart, stageEnd);
-  const scanStart = stageEnd;
-  const batchStart = source.indexOf(
-    "async function reconcileCredentialPolicyCleanupBatch",
-    scanStart,
-  );
-  const scanSource = source.slice(scanStart, batchStart);
-  const batchEnd = source.indexOf("async function reconcileCredentialPolicyCleanup(", batchStart);
-  const batchSource = source.slice(batchStart, batchEnd);
-  const cleanupStart = batchEnd;
-  const cleanupEnd = source.indexOf(
-    "async function completeCredentialPolicyCleanupSession",
-    cleanupStart,
-  );
-  const cleanupSource = source.slice(cleanupStart, cleanupEnd);
-  const completionEnd = source.indexOf("function legacyInteractiveSessionLeaseId", cleanupEnd);
-  const completionSource = source.slice(cleanupEnd, completionEnd);
-  const provisionStart = source.indexOf("async function provisionWithSandbox");
-  const provisionEnd = source.indexOf(
-    "async function registerSandboxCredentialPolicy",
-    provisionStart,
-  );
-  const provisionSource = source.slice(provisionStart, provisionEnd);
-  const registerStart = provisionEnd;
-  const registerEnd = source.indexOf("async function ensureSandboxCredentialPolicy", registerStart);
-  const registerSource = source.slice(registerStart, registerEnd);
-  const registrationLifecycleStart = source.indexOf(
-    "function sandboxCredentialPolicyRegistrationQueries",
-  );
-  const registrationLifecycleSource = source.slice(registrationLifecycleStart, registerEnd);
-  const finishStart = source.indexOf("async function finishSandboxCredentialPolicyRegistration");
-  const finishEnd = source.indexOf(
-    "async function abandonSandboxCredentialPolicyRegistration",
-    finishStart,
-  );
-  const finishSource = source.slice(finishStart, finishEnd);
-  const abandonEnd = source.indexOf("async function registerSandboxCredentialPolicy", finishEnd);
-  const abandonSource = source.slice(finishEnd, abandonEnd);
-  const scanDecisionStart = source.indexOf("function credentialPolicyScanRequiresCleanup");
-  const scanDecisionEnd = source.indexOf(
-    "async function normalizeCredentialPolicyCleanupGroups",
-    scanDecisionStart,
-  );
-  const scanDecisionSource = source.slice(scanDecisionStart, scanDecisionEnd);
-  const controlStart = source.indexOf("export class SessionControlDO");
-  const controlEnd = source.indexOf("function dedupeSandboxPolicies", controlStart);
-  const controlSource = source.slice(controlStart, controlEnd);
-  const refreshStart = source.indexOf("async function ensureCurrentSandboxLease");
-  const refreshEnd = source.indexOf("async function prepareSandboxWorkspace", refreshStart);
-  const refreshSource = source.slice(refreshStart, refreshEnd);
-  const ownershipStart = source.indexOf("function sandboxTerminalCleanupOwnership");
-  const ownershipSource = source.slice(ownershipStart, stageStart);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const migration = await readFile(
+		new URL("../migrations/0022_credential_policy_cleanup.sql", import.meta.url),
+		"utf8",
+	);
+	const stageStart = source.indexOf("async function stageTerminalCredentialPolicyCleanup");
+	const stageEnd = source.indexOf("type CredentialPolicyScanRow", stageStart);
+	const stageSource = source.slice(stageStart, stageEnd);
+	const scanStart = stageEnd;
+	const batchStart = source.indexOf(
+		"async function reconcileCredentialPolicyCleanupBatch",
+		scanStart,
+	);
+	const scanSource = source.slice(scanStart, batchStart);
+	const batchEnd = source.indexOf("async function reconcileCredentialPolicyCleanup(", batchStart);
+	const batchSource = source.slice(batchStart, batchEnd);
+	const cleanupStart = batchEnd;
+	const cleanupEnd = source.indexOf(
+		"async function completeCredentialPolicyCleanupSession",
+		cleanupStart,
+	);
+	const cleanupSource = source.slice(cleanupStart, cleanupEnd);
+	const completionEnd = source.indexOf("function legacyInteractiveSessionLeaseId", cleanupEnd);
+	const completionSource = source.slice(cleanupEnd, completionEnd);
+	const provisionStart = source.indexOf("async function provisionWithSandbox");
+	const provisionEnd = source.indexOf(
+		"async function registerSandboxCredentialPolicy",
+		provisionStart,
+	);
+	const provisionSource = source.slice(provisionStart, provisionEnd);
+	const registerStart = provisionEnd;
+	const registerEnd = source.indexOf("async function ensureSandboxCredentialPolicy", registerStart);
+	const registerSource = source.slice(registerStart, registerEnd);
+	const registrationLifecycleStart = source.indexOf(
+		"function sandboxCredentialPolicyRegistrationQueries",
+	);
+	const registrationLifecycleSource = source.slice(registrationLifecycleStart, registerEnd);
+	const finishStart = source.indexOf("async function finishSandboxCredentialPolicyRegistration");
+	const finishEnd = source.indexOf(
+		"async function abandonSandboxCredentialPolicyRegistration",
+		finishStart,
+	);
+	const finishSource = source.slice(finishStart, finishEnd);
+	const abandonEnd = source.indexOf("async function registerSandboxCredentialPolicy", finishEnd);
+	const abandonSource = source.slice(finishEnd, abandonEnd);
+	const scanDecisionStart = source.indexOf("function credentialPolicyScanRequiresCleanup");
+	const scanDecisionEnd = source.indexOf(
+		"async function normalizeCredentialPolicyCleanupGroups",
+		scanDecisionStart,
+	);
+	const scanDecisionSource = source.slice(scanDecisionStart, scanDecisionEnd);
+	const controlStart = source.indexOf("export class SessionControlDO");
+	const controlEnd = source.indexOf("function dedupeSandboxPolicies", controlStart);
+	const controlSource = source.slice(controlStart, controlEnd);
+	const refreshStart = source.indexOf("async function ensureCurrentSandboxLease");
+	const refreshEnd = source.indexOf("async function prepareSandboxWorkspace", refreshStart);
+	const refreshSource = source.slice(refreshStart, refreshEnd);
+	const ownershipStart = source.indexOf("function sandboxTerminalCleanupOwnership");
+	const ownershipSource = source.slice(ownershipStart, stageStart);
 
-  assert.match(stageSource, /executeBatch\(env, \[sessionTransition, \.\.\.policyTransitions\]\)/);
-  assert.match(stageSource, /status: "stopping"/);
-  assert.match(stageSource, /credential_cleanup_terminal_status: cleanupIntent/);
-  assert.match(stageSource, /credential_cleanup_terminal_status = 'failed'/);
-  assert.match(stageSource, /credential_cleanup_terminal_status = 'expired'/);
-  assert.match(stageSource, /terminalCleanupIntentRank/);
-  assert.match(stageSource, /sandbox_refresh_claim: null/);
-  assert.match(stageSource, /sandboxManagedStoredOwnershipCondition\(ownership\.fence\)/);
-  assert.match(stageSource, /where\("updated_at", "=", session\.updated_at\)/);
-  assert.match(stageSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
-  assert.match(stageSource, /\.where\("sandbox_id", "=", sandboxId\)/);
-  assert.match(stageSource, /agent_token_hash: null/);
-  assert.match(stageSource, /controller: null/);
-  assert.match(stageSource, /terminal_failure_reason:/);
-  assert.match(stageSource, /failureReason/);
-  assert.match(stageSource, /NULLIF\(terminal_failure_reason, ''\)/);
-  assert.match(stageSource, /terminal_failure_reason: failureEvidence/);
-  assert.match(stageSource, /state: "cleanup_pending"/);
-  assert.match(stageSource, /for \(let attempt = 0; attempt < 3; attempt \+= 1\)/);
-  assert.match(ownershipSource, /sandboxLeaseWithoutRefresh/);
-  assert.match(ownershipSource, /sandbox_refresh_claim_expires_at/);
-  assert.match(ownershipSource, /sandboxIds: \[\.\.\.new Set/);
-  assert.match(scanSource, /credentialPolicyScanLimit/);
-  assert.match(scanSource, /scan_max_rowid/);
-  assert.match(scanSource, /maximumCredentialPolicyRowid/);
-  assert.match(scanSource, /policy\.rowid > \$\{cursor\}/);
-  assert.match(scanSource, /policy\.rowid <= \$\{maxRowid\}/);
-  assert.doesNotMatch(scanSource, /affectedSessions/);
-  assert.doesNotMatch(scanSource, /const transitioned = await update\.executeTakeFirst\(\)/);
-  assert.match(scanSource, /const sessionTransition = sql/);
-  assert.match(scanSource, /executeBatch\(env, \[sessionTransition, policyTransition\]\)/);
-  assert.match(scanSource, /executeBatch\(env, \[ownerTransition, policyTransition\]\)/);
-  assert.match(scanSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
-  assert.match(scanSource, /AND status IS \$\{row\.session_status\}/);
-  assert.match(scanSource, /AND lease_id IS \$\{row\.session_lease_id\}/);
-  assert.match(scanSource, /AND agent_token_hash IS \$\{row\.session_agent_token_hash\}/);
-  assert.match(scanSource, /standalone\.ownership_claim AS standalone_claim/);
-  assert.match(scanSource, /AND updated_at IS \$\{row\.session_updated_at\}/);
-  assert.match(scanSource, /\.where\("sandbox_id", "=", row\.sandbox_id\)/);
-  assert.match(scanSource, /\.where\("lookup_id", "=", row\.lookup_id\)/);
-  assert.match(
-    scanSource,
-    /\.where\("registration_generation", "=", row\.registration_generation\)/,
-  );
-  assert.match(scanSource, /terminal_failure_reason = CASE/);
-  assert.match(scanSource, /credential_cleanup_terminal_status = 'failed'/);
-  assert.match(scanSource, /credential_cleanup_terminal_status = 'expired'/);
-  assert.match(scanSource, /const transitionRevision = Math\.max/);
-  assert.match(scanSource, /agent_token_hash = NULL/);
-  assert.match(scanSource, /credentialPolicySandboxIsExpected/);
-  assert.match(scanSource, /sandbox_refresh_claim = NULL/);
-  assert.match(scanSource, /normalizeCredentialPolicyCleanupGroups/);
-  assert.match(scanSource, /group_max_session_id/);
-  assert.match(batchSource, /scanCredentialPolicyCleanupPage/);
-  assert.match(batchSource, /normalizeCredentialPolicyCleanupGroups/);
-  assert.match(batchSource, /COALESCE\(last_attempt_at, created_at\)/);
-  assert.match(batchSource, /\.limit\(credentialPolicyCleanupLimit\)/);
-  assert.match(batchSource, /completeStandaloneSandboxProvisionCleanupSafely/);
-  assert.match(cleanupSource, /cleanup_claim_expires_at/);
-  assert.match(cleanupSource, /registration_claim_expires_at > \$\{now\}/);
-  assert.match(cleanupSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
-  assert.ok(
-    cleanupSource.indexOf("cleanup_claim = ${claim}") <
-      cleanupSource.indexOf("unregisterSandboxCredentialPolicyLookup"),
-  );
-  assert.match(cleanupSource, /last_error:/);
-  assert.match(cleanupSource, /cleanup_claim: null/);
-  assert.match(cleanupSource, /async function completeStandaloneSandboxProvisionCleanupSafely/);
-  assert.match(cleanupSource, /standalone Sandbox cleanup pending/);
-  assert.match(cleanupSource, /standalone_sandbox_provisions/);
-  assert.match(cleanupSource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
-  assert.match(cleanupSource, /cleanup failure persistence failed/);
-  assert.match(completionSource, /NOT EXISTS \(/);
-  assert.match(completionSource, /status: terminalStatus/);
-  assert.match(completionSource, /terminal_finalize_pending: 1/);
-  assert.match(completionSource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
-  assert.match(completionSource, /\.where\("status", "=", session\.status\)/);
-  assert.match(completionSource, /\.where\("updated_at", "=", session\.updated_at\)/);
-  assert.match(completionSource, /retainedRuntimeAdapterFailureMessage/);
-  assert.match(completionSource, /terminal_failure_reason:/);
-  assert.match(completionSource, /\? failureMessage/);
-  assert.match(batchSource, /completeCredentialPolicyCleanupSession\(env, session\.id/);
-  assert.ok(
-    provisionSource.indexOf("stageTerminalCredentialPolicyCleanupById") <
-      provisionSource.indexOf("reconcileCredentialPolicyCleanupBatch"),
-  );
-  assert.match(provisionSource, /failureAt,\s*cleanupMessage,\s*ownershipFence/);
-  assert.match(provisionSource, /try \{[\s\S]*sandboxProvisionPreflightError\(env, session\)/);
-  assert.match(provisionSource, /!agentToken/);
-  assert.match(provisionSource, /managed Sandbox agent token is unavailable/);
-  assert.match(registrationLifecycleSource, /registration_generation/);
-  assert.match(registrationLifecycleSource, /registration_claim/);
-  assert.match(registrationLifecycleSource, /registration_claim_expires_at/);
-  assert.doesNotMatch(registrationLifecycleSource, /ownershipFence\?:/);
-  assert.doesNotMatch(registrationLifecycleSource, /1 = 1/);
-  assert.match(registrationLifecycleSource, /sandboxCredentialPolicyOwnerCondition/);
-  assert.match(registrationLifecycleSource, /sandboxCredentialPolicyOwnerCondition/);
-  assert.ok(
-    registerSource.indexOf("beginSandboxCredentialPolicyRegistration") <
-      registerSource.indexOf(
-        'stub.fetch("https://crabfleet.internal/api/session-control/register"',
-      ),
-  );
-  assert.ok(
-    registerSource.indexOf("renewSandboxCredentialPolicyRegistration") <
-      registerSource.indexOf(
-        'stub.fetch("https://crabfleet.internal/api/session-control/register"',
-      ),
-  );
-  assert.ok(
-    registerSource.indexOf('stub.fetch("https://crabfleet.internal/api/session-control/register"') <
-      registerSource.indexOf("finishSandboxCredentialPolicyRegistration"),
-  );
-  assert.doesNotMatch(finishSource, /INSERT INTO|insertInto/);
-  assert.match(finishSource, /state: "active"/);
-  assert.match(finishSource, /where\(sandboxCredentialPolicyOwnerCondition/);
-  assert.doesNotMatch(finishSource, /cleanup_pending/);
-  assert.match(registerSource, /abandonSandboxCredentialPolicyRegistration/);
-  assert.match(abandonSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
-  assert.match(abandonSource, /THEN 'cleanup_pending'/);
-  assert.match(abandonSource, /ELSE 'registering'/);
-  assert.ok(
-    scanDecisionSource.indexOf("sandboxExpected") <
-      scanDecisionSource.indexOf("if (registrationAbandoned) return true"),
-  );
-  assert.doesNotMatch(scanDecisionSource, /row\.session_agent_token_hash !== null/);
-  assert.match(scanDecisionSource, /sandboxExpected &&[\s\S]*row\.session_status === "ready"/);
-  assert.match(controlSource, /sandboxPolicyTombstoneKey/);
-  assert.match(controlSource, /credentialPolicyRegistrationAccepted/);
-  assert.match(controlSource, /credentialPolicyCleanupMatches/);
-  assert.match(controlSource, /this\.ctx\.storage\.transaction/);
-  assert.doesNotMatch(source, /async function unregisterSandboxCredentialPolicy\(/);
-  assert.match(migration, /CREATE TABLE IF NOT EXISTS interactive_session_credential_policies/);
-  assert.match(migration, /state IN \('registering', 'active', 'cleanup_pending'\)/);
-  assert.match(migration, /registration_generation TEXT NOT NULL/);
-  assert.match(migration, /registration_claim_expires_at INTEGER/);
-  assert.match(migration, /CREATE TABLE IF NOT EXISTS credential_policy_reconcile_state/);
-  assert.match(migration, /scan_max_rowid INTEGER NOT NULL/);
-  assert.match(migration, /group_max_session_id TEXT NOT NULL/);
-  assert.match(migration, /ADD COLUMN sandbox_refresh_sandbox_id TEXT/);
-  assert.match(migration, /ADD COLUMN sandbox_refresh_claim TEXT/);
-  assert.match(migration, /ADD COLUMN sandbox_refresh_claim_expires_at INTEGER/);
-  assert.match(migration, /CREATE TABLE IF NOT EXISTS standalone_sandbox_provisions/);
-  assert.match(migration, /idx_interactive_policy_fair_cleanup/);
-  assert.match(migration, /COALESCE\(last_attempt_at, created_at\)/);
-  assert.match(migration, /terminal_failure_reason = CASE/);
-  assert.match(migration, /terminal_finalize_pending = 0/);
-  assert.match(migration, /agent_token_hash = NULL/);
-  assert.match(migration, /SET\s+status = 'stopping'/);
-  assert.match(refreshSource, /sandbox_refresh_sandbox_id: refreshFence\.sandboxId/);
-  assert.match(refreshSource, /sandbox_refresh_claim: refreshFence\.claim/);
-  assert.match(refreshSource, /sandbox_refresh_claim_expires_at: refreshFence\.expiresAt/);
-  assert.match(refreshSource, /const agentToken = newAgentToken\(\)/);
-  assert.ok(
-    refreshSource.indexOf("sandboxProvisionPreflightError(env, refreshPayload)") <
-      refreshSource.indexOf("const agentToken = newAgentToken()"),
-  );
-  assert.match(refreshSource, /agent_token_hash: agentTokenHash/);
-  assert.match(refreshSource, /provisionWithSandbox\([\s\S]*?agentToken,[\s\S]*?refreshLease/);
-  assert.match(refreshSource, /where\("agent_token_hash", "=", agentTokenHash\)/);
-  assert.match(refreshSource, /sandbox_refresh_claim_expires_at", "=", refreshFence\.expiresAt/);
-  assert.match(refreshSource, /executeBatch\(env, commitQueries\)/);
-  assert.match(refreshSource, /state: "cleanup_pending"/);
-  assert.match(refreshSource, /stageFailedManagedSandboxProvision/);
-  assert.ok(
-    refreshSource.indexOf("sandbox_refresh_claim: null") <
-      refreshSource.lastIndexOf("reconcileCredentialPolicyCleanupBatch"),
-  );
-  assert.doesNotMatch(
-    refreshSource,
-    /queueSandboxCredentialPolicyCleanup\(env, session\.id, oldSandboxId, refreshedAt\)/,
-  );
-  assert.match(refreshSource, /const current = await readInteractiveSession/);
+	assert.match(stageSource, /executeBatch\(env, \[sessionTransition, \.\.\.policyTransitions\]\)/);
+	assert.match(stageSource, /status: "stopping"/);
+	assert.match(stageSource, /credential_cleanup_terminal_status: cleanupIntent/);
+	assert.match(stageSource, /credential_cleanup_terminal_status = 'failed'/);
+	assert.match(stageSource, /credential_cleanup_terminal_status = 'expired'/);
+	assert.match(stageSource, /terminalCleanupIntentRank/);
+	assert.match(stageSource, /sandbox_refresh_claim: null/);
+	assert.match(stageSource, /sandboxManagedStoredOwnershipCondition\(ownership\.fence\)/);
+	assert.match(stageSource, /where\("updated_at", "=", session\.updated_at\)/);
+	assert.match(stageSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
+	assert.match(stageSource, /\.where\("sandbox_id", "=", sandboxId\)/);
+	assert.match(stageSource, /agent_token_hash: null/);
+	assert.match(stageSource, /controller: null/);
+	assert.match(stageSource, /terminal_failure_reason:/);
+	assert.match(stageSource, /failureReason/);
+	assert.match(stageSource, /NULLIF\(terminal_failure_reason, ''\)/);
+	assert.match(stageSource, /terminal_failure_reason: failureEvidence/);
+	assert.match(stageSource, /state: "cleanup_pending"/);
+	assert.match(stageSource, /for \(let attempt = 0; attempt < 3; attempt \+= 1\)/);
+	assert.match(ownershipSource, /sandboxLeaseWithoutRefresh/);
+	assert.match(ownershipSource, /sandbox_refresh_claim_expires_at/);
+	assert.match(ownershipSource, /sandboxIds: \[\.\.\.new Set/);
+	assert.match(scanSource, /credentialPolicyScanLimit/);
+	assert.match(scanSource, /scan_max_rowid/);
+	assert.match(scanSource, /maximumCredentialPolicyRowid/);
+	assert.match(scanSource, /policy\.rowid > \$\{cursor\}/);
+	assert.match(scanSource, /policy\.rowid <= \$\{maxRowid\}/);
+	assert.doesNotMatch(scanSource, /affectedSessions/);
+	assert.doesNotMatch(scanSource, /const transitioned = await update\.executeTakeFirst\(\)/);
+	assert.match(scanSource, /const sessionTransition = sql/);
+	assert.match(scanSource, /executeBatch\(env, \[sessionTransition, policyTransition\]\)/);
+	assert.match(scanSource, /executeBatch\(env, \[ownerTransition, policyTransition\]\)/);
+	assert.match(scanSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
+	assert.match(scanSource, /AND status IS \$\{row\.session_status\}/);
+	assert.match(scanSource, /AND lease_id IS \$\{row\.session_lease_id\}/);
+	assert.match(scanSource, /AND agent_token_hash IS \$\{row\.session_agent_token_hash\}/);
+	assert.match(scanSource, /standalone\.ownership_claim AS standalone_claim/);
+	assert.match(scanSource, /AND updated_at IS \$\{row\.session_updated_at\}/);
+	assert.match(scanSource, /\.where\("sandbox_id", "=", row\.sandbox_id\)/);
+	assert.match(scanSource, /\.where\("lookup_id", "=", row\.lookup_id\)/);
+	assert.match(
+		scanSource,
+		/\.where\("registration_generation", "=", row\.registration_generation\)/,
+	);
+	assert.match(scanSource, /terminal_failure_reason = CASE/);
+	assert.match(scanSource, /credential_cleanup_terminal_status = 'failed'/);
+	assert.match(scanSource, /credential_cleanup_terminal_status = 'expired'/);
+	assert.match(scanSource, /const transitionRevision = Math\.max/);
+	assert.match(scanSource, /agent_token_hash = NULL/);
+	assert.match(scanSource, /credentialPolicySandboxIsExpected/);
+	assert.match(scanSource, /sandbox_refresh_claim = NULL/);
+	assert.match(scanSource, /normalizeCredentialPolicyCleanupGroups/);
+	assert.match(scanSource, /group_max_session_id/);
+	assert.match(batchSource, /scanCredentialPolicyCleanupPage/);
+	assert.match(batchSource, /normalizeCredentialPolicyCleanupGroups/);
+	assert.match(batchSource, /COALESCE\(last_attempt_at, created_at\)/);
+	assert.match(batchSource, /\.limit\(credentialPolicyCleanupLimit\)/);
+	assert.match(batchSource, /completeStandaloneSandboxProvisionCleanupSafely/);
+	assert.match(cleanupSource, /cleanup_claim_expires_at/);
+	assert.match(cleanupSource, /registration_claim_expires_at > \$\{now\}/);
+	assert.match(cleanupSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
+	assert.ok(
+		cleanupSource.indexOf("cleanup_claim = ${claim}") <
+			cleanupSource.indexOf("unregisterSandboxCredentialPolicyLookup"),
+	);
+	assert.match(cleanupSource, /last_error:/);
+	assert.match(cleanupSource, /cleanup_claim: null/);
+	assert.match(cleanupSource, /async function completeStandaloneSandboxProvisionCleanupSafely/);
+	assert.match(cleanupSource, /standalone Sandbox cleanup pending/);
+	assert.match(cleanupSource, /standalone_sandbox_provisions/);
+	assert.match(cleanupSource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
+	assert.match(cleanupSource, /cleanup failure persistence failed/);
+	assert.match(completionSource, /NOT EXISTS \(/);
+	assert.match(completionSource, /status: terminalStatus/);
+	assert.match(completionSource, /terminal_finalize_pending: 1/);
+	assert.match(completionSource, /MAX\(updated_at \+ 1, \$\{now\}\)/);
+	assert.match(completionSource, /\.where\("status", "=", session\.status\)/);
+	assert.match(completionSource, /\.where\("updated_at", "=", session\.updated_at\)/);
+	assert.match(completionSource, /retainedRuntimeAdapterFailureMessage/);
+	assert.match(completionSource, /terminal_failure_reason:/);
+	assert.match(completionSource, /\? failureMessage/);
+	assert.match(batchSource, /completeCredentialPolicyCleanupSession\(env, session\.id/);
+	assert.ok(
+		provisionSource.indexOf("stageTerminalCredentialPolicyCleanupById") <
+			provisionSource.indexOf("reconcileCredentialPolicyCleanupBatch"),
+	);
+	assert.match(provisionSource, /failureAt,\s*cleanupMessage,\s*ownershipFence/);
+	assert.match(provisionSource, /try \{[\s\S]*sandboxProvisionPreflightError\(env, session\)/);
+	assert.match(provisionSource, /!agentToken/);
+	assert.match(provisionSource, /managed Sandbox agent token is unavailable/);
+	assert.match(registrationLifecycleSource, /registration_generation/);
+	assert.match(registrationLifecycleSource, /registration_claim/);
+	assert.match(registrationLifecycleSource, /registration_claim_expires_at/);
+	assert.doesNotMatch(registrationLifecycleSource, /ownershipFence\?:/);
+	assert.doesNotMatch(registrationLifecycleSource, /1 = 1/);
+	assert.match(registrationLifecycleSource, /sandboxCredentialPolicyOwnerCondition/);
+	assert.match(registrationLifecycleSource, /sandboxCredentialPolicyOwnerCondition/);
+	assert.ok(
+		registerSource.indexOf("beginSandboxCredentialPolicyRegistration") <
+			registerSource.indexOf(
+				'stub.fetch("https://crabfleet.internal/api/session-control/register"',
+			),
+	);
+	assert.ok(
+		registerSource.indexOf("renewSandboxCredentialPolicyRegistration") <
+			registerSource.indexOf(
+				'stub.fetch("https://crabfleet.internal/api/session-control/register"',
+			),
+	);
+	assert.ok(
+		registerSource.indexOf('stub.fetch("https://crabfleet.internal/api/session-control/register"') <
+			registerSource.indexOf("finishSandboxCredentialPolicyRegistration"),
+	);
+	assert.doesNotMatch(finishSource, /INSERT INTO|insertInto/);
+	assert.match(finishSource, /state: "active"/);
+	assert.match(finishSource, /where\(sandboxCredentialPolicyOwnerCondition/);
+	assert.doesNotMatch(finishSource, /cleanup_pending/);
+	assert.match(registerSource, /abandonSandboxCredentialPolicyRegistration/);
+	assert.match(abandonSource, /sandboxCredentialPolicyCleanupAuthorizedCondition/);
+	assert.match(abandonSource, /THEN 'cleanup_pending'/);
+	assert.match(abandonSource, /ELSE 'registering'/);
+	assert.ok(
+		scanDecisionSource.indexOf("sandboxExpected") <
+			scanDecisionSource.indexOf("if (registrationAbandoned) return true"),
+	);
+	assert.doesNotMatch(scanDecisionSource, /row\.session_agent_token_hash !== null/);
+	assert.match(scanDecisionSource, /sandboxExpected &&[\s\S]*row\.session_status === "ready"/);
+	assert.match(controlSource, /sandboxPolicyTombstoneKey/);
+	assert.match(controlSource, /credentialPolicyRegistrationAccepted/);
+	assert.match(controlSource, /credentialPolicyCleanupMatches/);
+	assert.match(controlSource, /this\.ctx\.storage\.transaction/);
+	assert.doesNotMatch(source, /async function unregisterSandboxCredentialPolicy\(/);
+	assert.match(migration, /CREATE TABLE IF NOT EXISTS interactive_session_credential_policies/);
+	assert.match(migration, /state IN \('registering', 'active', 'cleanup_pending'\)/);
+	assert.match(migration, /registration_generation TEXT NOT NULL/);
+	assert.match(migration, /registration_claim_expires_at INTEGER/);
+	assert.match(migration, /CREATE TABLE IF NOT EXISTS credential_policy_reconcile_state/);
+	assert.match(migration, /scan_max_rowid INTEGER NOT NULL/);
+	assert.match(migration, /group_max_session_id TEXT NOT NULL/);
+	assert.match(migration, /ADD COLUMN sandbox_refresh_sandbox_id TEXT/);
+	assert.match(migration, /ADD COLUMN sandbox_refresh_claim TEXT/);
+	assert.match(migration, /ADD COLUMN sandbox_refresh_claim_expires_at INTEGER/);
+	assert.match(migration, /CREATE TABLE IF NOT EXISTS standalone_sandbox_provisions/);
+	assert.match(migration, /idx_interactive_policy_fair_cleanup/);
+	assert.match(migration, /COALESCE\(last_attempt_at, created_at\)/);
+	assert.match(migration, /terminal_failure_reason = CASE/);
+	assert.match(migration, /terminal_finalize_pending = 0/);
+	assert.match(migration, /agent_token_hash = NULL/);
+	assert.match(migration, /SET\s+status = 'stopping'/);
+	assert.match(refreshSource, /sandbox_refresh_sandbox_id: refreshFence\.sandboxId/);
+	assert.match(refreshSource, /sandbox_refresh_claim: refreshFence\.claim/);
+	assert.match(refreshSource, /sandbox_refresh_claim_expires_at: refreshFence\.expiresAt/);
+	assert.match(refreshSource, /const agentToken = newAgentToken\(\)/);
+	assert.ok(
+		refreshSource.indexOf("sandboxProvisionPreflightError(env, refreshPayload)") <
+			refreshSource.indexOf("const agentToken = newAgentToken()"),
+	);
+	assert.match(refreshSource, /agent_token_hash: agentTokenHash/);
+	assert.match(refreshSource, /provisionWithSandbox\([\s\S]*?agentToken,[\s\S]*?refreshLease/);
+	assert.match(refreshSource, /where\("agent_token_hash", "=", agentTokenHash\)/);
+	assert.match(refreshSource, /sandbox_refresh_claim_expires_at", "=", refreshFence\.expiresAt/);
+	assert.match(refreshSource, /executeBatch\(env, commitQueries\)/);
+	assert.match(refreshSource, /state: "cleanup_pending"/);
+	assert.match(refreshSource, /stageFailedManagedSandboxProvision/);
+	assert.ok(
+		refreshSource.indexOf("sandbox_refresh_claim: null") <
+			refreshSource.lastIndexOf("reconcileCredentialPolicyCleanupBatch"),
+	);
+	assert.doesNotMatch(
+		refreshSource,
+		/queueSandboxCredentialPolicyCleanup\(env, session\.id, oldSandboxId, refreshedAt\)/,
+	);
+	assert.match(refreshSource, /const current = await readInteractiveSession/);
 });
 
 test("terminal endpoints enforce current runtime capabilities", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const decorateStart = source.indexOf("function decorateInteractiveSession");
-  const decorateEnd = source.indexOf(
-    "function canChangeInteractiveSessionMultiplayer",
-    decorateStart,
-  );
-  const decorateSource = source.slice(decorateStart, decorateEnd);
-  const directPtyStart = source.indexOf("async function interactiveSessionPty");
-  const directPtyEnd = source.indexOf("async function interactiveSandboxTerminal", directPtyStart);
-  const directPtySource = source.slice(directPtyStart, directPtyEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const decorateStart = source.indexOf("function decorateInteractiveSession");
+	const decorateEnd = source.indexOf(
+		"function canChangeInteractiveSessionMultiplayer",
+		decorateStart,
+	);
+	const decorateSource = source.slice(decorateStart, decorateEnd);
+	const directPtyStart = source.indexOf("async function interactiveSessionPty");
+	const directPtyEnd = source.indexOf("async function interactiveSandboxTerminal", directPtyStart);
+	const directPtySource = source.slice(directPtyStart, directPtyEnd);
 
-  assert.match(source, /type InteractiveSession = \{[\s\S]*ptyAvailable\?: boolean;/);
-  assert.match(source, /if \(!session\.capabilities\.terminal\)/);
-  assert.match(source, /runtimeCapabilities\(row\.runtime, row\.capabilities_json\)\.terminal/);
-  assert.match(source, /runtimeAdapterTerminalFailureStatus\(existing\.adapter\) === "detached"/);
-  assert.match(source, /attachUrl: capabilities\.terminal \? row\.attach_url : null/);
-  assert.match(decorateSource, /const routeKind = interactivePtyRouteKind\(env, session\)/);
-  assert.match(decorateSource, /interactiveTerminalTarget\(env, session, routeKind\)/);
-  assert.match(decorateSource, /routeAvailable/);
-  assert.match(
-    decorateSource,
-    /const proxyManagedTerminal =[\s\S]*session\.runtime === githubActionsRuntime \|\|[\s\S]*session\.adapter === runtimeAdapterName/,
-  );
-  assert.match(
-    decorateSource,
-    /const attachUrl = proxyManagedTerminal[\s\S]*\? ptyAvailable[\s\S]*`\/api\/interactive-sessions\/\$\{encodeURIComponent\(session\.id\)\}\/pty`[\s\S]*: null/,
-  );
-  assert.match(directPtySource, /session\.runtime === githubActionsRuntime/);
-  assert.match(directPtySource, /openInteractiveTerminalUpstream\(/);
-  assert.match(decorateSource, /attachUrl,/);
-  assert.doesNotMatch(
-    decorateSource,
-    /attachUrl: canControl && session\.capabilities\.terminal \? session\.attachUrl : null/,
-  );
+	assert.match(source, /type InteractiveSession = \{[\s\S]*ptyAvailable\?: boolean;/);
+	assert.match(source, /if \(!session\.capabilities\.terminal\)/);
+	assert.match(source, /runtimeCapabilities\(row\.runtime, row\.capabilities_json\)\.terminal/);
+	assert.match(source, /runtimeAdapterTerminalFailureStatus\(existing\.adapter\) === "detached"/);
+	assert.match(source, /attachUrl: capabilities\.terminal \? row\.attach_url : null/);
+	assert.match(decorateSource, /const routeKind = interactivePtyRouteKind\(env, session\)/);
+	assert.match(decorateSource, /interactiveTerminalTarget\(env, session, routeKind\)/);
+	assert.match(decorateSource, /routeAvailable/);
+	assert.match(
+		decorateSource,
+		/const proxyManagedTerminal =[\s\S]*session\.runtime === githubActionsRuntime \|\|[\s\S]*session\.adapter === runtimeAdapterName/,
+	);
+	assert.match(
+		decorateSource,
+		/const attachUrl = proxyManagedTerminal[\s\S]*\? ptyAvailable[\s\S]*`\/api\/interactive-sessions\/\$\{encodeURIComponent\(session\.id\)\}\/pty`[\s\S]*: null/,
+	);
+	assert.match(directPtySource, /session\.runtime === githubActionsRuntime/);
+	assert.match(directPtySource, /openInteractiveTerminalUpstream\(/);
+	assert.match(decorateSource, /attachUrl,/);
+	assert.doesNotMatch(
+		decorateSource,
+		/attachUrl: canControl && session\.capabilities\.terminal \? session\.attachUrl : null/,
+	);
 });
 
 test("non-retryable adapter client errors do not enter ambiguous replay", () => {
-  assert.equal(definitiveRuntimeAdapterCreateFailure(413), true);
-  assert.equal(definitiveRuntimeAdapterCreateFailure(415), true);
-  assert.equal(definitiveRuntimeAdapterCreateFailure(422), true);
-  assert.equal(definitiveRuntimeAdapterCreateFailure(408), false);
-  assert.equal(definitiveRuntimeAdapterCreateFailure(409), false);
-  assert.equal(definitiveRuntimeAdapterCreateFailure(423), false);
-  assert.equal(definitiveRuntimeAdapterCreateFailure(425), false);
-  assert.equal(definitiveRuntimeAdapterCreateFailure(429), false);
-  assert.equal(definitiveRuntimeAdapterCreateFailure(503), false);
+	assert.equal(definitiveRuntimeAdapterCreateFailure(413), true);
+	assert.equal(definitiveRuntimeAdapterCreateFailure(415), true);
+	assert.equal(definitiveRuntimeAdapterCreateFailure(422), true);
+	assert.equal(definitiveRuntimeAdapterCreateFailure(408), false);
+	assert.equal(definitiveRuntimeAdapterCreateFailure(409), false);
+	assert.equal(definitiveRuntimeAdapterCreateFailure(423), false);
+	assert.equal(definitiveRuntimeAdapterCreateFailure(425), false);
+	assert.equal(definitiveRuntimeAdapterCreateFailure(429), false);
+	assert.equal(definitiveRuntimeAdapterCreateFailure(503), false);
 });
 
 test("explicit workspace id conflicts are distinct from retryable 409 responses", () => {
-  assert.equal(
-    runtimeAdapterWorkspaceIdConflict(409, {
-      error: { code: "workspace_id_conflict", message: "workspace id is already owned" },
-    }),
-    true,
-  );
-  assert.equal(runtimeAdapterWorkspaceIdConflict(409, { error: { code: "busy" } }), false);
-  assert.equal(
-    runtimeAdapterWorkspaceIdConflict(422, { error: { code: "workspace_id_conflict" } }),
-    false,
-  );
+	assert.equal(
+		runtimeAdapterWorkspaceIdConflict(409, {
+			error: { code: "workspace_id_conflict", message: "workspace id is already owned" },
+		}),
+		true,
+	);
+	assert.equal(runtimeAdapterWorkspaceIdConflict(409, { error: { code: "busy" } }), false);
+	assert.equal(
+		runtimeAdapterWorkspaceIdConflict(422, { error: { code: "workspace_id_conflict" } }),
+		false,
+	);
 });
 
 test("workspace id conflicts detach without adopting or deleting the existing workspace", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const createStart = source.indexOf("async function provisionWithRuntimeAdapter");
-  const createEnd = source.indexOf("function persistedRuntimeAdapterSeconds", createStart);
-  const createSource = source.slice(createStart, createEnd);
-  const conflictStart = source.indexOf("async function failRuntimeAdapterWorkspaceIdConflict");
-  const conflictEnd = source.indexOf(
-    "async function releaseFailedRuntimeAdapterProvision",
-    conflictStart,
-  );
-  const conflictSource = source.slice(conflictStart, conflictEnd);
-  const stageStart = source.indexOf("async function stageRuntimeAdapterProvision");
-  const stageEnd = source.indexOf("function ambiguousRuntimeAdapterProvision", stageStart);
-  const stageSource = source.slice(stageStart, stageEnd);
-  const stoppingReplayStart = source.indexOf("async function replayStoppingRuntimeAdapterCreate");
-  const stoppingReplayEnd = source.indexOf(
-    "async function stopRuntimeAdapterWorkspace(",
-    stoppingReplayStart,
-  );
-  const stoppingReplaySource = source.slice(stoppingReplayStart, stoppingReplayEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const createStart = source.indexOf("async function provisionWithRuntimeAdapter");
+	const createEnd = source.indexOf("function persistedRuntimeAdapterSeconds", createStart);
+	const createSource = source.slice(createStart, createEnd);
+	const conflictStart = source.indexOf("async function failRuntimeAdapterWorkspaceIdConflict");
+	const conflictEnd = source.indexOf(
+		"async function releaseFailedRuntimeAdapterProvision",
+		conflictStart,
+	);
+	const conflictSource = source.slice(conflictStart, conflictEnd);
+	const stageStart = source.indexOf("async function stageRuntimeAdapterProvision");
+	const stageEnd = source.indexOf("function ambiguousRuntimeAdapterProvision", stageStart);
+	const stageSource = source.slice(stageStart, stageEnd);
+	const stoppingReplayStart = source.indexOf("async function replayStoppingRuntimeAdapterCreate");
+	const stoppingReplayEnd = source.indexOf(
+		"async function stopRuntimeAdapterWorkspace(",
+		stoppingReplayStart,
+	);
+	const stoppingReplaySource = source.slice(stoppingReplayStart, stoppingReplayEnd);
 
-  assert.ok(
-    createSource.indexOf("runtimeAdapterWorkspaceIdConflict") <
-      createSource.indexOf("definitiveRuntimeAdapterCreateFailure"),
-  );
-  assert.match(createSource, /failRuntimeAdapterWorkspaceIdConflict/);
-  assert.match(
-    createSource,
-    /throw conflict\("runtime adapter workspace conflict response is stale"\)/,
-  );
-  assert.match(stageSource, /updated_at: sql<number>`MAX\(updated_at \+ 1, \$\{stageAt\}\)`/);
-  assert.match(
-    stageSource,
-    /returning\(\["status", "updated_at", "last_reconciled_at", "terminal_status"\]\)/,
-  );
-  assert.match(stageSource, /last_reconciled_at", "=", reconciliationOwner\.lastReconciledAt/);
-  assert.match(conflictSource, /adapter: null/);
-  assert.match(conflictSource, /adapter_workspace_id: null/);
-  assert.match(conflictSource, /adapter_control_plane: null/);
-  assert.match(conflictSource, /adapter_create_payload_json: null/);
-  assert.match(conflictSource, /adapter_create_pending: 0/);
-  assert.match(conflictSource, /AND adapter_create_pending = 1/);
-  assert.match(conflictSource, /AND status = \$\{createAttempt\.status\}/);
-  assert.match(conflictSource, /AND updated_at = \$\{createAttempt\.updatedAt\}/);
-  assert.match(conflictSource, /AND \$\{lastReconciledOwner\}/);
-  assert.match(conflictSource, /AND \$\{terminalStatusOwner\}/);
-  assert.match(conflictSource, /if \(!results\.at\(-1\)\?\.results\.length\) return null/);
-  assert.match(conflictSource, /terminal_finalize_pending: 1/);
-  assert.match(conflictSource, /env\.DB\.batch/);
-  assert.match(
-    conflictSource,
-    /finalizeTerminalInteractiveSession\(env, session\.id, "failed", now\)/,
-  );
-  assert.doesNotMatch(conflictSource, /stopRuntimeAdapterWorkspace/);
-  assert.match(stoppingReplaySource, /runtimeAdapterWorkspaceIdConflict/);
-  assert.match(stoppingReplaySource, /terminalResult/);
-  assert.doesNotMatch(stoppingReplaySource, /definitiveRuntimeAdapterCreateFailure/);
+	assert.ok(
+		createSource.indexOf("runtimeAdapterWorkspaceIdConflict") <
+			createSource.indexOf("definitiveRuntimeAdapterCreateFailure"),
+	);
+	assert.match(createSource, /failRuntimeAdapterWorkspaceIdConflict/);
+	assert.match(
+		createSource,
+		/throw conflict\("runtime adapter workspace conflict response is stale"\)/,
+	);
+	assert.match(stageSource, /updated_at: sql<number>`MAX\(updated_at \+ 1, \$\{stageAt\}\)`/);
+	assert.match(
+		stageSource,
+		/returning\(\["status", "updated_at", "last_reconciled_at", "terminal_status"\]\)/,
+	);
+	assert.match(stageSource, /last_reconciled_at", "=", reconciliationOwner\.lastReconciledAt/);
+	assert.match(conflictSource, /adapter: null/);
+	assert.match(conflictSource, /adapter_workspace_id: null/);
+	assert.match(conflictSource, /adapter_control_plane: null/);
+	assert.match(conflictSource, /adapter_create_payload_json: null/);
+	assert.match(conflictSource, /adapter_create_pending: 0/);
+	assert.match(conflictSource, /AND adapter_create_pending = 1/);
+	assert.match(conflictSource, /AND status = \$\{createAttempt\.status\}/);
+	assert.match(conflictSource, /AND updated_at = \$\{createAttempt\.updatedAt\}/);
+	assert.match(conflictSource, /AND \$\{lastReconciledOwner\}/);
+	assert.match(conflictSource, /AND \$\{terminalStatusOwner\}/);
+	assert.match(conflictSource, /if \(!results\.at\(-1\)\?\.results\.length\) return null/);
+	assert.match(conflictSource, /terminal_finalize_pending: 1/);
+	assert.match(conflictSource, /env\.DB\.batch/);
+	assert.match(
+		conflictSource,
+		/finalizeTerminalInteractiveSession\(env, session\.id, "failed", now\)/,
+	);
+	assert.doesNotMatch(conflictSource, /stopRuntimeAdapterWorkspace/);
+	assert.match(stoppingReplaySource, /runtimeAdapterWorkspaceIdConflict/);
+	assert.match(stoppingReplaySource, /terminalResult/);
+	assert.doesNotMatch(stoppingReplaySource, /definitiveRuntimeAdapterCreateFailure/);
 });
 
 test("definitive adapter create errors retain a redacted provider reason before release", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const createStart = source.indexOf("async function provisionWithRuntimeAdapter");
-  const createEnd = source.indexOf("function persistedRuntimeAdapterSeconds", createStart);
-  const createSource = source.slice(createStart, createEnd);
-  const replayStart = source.indexOf("async function replayStoppingRuntimeAdapterCreate");
-  const replayEnd = source.indexOf("async function stopRuntimeAdapterWorkspace", replayStart);
-  const replaySource = source.slice(replayStart, replayEnd);
-  const releaseStart = source.indexOf("async function releaseFailedRuntimeAdapterProvision");
-  const releaseEnd = source.indexOf(
-    "async function persistRuntimeAdapterStopEvidence",
-    releaseStart,
-  );
-  const releaseSource = source.slice(releaseStart, releaseEnd);
-  const bodyStart = source.indexOf("async function readRuntimeAdapterResponseBody");
-  const bodyEnd = source.indexOf("function runtimeAdapterToken", bodyStart);
-  const bodySource = source.slice(bodyStart, bodyEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const createStart = source.indexOf("async function provisionWithRuntimeAdapter");
+	const createEnd = source.indexOf("function persistedRuntimeAdapterSeconds", createStart);
+	const createSource = source.slice(createStart, createEnd);
+	const replayStart = source.indexOf("async function replayStoppingRuntimeAdapterCreate");
+	const replayEnd = source.indexOf("async function stopRuntimeAdapterWorkspace", replayStart);
+	const replaySource = source.slice(replayStart, replayEnd);
+	const releaseStart = source.indexOf("async function releaseFailedRuntimeAdapterProvision");
+	const releaseEnd = source.indexOf(
+		"async function persistRuntimeAdapterStopEvidence",
+		releaseStart,
+	);
+	const releaseSource = source.slice(releaseStart, releaseEnd);
+	const bodyStart = source.indexOf("async function readRuntimeAdapterResponseBody");
+	const bodyEnd = source.indexOf("function runtimeAdapterToken", bodyStart);
+	const bodySource = source.slice(bodyStart, bodyEnd);
 
-  const bodyReadIndex = createSource.indexOf(
-    "responseBody = await readRuntimeAdapterResponseBody(response)",
-  );
-  assert.ok(bodyReadIndex >= 0 && bodyReadIndex < createSource.indexOf("if (!response.ok)"));
-  assert.match(createSource, /redactedAdapterResponseMessage/);
-  assert.match(createSource, /runtime adapter provision failed: \$\{responseMessage\}/);
-  assert.match(createSource, /releaseFailedRuntimeAdapterProvision/);
-  assert.doesNotMatch(createSource, /response\.json/);
-  assert.match(replaySource, /readRuntimeAdapterResponseBody\(response\)/);
-  assert.match(replaySource, /redactedAdapterResponseMessage/);
-  assert.match(replaySource, /reconcile_error: message/);
-  assert.match(replaySource, /INSERT INTO interactive_session_events/);
-  assert.doesNotMatch(replaySource, /response\.json/);
-  assert.ok(
-    releaseSource.indexOf("stageFailedRuntimeAdapterRelease") <
-      releaseSource.indexOf("stopRuntimeAdapterWorkspaceForSession"),
-  );
-  assert.match(bodySource, /await readBoundedResponseText\(response\)/);
-  assert.doesNotMatch(bodySource, /response\.(?:json|text)\(/);
-  assert.match(bodySource, /JSON\.parse\(body\)/);
-  assert.equal(
-    redactedAdapterResponseMessage(
-      { detail: "capacity unavailable; token=private-value" },
-      "HTTP 422",
-    ),
-    "capacity unavailable; [credential]",
-  );
-  const opaqueErrorIds = ["provider-body", "provider-workspace", "provider-error"];
-  const opaqueErrorMessage = redactedAdapterResponseMessage(
-    {
-      providerResourceId: opaqueErrorIds[0],
-      workspace: { provider_resource_id: opaqueErrorIds[1] },
-      error: {
-        leaseId: opaqueErrorIds[2],
-        message: `failed ${opaqueErrorIds.join(" ")}`,
-      },
-    },
-    "HTTP 422",
-  );
-  assert.equal(opaqueErrorMessage, "failed [workspace] [workspace] [workspace]");
-  for (const identifier of opaqueErrorIds) {
-    assert.doesNotMatch(opaqueErrorMessage, new RegExp(identifier));
-  }
+	const bodyReadIndex = createSource.indexOf(
+		"responseBody = await readRuntimeAdapterResponseBody(response)",
+	);
+	assert.ok(bodyReadIndex >= 0 && bodyReadIndex < createSource.indexOf("if (!response.ok)"));
+	assert.match(createSource, /redactedAdapterResponseMessage/);
+	assert.match(createSource, /runtime adapter provision failed: \$\{responseMessage\}/);
+	assert.match(createSource, /releaseFailedRuntimeAdapterProvision/);
+	assert.doesNotMatch(createSource, /response\.json/);
+	assert.match(replaySource, /readRuntimeAdapterResponseBody\(response\)/);
+	assert.match(replaySource, /redactedAdapterResponseMessage/);
+	assert.match(replaySource, /reconcile_error: message/);
+	assert.match(replaySource, /INSERT INTO interactive_session_events/);
+	assert.doesNotMatch(replaySource, /response\.json/);
+	assert.ok(
+		releaseSource.indexOf("stageFailedRuntimeAdapterRelease") <
+			releaseSource.indexOf("stopRuntimeAdapterWorkspaceForSession"),
+	);
+	assert.match(bodySource, /await readBoundedResponseText\(response\)/);
+	assert.doesNotMatch(bodySource, /response\.(?:json|text)\(/);
+	assert.match(bodySource, /JSON\.parse\(body\)/);
+	assert.equal(
+		redactedAdapterResponseMessage(
+			{ detail: "capacity unavailable; token=private-value" },
+			"HTTP 422",
+		),
+		"capacity unavailable; [credential]",
+	);
+	const opaqueErrorIds = ["provider-body", "provider-workspace", "provider-error"];
+	const opaqueErrorMessage = redactedAdapterResponseMessage(
+		{
+			providerResourceId: opaqueErrorIds[0],
+			workspace: { provider_resource_id: opaqueErrorIds[1] },
+			error: {
+				leaseId: opaqueErrorIds[2],
+				message: `failed ${opaqueErrorIds.join(" ")}`,
+			},
+		},
+		"HTTP 422",
+	);
+	assert.equal(opaqueErrorMessage, "failed [workspace] [workspace] [workspace]");
+	for (const identifier of opaqueErrorIds) {
+		assert.doesNotMatch(opaqueErrorMessage, new RegExp(identifier));
+	}
 });
 
 test("successful DELETE requires an implicit or parsed release confirmation", () => {
-  const ready = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "ready" });
-  const stopped = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "stopped" });
-  const wrong = parseAdapterWorkspaceResult({ id: "fleet-b-is-101", status: "stopped" });
-  assert.equal(runtimeAdapterStopOutcome(200, null, "fleet-a-is-101"), "stopping");
-  assert.equal(runtimeAdapterStopOutcome(202, null, "fleet-a-is-101"), "stopping");
-  assert.equal(runtimeAdapterStopOutcome(200, ready, "fleet-a-is-101"), "stopping");
-  assert.equal(runtimeAdapterStopOutcome(200, stopped, "fleet-a-is-101"), "stopped");
-  assert.equal(runtimeAdapterStopOutcome(204, null, "fleet-a-is-101"), "stopped");
-  assert.equal(runtimeAdapterStopOutcome(200, wrong, "fleet-a-is-101"), "identity_mismatch");
+	const ready = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "ready" });
+	const stopped = parseAdapterWorkspaceResult({ id: "fleet-a-is-101", status: "stopped" });
+	const wrong = parseAdapterWorkspaceResult({ id: "fleet-b-is-101", status: "stopped" });
+	assert.equal(runtimeAdapterStopOutcome(200, null, "fleet-a-is-101"), "stopping");
+	assert.equal(runtimeAdapterStopOutcome(202, null, "fleet-a-is-101"), "stopping");
+	assert.equal(runtimeAdapterStopOutcome(200, ready, "fleet-a-is-101"), "stopping");
+	assert.equal(runtimeAdapterStopOutcome(200, stopped, "fleet-a-is-101"), "stopped");
+	assert.equal(runtimeAdapterStopOutcome(204, null, "fleet-a-is-101"), "stopped");
+	assert.equal(runtimeAdapterStopOutcome(200, wrong, "fleet-a-is-101"), "identity_mismatch");
 });
 
 test("adapter DELETE evidence survives pending and confirmed release", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const deleteStart = source.indexOf("async function stopRuntimeAdapterWorkspace(");
-  const deleteEnd = source.indexOf("async function runtimeAdapterFetch", deleteStart);
-  const deleteSource = source.slice(deleteStart, deleteEnd);
-  const reconcileStart = source.indexOf("async function reconcileStoppingRuntimeAdapterWorkspace");
-  const reconcileEnd = source.indexOf("type StoppingRuntimeAdapterReplay", reconcileStart);
-  const reconcileSource = source.slice(reconcileStart, reconcileEnd);
-  const releaseStart = source.indexOf("async function recordConfirmedRuntimeAdapterRelease");
-  const releaseEnd = source.indexOf(
-    "async function clearRuntimeAdapterCreatePending",
-    releaseStart,
-  );
-  const releaseSource = source.slice(releaseStart, releaseEnd);
-  const failedReleaseStart = source.indexOf("async function releaseFailedRuntimeAdapterProvision");
-  const failedReleaseEnd = source.indexOf(
-    "async function stageFailedRuntimeAdapterRelease",
-    failedReleaseStart,
-  );
-  const failedReleaseSource = source.slice(failedReleaseStart, failedReleaseEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const deleteStart = source.indexOf("async function stopRuntimeAdapterWorkspace(");
+	const deleteEnd = source.indexOf("async function runtimeAdapterFetch", deleteStart);
+	const deleteSource = source.slice(deleteStart, deleteEnd);
+	const reconcileStart = source.indexOf("async function reconcileStoppingRuntimeAdapterWorkspace");
+	const reconcileEnd = source.indexOf("type StoppingRuntimeAdapterReplay", reconcileStart);
+	const reconcileSource = source.slice(reconcileStart, reconcileEnd);
+	const releaseStart = source.indexOf("async function recordConfirmedRuntimeAdapterRelease");
+	const releaseEnd = source.indexOf(
+		"async function clearRuntimeAdapterCreatePending",
+		releaseStart,
+	);
+	const releaseSource = source.slice(releaseStart, releaseEnd);
+	const failedReleaseStart = source.indexOf("async function releaseFailedRuntimeAdapterProvision");
+	const failedReleaseEnd = source.indexOf(
+		"async function stageFailedRuntimeAdapterRelease",
+		failedReleaseStart,
+	);
+	const failedReleaseSource = source.slice(failedReleaseStart, failedReleaseEnd);
 
-  assert.match(deleteSource, /await readRuntimeAdapterResponseBody\(response\)/);
-  assert.doesNotMatch(deleteSource, /response\.json/);
-  assert.match(deleteSource, /redactedAdapterResponseMessage/);
-  assert.match(deleteSource, /return \{ status: "stopped", message \}/);
-  assert.match(deleteSource, /return \{ status: outcome, message \}/);
-  assert.match(reconcileSource, /runtime adapter stop pending: \$\{safeProviderError/);
-  assert.match(reconcileSource, /reconcileError: message/);
-  assert.match(reconcileSource, /release\.message/);
-  assert.match(releaseSource, /retainedReleaseMessage/);
-  assert.match(releaseSource, /env\.DB\.batch/);
-  assert.match(releaseSource, /INSERT INTO interactive_session_events/);
-  assert.match(releaseSource, /terminal_finalize_pending: 1/);
-  assert.match(failedReleaseSource, /persistRuntimeAdapterStopEvidence/);
-  assert.match(failedReleaseSource, /await executeBatch\(env, \[/);
-  assert.match(failedReleaseSource, /INSERT INTO interactive_session_events/);
-  assert.match(failedReleaseSource, /AND NOT EXISTS/);
+	assert.match(deleteSource, /await readRuntimeAdapterResponseBody\(response\)/);
+	assert.doesNotMatch(deleteSource, /response\.json/);
+	assert.match(deleteSource, /redactedAdapterResponseMessage/);
+	assert.match(deleteSource, /return \{ status: "stopped", message \}/);
+	assert.match(deleteSource, /return \{ status: outcome, message \}/);
+	assert.match(reconcileSource, /runtime adapter stop pending: \$\{safeProviderError/);
+	assert.match(reconcileSource, /reconcileError: message/);
+	assert.match(reconcileSource, /release\.message/);
+	assert.match(releaseSource, /retainedReleaseMessage/);
+	assert.match(releaseSource, /env\.DB\.batch/);
+	assert.match(releaseSource, /INSERT INTO interactive_session_events/);
+	assert.match(releaseSource, /terminal_finalize_pending: 1/);
+	assert.match(failedReleaseSource, /persistRuntimeAdapterStopEvidence/);
+	assert.match(failedReleaseSource, /await executeBatch\(env, \[/);
+	assert.match(failedReleaseSource, /INSERT INTO interactive_session_events/);
+	assert.match(failedReleaseSource, /AND NOT EXISTS/);
 });
 
 test("adapter workspace paths use the controller id and encode it", () => {
-  assert.equal(normalizeAdapterWorkspaceId("IS-101"), "is-101");
-  assert.equal(
-    runtimeAdapterWorkspaceUrl("https://controller.example/base", "session/one"),
-    "https://controller.example/base/v1/workspaces/session%2Fone",
-  );
-  assert.equal(
-    runtimeAdapterDesktopUrl("https://controller.example/base", "is-101"),
-    "https://controller.example/base/v1/workspaces/is-101/connections/desktop",
-  );
-  assert.equal(
-    runtimeAdapterBrowserVncUrl("https://fleet.example", "IS/101"),
-    "https://fleet.example/api/interactive-sessions/IS%2F101/vnc",
-  );
+	assert.equal(normalizeAdapterWorkspaceId("IS-101"), "is-101");
+	assert.equal(
+		runtimeAdapterWorkspaceUrl("https://controller.example/base", "session/one"),
+		"https://controller.example/base/v1/workspaces/session%2Fone",
+	);
+	assert.equal(
+		runtimeAdapterDesktopUrl("https://controller.example/base", "is-101"),
+		"https://controller.example/base/v1/workspaces/is-101/connections/desktop",
+	);
+	assert.equal(
+		runtimeAdapterBrowserVncUrl("https://fleet.example", "IS/101"),
+		"https://fleet.example/api/interactive-sessions/IS%2F101/vnc",
+	);
 });
 
 test("runtime adapter control-plane identity is canonical and origin-bound", () => {
-  assert.equal(
-    runtimeAdapterControlPlaneIdentity("https://controller.example/api/"),
-    "https://controller.example/api",
-  );
-  assert.equal(
-    runtimeAdapterControlPlaneIdentity("https://controller.example"),
-    "https://controller.example/",
-  );
-  assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api?tenant=a"), null);
-  assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api?"), null);
-  assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api#fragment"), null);
-  assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api#"), null);
-  assert.equal(runtimeAdapterControlPlaneIdentity("http://controller.example/api"), null);
-  assert.equal(
-    runtimeAdapterControlPlaneIdentity("http://127.0.0.1:8788/adapter/"),
-    "http://127.0.0.1:8788/adapter",
-  );
-  assert.equal(
-    runtimeAdapterWorkspaceUrl("https://controller.example/root/adapter", "fleet-is-1"),
-    "https://controller.example/root/adapter/v1/workspaces/fleet-is-1",
-  );
+	assert.equal(
+		runtimeAdapterControlPlaneIdentity("https://controller.example/api/"),
+		"https://controller.example/api",
+	);
+	assert.equal(
+		runtimeAdapterControlPlaneIdentity("https://controller.example"),
+		"https://controller.example/",
+	);
+	assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api?tenant=a"), null);
+	assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api?"), null);
+	assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api#fragment"), null);
+	assert.equal(runtimeAdapterControlPlaneIdentity("https://controller.example/api#"), null);
+	assert.equal(runtimeAdapterControlPlaneIdentity("http://controller.example/api"), null);
+	assert.equal(
+		runtimeAdapterControlPlaneIdentity("http://127.0.0.1:8788/adapter/"),
+		"http://127.0.0.1:8788/adapter",
+	);
+	assert.equal(
+		runtimeAdapterWorkspaceUrl("https://controller.example/root/adapter", "fleet-is-1"),
+		"https://controller.example/root/adapter/v1/workspaces/fleet-is-1",
+	);
 });
 
 test("runtime adapter profile routes expand one allowlisted path segment", () => {
-  assert.equal(
-    runtimeAdapterControlPlaneForProfile(
-      undefined,
-      "https://controller.example/v1/adapters/{profile}/proxy/",
-      "linux-desktop",
-    ),
-    "https://controller.example/v1/adapters/linux-desktop/proxy",
-  );
-  assert.equal(
-    runtimeAdapterControlPlaneForProfile(
-      undefined,
-      "https://controller.example/v1/adapters/{profile}/proxy",
-      "macos-desktop",
-    ),
-    "https://controller.example/v1/adapters/macos-desktop/proxy",
-  );
-  assert.equal(
-    runtimeAdapterControlPlaneForProfile(
-      "https://controller.example/default",
-      undefined,
-      "legacy.profile",
-    ),
-    "https://controller.example/default",
-  );
-  assert.equal(
-    runtimeAdapterControlPlaneForProfile(
-      "https://controller.example/default",
-      "https://controller.example/{profile}",
-      "linux-desktop",
-    ),
-    null,
-  );
-  assert.equal(
-    runtimeAdapterControlPlaneForProfile(
-      undefined,
-      "https://{profile}.controller.example/proxy",
-      "linux-desktop",
-    ),
-    null,
-  );
-  assert.equal(
-    runtimeAdapterControlPlaneForProfile(undefined, "https://{profile}/proxy", "linux-desktop"),
-    null,
-  );
-  assert.equal(
-    runtimeAdapterControlPlaneForProfile(
-      undefined,
-      "https://controller.example/{profile}/proxy?tenant=fleet",
-      "linux-desktop",
-    ),
-    null,
-  );
-  assert.equal(
-    runtimeAdapterControlPlaneForProfile(
-      undefined,
-      "https://controller.example/{profile}/{profile}",
-      "linux-desktop",
-    ),
-    null,
-  );
-  assert.equal(
-    runtimeAdapterControlPlaneForProfile(
-      undefined,
-      "https://controller.example/{profile}/proxy",
-      "macos_desktop",
-    ),
-    null,
-  );
+	assert.equal(
+		runtimeAdapterControlPlaneForProfile(
+			undefined,
+			"https://controller.example/v1/adapters/{profile}/proxy/",
+			"linux-desktop",
+		),
+		"https://controller.example/v1/adapters/linux-desktop/proxy",
+	);
+	assert.equal(
+		runtimeAdapterControlPlaneForProfile(
+			undefined,
+			"https://controller.example/v1/adapters/{profile}/proxy",
+			"macos-desktop",
+		),
+		"https://controller.example/v1/adapters/macos-desktop/proxy",
+	);
+	assert.equal(
+		runtimeAdapterControlPlaneForProfile(
+			"https://controller.example/default",
+			undefined,
+			"legacy.profile",
+		),
+		"https://controller.example/default",
+	);
+	assert.equal(
+		runtimeAdapterControlPlaneForProfile(
+			"https://controller.example/default",
+			"https://controller.example/{profile}",
+			"linux-desktop",
+		),
+		null,
+	);
+	assert.equal(
+		runtimeAdapterControlPlaneForProfile(
+			undefined,
+			"https://{profile}.controller.example/proxy",
+			"linux-desktop",
+		),
+		null,
+	);
+	assert.equal(
+		runtimeAdapterControlPlaneForProfile(undefined, "https://{profile}/proxy", "linux-desktop"),
+		null,
+	);
+	assert.equal(
+		runtimeAdapterControlPlaneForProfile(
+			undefined,
+			"https://controller.example/{profile}/proxy?tenant=fleet",
+			"linux-desktop",
+		),
+		null,
+	);
+	assert.equal(
+		runtimeAdapterControlPlaneForProfile(
+			undefined,
+			"https://controller.example/{profile}/{profile}",
+			"linux-desktop",
+		),
+		null,
+	);
+	assert.equal(
+		runtimeAdapterControlPlaneForProfile(
+			undefined,
+			"https://controller.example/{profile}/proxy",
+			"macos_desktop",
+		),
+		null,
+	);
 });
 
 test("adapter bodies share the bounded stream reader", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const ranges = [
-    ["async function provisionWithRuntimeAdapter", "function persistedRuntimeAdapterSeconds"],
-    [
-      "async function inspectRuntimeAdapterWorkspace",
-      "async function reconcileStoppingRuntimeAdapterWorkspace",
-    ],
-    [
-      "async function replayStoppingRuntimeAdapterCreate",
-      "async function stopRuntimeAdapterWorkspace(",
-    ],
-    ["async function stopRuntimeAdapterWorkspace(", "type RuntimeAdapterStopResult"],
-    ["async function interactiveSessionVnc", "function interactiveTerminalTarget"],
-  ] as const;
-  for (const [startMarker, endMarker] of ranges) {
-    const start = source.indexOf(startMarker);
-    const end = source.indexOf(endMarker, start + startMarker.length);
-    const operation = source.slice(start, end);
-    assert.match(operation, /readRuntimeAdapterResponseBody\(response\)/);
-    assert.doesNotMatch(operation, /response\.(?:json|text)\(/);
-  }
-  const readerStart = source.indexOf("async function readRuntimeAdapterResponseBody");
-  const readerEnd = source.indexOf("function runtimeAdapterToken", readerStart);
-  const readerSource = source.slice(readerStart, readerEnd);
-  assert.match(readerSource, /readBoundedResponseText\(response\)/);
-  assert.doesNotMatch(readerSource, /response\.(?:json|text)\(/);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const ranges = [
+		["async function provisionWithRuntimeAdapter", "function persistedRuntimeAdapterSeconds"],
+		[
+			"async function inspectRuntimeAdapterWorkspace",
+			"async function reconcileStoppingRuntimeAdapterWorkspace",
+		],
+		[
+			"async function replayStoppingRuntimeAdapterCreate",
+			"async function stopRuntimeAdapterWorkspace(",
+		],
+		["async function stopRuntimeAdapterWorkspace(", "type RuntimeAdapterStopResult"],
+		["async function interactiveSessionVnc", "function interactiveTerminalTarget"],
+	] as const;
+	for (const [startMarker, endMarker] of ranges) {
+		const start = source.indexOf(startMarker);
+		const end = source.indexOf(endMarker, start + startMarker.length);
+		const operation = source.slice(start, end);
+		assert.match(operation, /readRuntimeAdapterResponseBody\(response\)/);
+		assert.doesNotMatch(operation, /response\.(?:json|text)\(/);
+	}
+	const readerStart = source.indexOf("async function readRuntimeAdapterResponseBody");
+	const readerEnd = source.indexOf("function runtimeAdapterToken", readerStart);
+	const readerSource = source.slice(readerStart, readerEnd);
+	assert.match(readerSource, /readBoundedResponseText\(response\)/);
+	assert.doesNotMatch(readerSource, /response\.(?:json|text)\(/);
 });
 
 test("desktop mint revalidates current ownership before redirect", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const vncStart = source.indexOf("async function interactiveSessionVnc");
-  const vncEnd = source.indexOf("function interactiveTerminalTarget", vncStart);
-  const vncSource = source.slice(vncStart, vncEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const vncStart = source.indexOf("async function interactiveSessionVnc");
+	const vncEnd = source.indexOf("function interactiveTerminalTarget", vncStart);
+	const vncSource = source.slice(vncStart, vncEnd);
 
-  assert.ok(
-    vncSource.indexOf("currentAdapterDesktopConnection") <
-      vncSource.indexOf("currentRuntimeAdapterDesktopAccess"),
-  );
-  assert.ok(
-    vncSource.indexOf("currentRuntimeAdapterDesktopAccess") <
-      vncSource.indexOf("target = connection.url"),
-  );
-  assert.match(vncSource, /selectFrom\("interactive_sessions"\)/);
-  assert.match(vncSource, /adapter_workspace_id/);
-  assert.match(vncSource, /adapter_control_plane/);
-  assert.match(vncSource, /provider_resource_id/);
-  assert.match(vncSource, /adapter_create_pending/);
-  assert.match(vncSource, /\["ready", "attached", "detached"\]/);
-  assert.match(vncSource, /current\.capabilities\.vnc/);
-  assert.match(vncSource, /current\.capabilities\.desktop/);
-  assert.match(vncSource, /canControlInteractiveSession/);
-  assert.match(vncSource, /desktop authorization changed; retry/);
-  assert.doesNotMatch(vncSource, /body:\s*JSON\.stringify\(\{\}\)/);
+	assert.ok(
+		vncSource.indexOf("currentAdapterDesktopConnection") <
+			vncSource.indexOf("currentRuntimeAdapterDesktopAccess"),
+	);
+	assert.ok(
+		vncSource.indexOf("currentRuntimeAdapterDesktopAccess") <
+			vncSource.indexOf("target = connection.url"),
+	);
+	assert.match(vncSource, /selectFrom\("interactive_sessions"\)/);
+	assert.match(vncSource, /adapter_workspace_id/);
+	assert.match(vncSource, /adapter_control_plane/);
+	assert.match(vncSource, /provider_resource_id/);
+	assert.match(vncSource, /adapter_create_pending/);
+	assert.match(vncSource, /\["ready", "attached", "detached"\]/);
+	assert.match(vncSource, /current\.capabilities\.vnc/);
+	assert.match(vncSource, /current\.capabilities\.desktop/);
+	assert.match(vncSource, /canControlInteractiveSession/);
+	assert.match(vncSource, /desktop authorization changed; retry/);
+	assert.doesNotMatch(vncSource, /body:\s*JSON\.stringify\(\{\}\)/);
 });
 
 test("runtime adapter terminals use the server-side adapter bearer", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
-  const targetStart = source.indexOf("function interactiveTerminalTarget");
-  const targetEnd = source.indexOf("function interactivePtyRouteKind", targetStart);
-  const targetSource = source.slice(targetStart, targetEnd);
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const targetStart = source.indexOf("function interactiveTerminalTarget");
+	const targetEnd = source.indexOf("function interactivePtyRouteKind", targetStart);
+	const targetSource = source.slice(targetStart, targetEnd);
 
-  assert.match(targetSource, /session\.adapter === runtimeAdapterName/);
-  assert.match(targetSource, /session\[interactiveSessionAdapterControlPlane\]/);
-  assert.match(targetSource, /runtimeAdapterTerminalAuthorization/);
-  assert.match(targetSource, /requireRegisteredRuntimeAdapterControlPlane/);
-  assert.match(targetSource, /runtimeAdapterTerminalOriginMatches\(controlPlane, attachUrl\)/);
-  assert.match(targetSource, /bearer\(runtimeAdapterToken\(env\)\)/);
-  assert.doesNotMatch(targetSource, /searchParams\.set\([^)]*(?:token|ticket)/u);
-  const decorateStart = source.indexOf("function decorateInteractiveSession");
-  const decorateEnd = source.indexOf(
-    "function canChangeInteractiveSessionMultiplayer",
-    decorateStart,
-  );
-  const decorateSource = source.slice(decorateStart, decorateEnd);
-  assert.match(decorateSource, /interactiveTerminalTarget\(env, session, routeKind\)/);
-  assert.match(decorateSource, /routeAvailable/);
+	assert.match(targetSource, /session\.adapter === runtimeAdapterName/);
+	assert.match(targetSource, /session\[interactiveSessionAdapterControlPlane\]/);
+	assert.match(targetSource, /runtimeAdapterTerminalAuthorization/);
+	assert.match(targetSource, /requireRegisteredRuntimeAdapterControlPlane/);
+	assert.match(targetSource, /runtimeAdapterTerminalOriginMatches\(controlPlane, attachUrl\)/);
+	assert.match(targetSource, /bearer\(runtimeAdapterToken\(env\)\)/);
+	assert.doesNotMatch(targetSource, /searchParams\.set\([^)]*(?:token|ticket)/u);
+	const decorateStart = source.indexOf("function decorateInteractiveSession");
+	const decorateEnd = source.indexOf(
+		"function canChangeInteractiveSessionMultiplayer",
+		decorateStart,
+	);
+	const decorateSource = source.slice(decorateStart, decorateEnd);
+	assert.match(decorateSource, /interactiveTerminalTarget\(env, session, routeKind\)/);
+	assert.match(decorateSource, /routeAvailable/);
 });
 
 test("runtime adapter terminal flow control stays explicit and end-to-end", async () => {
-  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
 
-  assert.match(source, /frame\.type === TerminalMessageType\.Ack/);
-  assert.match(source, /subscription\.outputAcknowledgements/);
-  assert.match(source, /bytes <= subscription\.outputAcknowledgementBytes/);
-  assert.match(source, /acknowledgedBytes <= rightOutputAcknowledgementBytes/);
-  assert.match(source, /TerminalSubscribeFlags\.OutputAcknowledgements/);
-  assert.match(source, /searchParams\.get\("flow"\) === "ack-v1"/);
-  assert.match(source, /JSON\.stringify\(\{ type: "ack", bytes \}\)/);
-  assert.match(source, /terminalOutputAcknowledgement\(forwarded\)/);
-  assert.match(source, /else if \(upstreamConnection\.outputAcknowledgements\)/);
+	assert.match(source, /frame\.type === TerminalMessageType\.Ack/);
+	assert.match(source, /subscription\.outputAcknowledgements/);
+	assert.match(source, /bytes <= subscription\.outputAcknowledgementBytes/);
+	assert.match(source, /acknowledgedBytes <= rightOutputAcknowledgementBytes/);
+	assert.match(source, /TerminalSubscribeFlags\.OutputAcknowledgements/);
+	assert.match(source, /searchParams\.get\("flow"\) === "ack-v1"/);
+	assert.match(source, /JSON\.stringify\(\{ type: "ack", bytes \}\)/);
+	assert.match(source, /terminalOutputAcknowledgement\(forwarded\)/);
+	assert.match(source, /else if \(upstreamConnection\.outputAcknowledgements\)/);
 });
 
 test("runtime adapter terminal bearer stays on the registered origin", () => {
-  assert.equal(
-    runtimeAdapterTerminalOriginMatches(
-      "https://controller.example/adapter",
-      "wss://controller.example/v1/workspaces/fleet-is-101/terminal",
-    ),
-    true,
-  );
-  assert.equal(
-    runtimeAdapterTerminalOriginMatches(
-      "http://127.0.0.1:8788/adapter",
-      "ws://127.0.0.1:8788/v1/workspaces/fleet-is-101/terminal",
-    ),
-    true,
-  );
-  assert.equal(
-    runtimeAdapterTerminalOriginMatches(
-      "https://controller.example/adapter",
-      "wss://terminal.example/v1/workspaces/fleet-is-101/terminal",
-    ),
-    false,
-  );
-  assert.equal(
-    runtimeAdapterTerminalOriginMatches(
-      "https://controller.example/adapter",
-      "wss://controller.example:8443/v1/workspaces/fleet-is-101/terminal",
-    ),
-    false,
-  );
+	assert.equal(
+		runtimeAdapterTerminalOriginMatches(
+			"https://controller.example/adapter",
+			"wss://controller.example/v1/workspaces/fleet-is-101/terminal",
+		),
+		true,
+	);
+	assert.equal(
+		runtimeAdapterTerminalOriginMatches(
+			"http://127.0.0.1:8788/adapter",
+			"ws://127.0.0.1:8788/v1/workspaces/fleet-is-101/terminal",
+		),
+		true,
+	);
+	assert.equal(
+		runtimeAdapterTerminalOriginMatches(
+			"https://controller.example/adapter",
+			"wss://terminal.example/v1/workspaces/fleet-is-101/terminal",
+		),
+		false,
+	);
+	assert.equal(
+		runtimeAdapterTerminalOriginMatches(
+			"https://controller.example/adapter",
+			"wss://controller.example:8443/v1/workspaces/fleet-is-101/terminal",
+		),
+		false,
+	);
 });
 
 test("desktop redirects require HTTPS or literal loopback HTTP", () => {
-  assert.equal(
-    safeDesktopUrl("https://desktop.example/session"),
-    "https://desktop.example/session",
-  );
-  assert.equal(safeDesktopUrl("http://127.0.0.1:6080/vnc"), "http://127.0.0.1:6080/vnc");
-  assert.equal(safeDesktopUrl("http://localhost:6080/vnc"), "http://localhost:6080/vnc");
-  assert.equal(safeDesktopUrl("http://desktop.example/vnc"), null);
-  assert.equal(safeDesktopUrl("http://2130706433:6080/vnc"), null);
-  assert.equal(safeDesktopUrl("https://user:secret@desktop.example/vnc"), null);
-  assert.equal(safeDesktopUrl("javascript:alert(1)"), null);
-  assert.equal(safeDesktopUrl(" https://desktop.example/vnc"), null);
-  const signed = "https://Desktop.Example:443/%7Edesktop?signature=a%2Bb%2Fc%3D&dup=1&dup=2";
-  assert.equal(safeDesktopUrl(signed), signed);
-  assert.equal(parseAdapterDesktopConnection({ url: signed })?.url, signed);
+	assert.equal(
+		safeDesktopUrl("https://desktop.example/session"),
+		"https://desktop.example/session",
+	);
+	assert.equal(safeDesktopUrl("http://127.0.0.1:6080/vnc"), "http://127.0.0.1:6080/vnc");
+	assert.equal(safeDesktopUrl("http://localhost:6080/vnc"), "http://localhost:6080/vnc");
+	assert.equal(safeDesktopUrl("http://desktop.example/vnc"), null);
+	assert.equal(safeDesktopUrl("http://2130706433:6080/vnc"), null);
+	assert.equal(safeDesktopUrl("https://user:secret@desktop.example/vnc"), null);
+	assert.equal(safeDesktopUrl("javascript:alert(1)"), null);
+	assert.equal(safeDesktopUrl(" https://desktop.example/vnc"), null);
+	const signed = "https://Desktop.Example:443/%7Edesktop?signature=a%2Bb%2Fc%3D&dup=1&dup=2";
+	assert.equal(safeDesktopUrl(signed), signed);
+	assert.equal(parseAdapterDesktopConnection({ url: signed })?.url, signed);
 });
 
 test("terminal URLs require WSS except literal loopback WS", () => {
-  assert.equal(
-    safeWebSocketUrl("wss://terminal.example/session"),
-    "wss://terminal.example/session",
-  );
-  assert.equal(safeWebSocketUrl("ws://localhost:8787/session"), "ws://localhost:8787/session");
-  assert.equal(safeWebSocketUrl("ws://127.0.0.1:8787/session"), "ws://127.0.0.1:8787/session");
-  assert.equal(safeWebSocketUrl("ws://terminal.example/session"), null);
-  assert.equal(safeWebSocketUrl("ws://127.1:8787/session"), null);
-  assert.equal(safeWebSocketUrl("wss://terminal.example/session\n"), null);
-  const signed = "wss://Terminal.Example:443/%7Epty?signature=a%2Bb%2Fc%3D&dup=1&dup=2";
-  assert.equal(safeWebSocketUrl(signed), signed);
-  assert.equal(
-    parseAdapterWorkspaceResult({ status: "ready", attachUrl: signed })?.terminalUrl,
-    signed,
-  );
-  const message = parseAdapterWorkspaceResult({
-    id: "fleet-a-is-101",
-    status: "ready",
-    attachUrl: signed,
-    message: `attach ${signed}; Authorization: Bearer bearer-secret; token=query-secret`,
-  })?.message;
-  assert.equal(message, "attach [connection] [credential]");
-  assert.doesNotMatch(message ?? "", /bearer-secret|query-secret|signature=/u);
-  const slashEscaped = signed.replaceAll("/", "\\/");
-  const nestedEscaped = JSON.stringify(slashEscaped).slice(1, -1);
-  for (const escaped of [slashEscaped, nestedEscaped]) {
-    const redacted = redactedAdapterMessage(`provider terminal ${escaped}`, "failed", [], [signed]);
-    assert.equal(redacted, "provider terminal [connection]");
-    assert.doesNotMatch(redacted, /signature|Terminal\.Example/iu);
-  }
-  for (const arbitrary of [
-    String.raw`failed https:\/\/host.example\/pty?bearer=path-secret`,
-    String.raw`nested {\"detail\":\"wss:\\/\\/host.example\\/pty?token=nested-secret\"}`,
-    String.raw`mixed ws:\/\/host.example\/pty?authorization=Bearer-query-secret`,
-  ]) {
-    const redacted = redactedAdapterMessage(arbitrary, "failed");
-    assert.match(redacted, /\[connection\]/u);
-    assert.doesNotMatch(redacted, /host\.example|path-secret|nested-secret|query-secret/iu);
-  }
-  assert.equal(
-    redactedAdapterResponseMessage(
-      {
-        message: `desktop ${slashEscaped}`,
-        desktopUrl: signed.replace("wss://", "https://"),
-        terminalUrl: signed,
-      },
-      "fallback",
-    ),
-    "desktop [connection]",
-  );
-  assert.equal(
-    redactedAdapterMessage(
-      "desktop https://desktop.example/vnc?ticket=secret and sig=second-secret",
-      "ready",
-    ),
-    "desktop [connection] and [credential]",
-  );
-  const structured = redactedAdapterMessage(
-    `provider {"token":"json-secret","ticket":"ticket-secret","safe":"ok"}; Authorization: Basic dXNlcjpwYXNz`,
-    "failed",
-  );
-  assert.doesNotMatch(
-    structured,
-    /json-secret|ticket-secret|dXNlcjpwYXNz|access_token|refresh_token/iu,
-  );
-  assert.match(structured, /\[credential\]/u);
-  for (const providerMessage of [
-    `X-Api-Key: colon-secret`,
-    `access_token: quoted-secret`,
-    String.raw`escaped {\"refresh_token\":\"escaped-secret\"}`,
-    `password=pass-secret; code: code-secret`,
-  ]) {
-    const redacted = redactedAdapterMessage(providerMessage, "failed");
-    assert.doesNotMatch(
-      redacted,
-      /colon-secret|quoted-secret|escaped-secret|pass-secret|code-secret/iu,
-    );
-  }
-  const opaqueIdentifierCollision = redactedAdapterMessage(
-    "provider token=identifier-hidden-secret",
-    "failed",
-    ["token"],
-  );
-  assert.equal(opaqueIdentifierCollision, "provider [credential]");
-  assert.doesNotMatch(opaqueIdentifierCollision, /identifier-hidden-secret/u);
+	assert.equal(
+		safeWebSocketUrl("wss://terminal.example/session"),
+		"wss://terminal.example/session",
+	);
+	assert.equal(safeWebSocketUrl("ws://localhost:8787/session"), "ws://localhost:8787/session");
+	assert.equal(safeWebSocketUrl("ws://127.0.0.1:8787/session"), "ws://127.0.0.1:8787/session");
+	assert.equal(safeWebSocketUrl("ws://terminal.example/session"), null);
+	assert.equal(safeWebSocketUrl("ws://127.1:8787/session"), null);
+	assert.equal(safeWebSocketUrl("wss://terminal.example/session\n"), null);
+	const signed = "wss://Terminal.Example:443/%7Epty?signature=a%2Bb%2Fc%3D&dup=1&dup=2";
+	assert.equal(safeWebSocketUrl(signed), signed);
+	assert.equal(
+		parseAdapterWorkspaceResult({ status: "ready", attachUrl: signed })?.terminalUrl,
+		signed,
+	);
+	const message = parseAdapterWorkspaceResult({
+		id: "fleet-a-is-101",
+		status: "ready",
+		attachUrl: signed,
+		message: `attach ${signed}; Authorization: Bearer bearer-secret; token=query-secret`,
+	})?.message;
+	assert.equal(message, "attach [connection] [credential]");
+	assert.doesNotMatch(message ?? "", /bearer-secret|query-secret|signature=/u);
+	const slashEscaped = signed.replaceAll("/", "\\/");
+	const nestedEscaped = JSON.stringify(slashEscaped).slice(1, -1);
+	for (const escaped of [slashEscaped, nestedEscaped]) {
+		const redacted = redactedAdapterMessage(`provider terminal ${escaped}`, "failed", [], [signed]);
+		assert.equal(redacted, "provider terminal [connection]");
+		assert.doesNotMatch(redacted, /signature|Terminal\.Example/iu);
+	}
+	for (const arbitrary of [
+		String.raw`failed https:\/\/host.example\/pty?bearer=path-secret`,
+		String.raw`nested {\"detail\":\"wss:\\/\\/host.example\\/pty?token=nested-secret\"}`,
+		String.raw`mixed ws:\/\/host.example\/pty?authorization=Bearer-query-secret`,
+	]) {
+		const redacted = redactedAdapterMessage(arbitrary, "failed");
+		assert.match(redacted, /\[connection\]/u);
+		assert.doesNotMatch(redacted, /host\.example|path-secret|nested-secret|query-secret/iu);
+	}
+	assert.equal(
+		redactedAdapterResponseMessage(
+			{
+				message: `desktop ${slashEscaped}`,
+				desktopUrl: signed.replace("wss://", "https://"),
+				terminalUrl: signed,
+			},
+			"fallback",
+		),
+		"desktop [connection]",
+	);
+	assert.equal(
+		redactedAdapterMessage(
+			"desktop https://desktop.example/vnc?ticket=secret and sig=second-secret",
+			"ready",
+		),
+		"desktop [connection] and [credential]",
+	);
+	const structured = redactedAdapterMessage(
+		`provider {"token":"json-secret","ticket":"ticket-secret","safe":"ok"}; Authorization: Basic dXNlcjpwYXNz`,
+		"failed",
+	);
+	assert.doesNotMatch(
+		structured,
+		/json-secret|ticket-secret|dXNlcjpwYXNz|access_token|refresh_token/iu,
+	);
+	assert.match(structured, /\[credential\]/u);
+	for (const providerMessage of [
+		`X-Api-Key: colon-secret`,
+		`access_token: quoted-secret`,
+		String.raw`escaped {\"refresh_token\":\"escaped-secret\"}`,
+		`password=pass-secret; code: code-secret`,
+	]) {
+		const redacted = redactedAdapterMessage(providerMessage, "failed");
+		assert.doesNotMatch(
+			redacted,
+			/colon-secret|quoted-secret|escaped-secret|pass-secret|code-secret/iu,
+		);
+	}
+	const opaqueIdentifierCollision = redactedAdapterMessage(
+		"provider token=identifier-hidden-secret",
+		"failed",
+		["token"],
+	);
+	assert.equal(opaqueIdentifierCollision, "provider [credential]");
+	assert.doesNotMatch(opaqueIdentifierCollision, /identifier-hidden-secret/u);
 });
 
 test("desktop connection parser accepts current controller response aliases", () => {
-  assert.deepEqual(
-    parseAdapterDesktopConnection({
-      vncUrl: "https://desktop.example/session?ticket=short-lived",
-      expiresAt: 1_800_000_000,
-    }),
-    {
-      url: "https://desktop.example/session?ticket=short-lived",
-      expiresAt: 1_800_000_000_000,
-      expiresAtPresent: true,
-    },
-  );
+	assert.deepEqual(
+		parseAdapterDesktopConnection({
+			vncUrl: "https://desktop.example/session?ticket=short-lived",
+			expiresAt: 1_800_000_000,
+		}),
+		{
+			url: "https://desktop.example/session?ticket=short-lived",
+			expiresAt: 1_800_000_000_000,
+			expiresAtPresent: true,
+		},
+	);
 });
 
 test("desktop connection expiry is optional but bounded when present", () => {
-  const now = 1_800_000_000_000;
-  const url = "https://desktop.example/session?ticket=transient";
-  assert.equal(currentAdapterDesktopConnection({ url }, now)?.url, url);
-  assert.equal(
-    currentAdapterDesktopConnection({ url, expiresAt: now + 60_000 }, now)?.expiresAt,
-    now + 60_000,
-  );
-  assert.equal(currentAdapterDesktopConnection({ url, expiresAt: now }, now), null);
-  assert.equal(currentAdapterDesktopConnection({ url, expiresAt: now + 16 * 60_000 }, now), null);
-  assert.equal(currentAdapterDesktopConnection({ url, expiresAt: "not-a-date" }, now), null);
-  assert.equal(parseAdapterDesktopConnection({ url, expiresAt: "" }), null);
-  assert.equal(parseAdapterDesktopConnection({ url, expiresAt: null })?.expiresAtPresent, false);
+	const now = 1_800_000_000_000;
+	const url = "https://desktop.example/session?ticket=transient";
+	assert.equal(currentAdapterDesktopConnection({ url }, now)?.url, url);
+	assert.equal(
+		currentAdapterDesktopConnection({ url, expiresAt: now + 60_000 }, now)?.expiresAt,
+		now + 60_000,
+	);
+	assert.equal(currentAdapterDesktopConnection({ url, expiresAt: now }, now), null);
+	assert.equal(currentAdapterDesktopConnection({ url, expiresAt: now + 16 * 60_000 }, now), null);
+	assert.equal(currentAdapterDesktopConnection({ url, expiresAt: "not-a-date" }, now), null);
+	assert.equal(parseAdapterDesktopConnection({ url, expiresAt: "" }), null);
+	assert.equal(parseAdapterDesktopConnection({ url, expiresAt: null })?.expiresAtPresent, false);
 });


### PR DESCRIPTION
## Summary

- add root-fenced OpenClaw service reads for Crabbox room trees
- add bounded transcript evidence, targeted PTY nudges, audited stop, and canonical browser URLs
- supervise service-created sessions plus their agent-created descendants with bounded fan-out
- retain supervised roots while any descendant remains active
- durably reserve room capacity before GitHub branch preparation and reject invalid room lineages
- authorize room lineage from D1 before targeted provider reconciliation
- validate exact GitHub owner/name and branch-ref write targets before privileged mutations
- prevent room-service credentials from attaching children to unrelated session trees

## Validation

- `pnpm test` (195 passed)
- `pnpm build`
- `pnpm exec tsgo --noEmit`
- `pnpm exec oxlint src/index.ts src/openclaw-service.ts tests/openclaw-service.test.ts tests/runtime-adapter.test.ts tests/session-id.test.ts`
- `pnpm exec oxfmt --check src/openclaw-service.ts tests/openclaw-service.test.ts migrations/0025_interactive_session_preparation.sql`
- `pnpm exec wrangler d1 migrations apply DB --local`
- `git diff --check`
- full branch autoreview: clean, no actionable findings

`pnpm check` passes asset generation, typecheck, and lint, then reaches the repo-wide formatter gate, which is currently red on 72 baseline files with the installed formatter; no unrelated formatter churn is included here.