### PR TITLE
fix(api): guarantee room lifecycle cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Make OpenClaw room trees recoverable with idempotent Crabbox creation and root-level admission freeze plus recursive stop.
 - Add root-fenced OpenClaw service supervision for Crabbox room trees, including current state, bounded transcript evidence, targeted terminal nudges, audited stop requests, and canonical browser URLs.
 - Allow MultiCodex to use a dedicated service capability without rotating the existing OpenClaw automation token.
 - Safely reserve room capacity and prepare missing service-requested branches from an explicit base branch before Crabbox provisioning.

--- a/docs/api.md
+++ b/docs/api.md
@@ -559,7 +559,9 @@ Creates a repo-ready crabbox for an operator, e.g. from a Discord meeting handof
 `requestId` is optional, limited to 200 characters, and strongly recommended for automation. Crabfleet
 persists it with the session reservation before branch preparation or runtime
 creation. Replaying the same request returns the original crabbox; reusing the
-ID with a different request is rejected.
+ID with a different request is rejected. A replay while the original reservation
+is still preparing returns a retryable service-unavailable response instead of
+claiming the crabbox is ready.
 
 Response:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -556,12 +556,14 @@ Creates a repo-ready crabbox for an operator, e.g. from a Discord meeting handof
 }
 ```
 
-`requestId` is optional, limited to 200 characters, and strongly recommended for automation. Crabfleet
-persists it with the session reservation before branch preparation or runtime
-creation. Replaying the same request returns the original crabbox; reusing the
-ID with a different request is rejected. A replay while the original reservation
-is still preparing returns a retryable service-unavailable response instead of
-claiming the crabbox is ready.
+`requestId` is optional, limited to 200 characters, and strongly recommended for
+automation. Crabfleet persists it in a durable replay ledger with the session
+reservation before branch preparation or runtime creation. Replaying the same
+request returns the original crabbox; reusing the ID with a different request is
+rejected. A replay while the original reservation is still preparing returns a
+retryable service-unavailable response instead of claiming the crabbox is ready.
+After finalized-session cleanup, the retained replay tombstone rejects the
+request instead of provisioning duplicate work.
 
 Response:
 
@@ -642,8 +644,10 @@ Root stop request:
 ```
 
 Root stop closes descendant admission before rolling back pending reservations
-and driving the remaining root tree terminal. It returns only after the tree is
-quiescent; a failed request leaves admission closed and can be retried safely.
+and driving the remaining root tree terminal in bounded batches, including a
+legacy tree above the normal supervision limit. It returns only after the whole
+tree is quiescent; a failed request leaves admission closed and can be retried
+safely.
 
 ## Admin
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -551,9 +551,15 @@ Creates a repo-ready crabbox for an operator, e.g. from a Discord meeting handof
   "branch": "main",
   "runtime": "crabbox",
   "command": "codex --yolo",
-  "prompt": "prep the meeting follow-up"
+  "prompt": "prep the meeting follow-up",
+  "requestId": "multicodex-room-123-host"
 }
 ```
+
+`requestId` is optional but strongly recommended for automation. Crabfleet
+persists it with the session reservation before branch preparation or runtime
+creation. Replaying the same request returns the original crabbox; reusing the
+ID with a different request is rejected.
 
 Response:
 
@@ -581,6 +587,8 @@ using browser cookies or an individual session's agent token:
 - `GET /api/openclaw/crabboxes/:id/transcript`: read a bounded recent transcript.
 - `POST /api/openclaw/crabboxes/:id/message`: send one terminal message/nudge.
 - `POST /api/openclaw/crabboxes/:id/actions`: request the supported `stop` action.
+- `POST /api/openclaw/session-roots/:rootSessionId/actions`: freeze room-tree
+  admission and recursively stop every pending or active descendant.
 
 Room supervision endpoints require a configured service capability: the
 existing `CRABBOX_OPENCLAW_TOKEN`, or the dedicated `CRABBOX_MULTICODEX_TOKEN`
@@ -622,6 +630,18 @@ Stop request:
   "action": "stop"
 }
 ```
+
+Root stop request:
+
+```json
+{
+  "action": "stop"
+}
+```
+
+Root stop closes descendant admission before rolling back pending reservations
+and driving the remaining root tree terminal. It returns only after the tree is
+quiescent; a failed request leaves admission closed and can be retried safely.
 
 ## Admin
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -556,7 +556,7 @@ Creates a repo-ready crabbox for an operator, e.g. from a Discord meeting handof
 }
 ```
 
-`requestId` is optional but strongly recommended for automation. Crabfleet
+`requestId` is optional, limited to 200 characters, and strongly recommended for automation. Crabfleet
 persists it with the session reservation before branch preparation or runtime
 creation. Replaying the same request returns the original crabbox; reusing the
 ID with a different request is rejected.

--- a/docs/api.md
+++ b/docs/api.md
@@ -563,7 +563,9 @@ request returns the original crabbox; reusing the ID with a different request is
 rejected. A replay while the original reservation is still preparing returns a
 retryable service-unavailable response instead of claiming the crabbox is ready.
 After finalized-session cleanup, the retained replay tombstone rejects the
-request instead of provisioning duplicate work.
+request instead of provisioning duplicate work. The fingerprint includes a
+nonreversible digest of any supplied GitHub credential; the credential itself is
+not stored in the replay ledger.
 
 Response:
 

--- a/migrations/0026_openclaw_lifecycle_guarantees.sql
+++ b/migrations/0026_openclaw_lifecycle_guarantees.sql
@@ -8,3 +8,14 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_interactive_sessions_openclaw_request
 
 CREATE INDEX IF NOT EXISTS idx_interactive_sessions_openclaw_admission
   ON interactive_sessions(id, openclaw_admission_closed);
+
+CREATE TABLE IF NOT EXISTS openclaw_request_replays (
+  request_id TEXT PRIMARY KEY,
+  request_hash TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_openclaw_request_replays_session
+  ON openclaw_request_replays(session_id);

--- a/migrations/0026_openclaw_lifecycle_guarantees.sql
+++ b/migrations/0026_openclaw_lifecycle_guarantees.sql
@@ -1,0 +1,10 @@
+ALTER TABLE interactive_sessions ADD COLUMN openclaw_request_id TEXT;
+ALTER TABLE interactive_sessions ADD COLUMN openclaw_request_hash TEXT;
+ALTER TABLE interactive_sessions ADD COLUMN openclaw_admission_closed INTEGER NOT NULL DEFAULT 0;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_interactive_sessions_openclaw_request
+  ON interactive_sessions(openclaw_request_id)
+  WHERE openclaw_request_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_interactive_sessions_openclaw_admission
+  ON interactive_sessions(id, openclaw_admission_closed);

--- a/src/index.ts
+++ b/src/index.ts
@@ -831,6 +831,9 @@ type InteractiveSessionTable = {
   adapter_create_payload_json: string | null;
   adapter_create_pending: number;
   preparation_pending: Generated<number>;
+  openclaw_request_id: Generated<string | null>;
+  openclaw_request_hash: Generated<string | null>;
+  openclaw_admission_closed: Generated<number>;
   terminal_finalize_pending: Generated<number>;
   credential_cleanup_terminal_status: Generated<"stopped" | "expired" | "failed" | null>;
   sandbox_refresh_sandbox_id: Generated<string | null>;
@@ -2295,6 +2298,19 @@ async function api(
     );
   }
 
+  const openClawSessionRootActionMatch = url.pathname.match(
+    /^\/api\/openclaw\/session-roots\/([^/]+)\/actions$/,
+  );
+  if (request.method === "POST" && openClawSessionRootActionMatch) {
+    return json(
+      await openClawMutateSessionRoot(
+        request,
+        env,
+        decodeURIComponent(openClawSessionRootActionMatch[1] ?? ""),
+      ),
+    );
+  }
+
   const openClawCrabboxTranscriptMatch = url.pathname.match(
     /^\/api\/openclaw\/crabboxes\/([^/]+)\/transcript$/,
   );
@@ -3238,6 +3254,7 @@ async function openClawCreateCrabbox(
     summary?: string;
     githubToken?: string;
     baseBranch?: string;
+    requestId?: string;
   }>(request);
   const owner = openClawOwner(body.owner);
   body.branch = openClawServiceBranch(body.branch, "branch", "main");
@@ -3245,6 +3262,17 @@ async function openClawCreateCrabbox(
   if (baseBranch) body.baseBranch = baseBranch;
   else delete body.baseBranch;
   const serviceUser = openClawServiceUser();
+  const requestId = clean(body.requestId, 200) || null;
+  const requestHash = requestId ? await openClawCrabboxRequestHash(body, owner) : null;
+  if (requestId && requestHash) {
+    const existing = await readOpenClawRequestSession(env, requestId, requestHash);
+    if (existing) {
+      return openClawDecoratedCrabboxResponse(
+        env,
+        decorateInteractiveSession(existing, serviceUser, env),
+      );
+    }
+  }
   const result = await createInteractiveSessionFromInput(
     env,
     serviceUser,
@@ -3253,6 +3281,8 @@ async function openClawCreateCrabbox(
     {
       owner,
       createdBy: "service:openclaw",
+      openClawRequestId: requestId,
+      openClawRequestHash: requestHash,
       afterReserve: async () => {
         const signal = AbortSignal.timeout(openClawPreparationTimeoutMs);
         try {
@@ -3286,6 +3316,57 @@ async function openClawCreateCrabbox(
     Date.now(),
   );
   return openClawDecoratedCrabboxResponse(env, result.session);
+}
+
+async function openClawCrabboxRequestHash(
+  body: {
+    repo?: string;
+    branch?: string;
+    runtime?: string;
+    profile?: string;
+    command?: string;
+    prompt?: string;
+    parentSessionId?: string;
+    rootSessionId?: string;
+    purpose?: string;
+    summary?: string;
+    baseBranch?: string;
+  },
+  owner: string,
+): Promise<string> {
+  return sha256(
+    JSON.stringify({
+      repo: normalizeRepo(body.repo),
+      branch: clean(body.branch, 120),
+      runtime: clean(body.runtime, 40),
+      profile: clean(body.profile, 80),
+      command: clean(body.command, 4000),
+      prompt: clean(body.prompt, 4000),
+      parentSessionId: clean(body.parentSessionId, 120),
+      rootSessionId: clean(body.rootSessionId, 120),
+      purpose: clean(body.purpose, 500),
+      summary: clean(body.summary, 500),
+      baseBranch: clean(body.baseBranch, 120),
+      owner,
+    }),
+  );
+}
+
+async function readOpenClawRequestSession(
+  env: RuntimeEnv,
+  requestId: string,
+  requestHash: string,
+): Promise<InteractiveSession | null> {
+  const row = await database(env)
+    .selectFrom("interactive_sessions")
+    .selectAll()
+    .where("openclaw_request_id", "=", requestId)
+    .executeTakeFirst();
+  if (!row) return null;
+  if (row.created_by !== "service:openclaw" || row.openclaw_request_hash !== requestHash) {
+    throw conflict("OpenClaw crabbox request id already belongs to a different request");
+  }
+  return interactiveSession(row, []);
 }
 
 async function openClawReadSessionRoot(
@@ -3340,6 +3421,104 @@ async function openClawReadSessionRoot(
       .filter((session) => openClawRoomSessionChainAllowed(sessions, session.id, root))
       .map((session) => openClawCrabboxSummaryResponse(env, serviceUser, session)),
   };
+}
+
+async function openClawMutateSessionRoot(
+  request: Request,
+  env: RuntimeEnv,
+  rootSessionId: string,
+): Promise<{
+  rootSessionId: string;
+  admissionClosed: true;
+  crabboxes: Array<{ session: InteractiveSession; browserUrl: string }>;
+}> {
+  requireOpenClawRoomService(request, env);
+  const body = await readJson<{ action?: string }>(request);
+  if (body.action !== "stop") throw badRequest("only stop is supported");
+  const root = clean(rootSessionId, 120);
+  if (!root) throw badRequest("root session id is required");
+  const rootSession = await readInteractiveSession(env, root);
+  if (!rootSession || !openClawRoomRootAllowed(rootSession)) {
+    throw notFound("session root not found");
+  }
+  await database(env)
+    .updateTable("interactive_sessions")
+    .set({ openclaw_admission_closed: 1 })
+    .where("id", "=", root)
+    .execute();
+  const serviceUser = openClawServiceUser();
+  const deadline = Date.now() + 60_000;
+  let terminalReads = 0;
+  while (Date.now() < deadline) {
+    let rows = await readOpenClawRootRows(env, root);
+    const pending = rows.filter((row) => row.preparation_pending !== 0);
+    await mapWithConcurrency(pending, 4, async (row) => {
+      await rollbackInteractiveSessionReservation(env, row.id, row.created_at).catch(
+        () => undefined,
+      );
+    });
+    rows = await readOpenClawRootRows(env, root);
+    const sessions = rows.map((row) => interactiveSession(row, []));
+    const active = sessions
+      .filter((session) => !deadInteractiveSessionStatuses.includes(session.status))
+      .reverse();
+    await mapWithConcurrency(active, 4, async (session) => {
+      await mutateInteractiveSession(request, env, serviceUser, session.id, "stop").catch(
+        () => undefined,
+      );
+    });
+    rows = await readOpenClawRootRows(env, root);
+    const complete =
+      rows.length > 0 &&
+      rows.every(
+        (row) =>
+          row.preparation_pending === 0 && deadInteractiveSessionStatuses.includes(row.status),
+      );
+    terminalReads = complete ? terminalReads + 1 : 0;
+    if (terminalReads >= 2) {
+      const sessions = rows.map((row) => interactiveSession(row, []));
+      await audit(env, serviceUser, `openclaw session root stopped ${root}`, Date.now());
+      return {
+        rootSessionId: root,
+        admissionClosed: true,
+        crabboxes: sessions.map((session) =>
+          openClawCrabboxSummaryResponse(env, serviceUser, session),
+        ),
+      };
+    }
+    await sleep(250);
+  }
+  throw serviceUnavailable("OpenClaw session root cleanup did not reach a terminal state");
+}
+
+async function readOpenClawRootRows(
+  env: RuntimeEnv,
+  rootSessionId: string,
+): Promise<InteractiveSessionRow[]> {
+  const rows = await database(env)
+    .selectFrom("interactive_sessions")
+    .selectAll()
+    .where((expression) =>
+      expression.or([
+        expression("root_session_id", "=", rootSessionId),
+        expression("id", "=", rootSessionId),
+      ]),
+    )
+    .where((expression) =>
+      expression.or([
+        expression("created_by", "=", "service:openclaw"),
+        expression("created_by", "like", "session:%"),
+      ]),
+    )
+    .where("runtime", "!=", "github_actions")
+    .where("work_key", "is", null)
+    .orderBy("created_at", "asc")
+    .limit(openClawRoomMaxSessions + 1)
+    .execute();
+  if (rows.length > openClawRoomMaxSessions) {
+    throw serviceUnavailable("session root exceeds the supervision limit");
+  }
+  return rows;
 }
 
 async function openClawReadCrabbox(
@@ -3510,6 +3689,9 @@ async function openClawSupervisedRootForCreate(
   if (createdBy === "service:openclaw" || createdBy === `session:${lineage.parentSessionId}`) {
     const chain = await openClawReadSessionChain(env, parent, root, lineage.rootSessionId);
     if (openClawRoomSessionChainAllowed(chain, parent.id, lineage.rootSessionId)) {
+      if (!(await openClawRootAdmissionOpen(env, lineage.rootSessionId))) {
+        throw conflict("OpenClaw room root is stopping");
+      }
       return lineage.rootSessionId;
     }
   }
@@ -3539,6 +3721,9 @@ async function enforceOpenClawRoomSessionLimitAfterInsert(
       AND (candidate.created_by = 'service:openclaw' OR candidate.created_by LIKE 'session:%')
       AND candidate.runtime != 'github_actions'
       AND candidate.work_key IS NULL
+    JOIN interactive_sessions AS room_root
+      ON room_root.id = ${rootSessionId}
+      AND room_root.openclaw_admission_closed = 0
     WHERE inserted.id = ${insertedSessionId}
       AND inserted.status = 'provisioning'
       AND inserted.preparation_pending = 1
@@ -3551,6 +3736,15 @@ async function enforceOpenClawRoomSessionLimitAfterInsert(
   if (!position) throw serviceUnavailable("session root reservation disappeared");
   await rollbackInteractiveSessionReservation(env, insertedSessionId, insertedAt);
   throw tooManyRequests("session root reached the supervision limit");
+}
+
+async function openClawRootAdmissionOpen(env: RuntimeEnv, rootSessionId: string): Promise<boolean> {
+  const row = await database(env)
+    .selectFrom("interactive_sessions")
+    .select("openclaw_admission_closed")
+    .where("id", "=", rootSessionId)
+    .executeTakeFirst();
+  return row?.openclaw_admission_closed === 0;
 }
 
 async function openClawRoomReservationLineageAllowed(
@@ -4723,6 +4917,8 @@ async function createInteractiveSessionFromInput(
     owner?: string;
     parentSessionId?: string | null;
     rootSessionId?: string | null;
+    openClawRequestId?: string | null;
+    openClawRequestHash?: string | null;
     afterReserve?: () => Promise<void>;
   } = {},
 ): Promise<{ session: InteractiveSession }> {
@@ -4834,6 +5030,9 @@ async function createInteractiveSessionFromInput(
           adapter_create_payload_json: adapterCreatePayloadJson,
           adapter_create_pending: adapterWorkspaceId && !preparationReservation ? 1 : 0,
           preparation_pending: preparationReservation ? 1 : 0,
+          openclaw_request_id: options.openClawRequestId ?? null,
+          openclaw_request_hash: options.openClawRequestHash ?? null,
+          openclaw_admission_closed: 0,
           command,
           prompt,
           purpose,
@@ -5054,6 +5253,14 @@ async function createInteractiveSessionFromInput(
         ),
       };
     } catch (error) {
+      if (isConstraintError(error) && options.openClawRequestId && options.openClawRequestHash) {
+        const existing = await readOpenClawRequestSession(
+          env,
+          options.openClawRequestId,
+          options.openClawRequestHash,
+        );
+        if (existing) return { session: decorateInteractiveSession(existing, user, env) };
+      }
       if (!isConstraintError(error) || attempt === 2) throw error;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3278,7 +3278,7 @@ async function openClawCreateCrabbox(
     throw badRequest("requestId must be at most 200 characters");
   }
   const requestId = body.requestId || null;
-  const requestHash = requestId ? await openClawCrabboxRequestHash(body, owner) : null;
+  const requestHash = requestId ? await openClawCrabboxRequestHash(env, body, owner) : null;
   if (requestId && requestHash) {
     const existing = await readOpenClawRequestSession(env, requestId, requestHash);
     if (existing) {
@@ -3334,6 +3334,7 @@ async function openClawCreateCrabbox(
 }
 
 async function openClawCrabboxRequestHash(
+  env: RuntimeEnv,
   body: {
     repo?: string;
     branch?: string;
@@ -3351,11 +3352,16 @@ async function openClawCrabboxRequestHash(
   owner: string,
 ): Promise<string> {
   const githubToken = clean(body.githubToken, 4000);
+  const runtime = oneOf(
+    body.runtime,
+    ["crabbox", "container"] as const,
+    deploymentConfig(env).defaultRuntime,
+  );
   return sha256(
     JSON.stringify({
       repo: normalizeRepo(body.repo),
       branch: clean(body.branch, 120),
-      runtime: clean(body.runtime, 40),
+      runtime,
       profile: clean(body.profile, 120),
       command: clean(body.command, 4000),
       prompt: clean(body.prompt, 4000),
@@ -5068,6 +5074,7 @@ async function createInteractiveSessionFromInput(
   const now = Date.now();
   const db = database(env);
   for (let attempt = 0; attempt < 3; attempt += 1) {
+    let reservationInserted = false;
     const id = await nextInteractiveSessionId(env);
     const rootSessionId = lineage.rootSessionId ?? id;
     const agentToken = newAgentToken();
@@ -5198,6 +5205,7 @@ async function createInteractiveSessionFromInput(
       } else {
         await insertSession.execute();
       }
+      reservationInserted = true;
       if (supervisedRootSessionId) {
         await enforceOpenClawRoomSessionLimitAfterInsert(
           env,
@@ -5381,7 +5389,12 @@ async function createInteractiveSessionFromInput(
         ),
       };
     } catch (error) {
-      if (isConstraintError(error) && options.openClawRequestId && options.openClawRequestHash) {
+      if (
+        !reservationInserted &&
+        isConstraintError(error) &&
+        options.openClawRequestId &&
+        options.openClawRequestHash
+      ) {
         const existing = await readOpenClawRequestSession(
           env,
           options.openClawRequestId,
@@ -5389,7 +5402,7 @@ async function createInteractiveSessionFromInput(
         );
         if (existing) return { session: decorateInteractiveSession(existing, user, env) };
       }
-      if (!isConstraintError(error) || attempt === 2) throw error;
+      if (reservationInserted || !isConstraintError(error) || attempt === 2) throw error;
     }
   }
   throw new Error("failed to allocate interactive session id");

--- a/src/index.ts
+++ b/src/index.ts
@@ -3512,7 +3512,7 @@ async function openClawMutateSessionRoot(
         session.id,
         now + Math.min(10_000, 500 * 2 ** Math.min(attempt - 1, 5)),
       );
-      if (session.status === "stopping") {
+      if (session.status === "stopping" && session.adapter !== runtimeAdapterName) {
         await runOpenClawRootOperationBeforeDeadline(deadline, () =>
           reconcileExternalInteractiveSessionById(env, session.id, now),
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -3262,7 +3262,13 @@ async function openClawCreateCrabbox(
   if (baseBranch) body.baseBranch = baseBranch;
   else delete body.baseBranch;
   const serviceUser = openClawServiceUser();
-  const requestId = clean(body.requestId, 200) || null;
+  if (body.requestId !== undefined && typeof body.requestId !== "string") {
+    throw badRequest("requestId must be a string");
+  }
+  if (body.requestId && body.requestId.length > 200) {
+    throw badRequest("requestId must be at most 200 characters");
+  }
+  const requestId = body.requestId || null;
   const requestHash = requestId ? await openClawCrabboxRequestHash(body, owner) : null;
   if (requestId && requestHash) {
     const existing = await readOpenClawRequestSession(env, requestId, requestHash);
@@ -3339,7 +3345,7 @@ async function openClawCrabboxRequestHash(
       repo: normalizeRepo(body.repo),
       branch: clean(body.branch, 120),
       runtime: clean(body.runtime, 40),
-      profile: clean(body.profile, 80),
+      profile: clean(body.profile, 120),
       command: clean(body.command, 4000),
       prompt: clean(body.prompt, 4000),
       parentSessionId: clean(body.parentSessionId, 120),
@@ -3441,12 +3447,13 @@ async function openClawMutateSessionRoot(
   if (!rootSession || !openClawRoomRootAllowed(rootSession)) {
     throw notFound("session root not found");
   }
+  const serviceUser = openClawServiceUser();
+  await audit(env, serviceUser, `openclaw session root stop requested ${root}`, Date.now());
   await database(env)
     .updateTable("interactive_sessions")
     .set({ openclaw_admission_closed: 1 })
     .where("id", "=", root)
     .execute();
-  const serviceUser = openClawServiceUser();
   const deadline = Date.now() + 60_000;
   let terminalReads = 0;
   while (Date.now() < deadline) {
@@ -3733,7 +3740,13 @@ async function enforceOpenClawRoomSessionLimitAfterInsert(
   `.execute(db);
   const position = Number(admission.rows[0]?.position ?? 0);
   if (position > 0 && position <= openClawRoomMaxSessions) return;
-  if (!position) throw serviceUnavailable("session root reservation disappeared");
+  if (!position) {
+    await rollbackInteractiveSessionReservation(env, insertedSessionId, insertedAt);
+    if (!(await openClawRootAdmissionOpen(env, rootSessionId))) {
+      throw conflict("OpenClaw room root is stopping");
+    }
+    throw serviceUnavailable("session root reservation disappeared");
+  }
   await rollbackInteractiveSessionReservation(env, insertedSessionId, insertedAt);
   throw tooManyRequests("session root reached the supervision limit");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3346,9 +3346,11 @@ async function openClawCrabboxRequestHash(
     purpose?: string;
     summary?: string;
     baseBranch?: string;
+    githubToken?: string;
   },
   owner: string,
 ): Promise<string> {
+  const githubToken = clean(body.githubToken, 4000);
   return sha256(
     JSON.stringify({
       repo: normalizeRepo(body.repo),
@@ -3362,6 +3364,7 @@ async function openClawCrabboxRequestHash(
       purpose: clean(body.purpose, 500),
       summary: clean(body.summary, 500),
       baseBranch: clean(body.baseBranch, 120),
+      githubTokenHash: githubToken ? await sha256(githubToken) : null,
       owner,
     }),
   );
@@ -3372,24 +3375,21 @@ async function readOpenClawRequestSession(
   requestId: string,
   requestHash: string,
 ): Promise<InteractiveSession | null> {
-  const db = database(env);
-  const replay = await db
-    .selectFrom("openclaw_request_replays")
-    .selectAll()
-    .where("request_id", "=", requestId)
+  const replay = await database(env)
+    .selectFrom("openclaw_request_replays as replay")
+    .leftJoin("interactive_sessions as session", "session.id", "replay.session_id")
+    .selectAll("session")
+    .select("replay.request_hash as replay_request_hash")
+    .where("replay.request_id", "=", requestId)
     .executeTakeFirst();
   if (!replay) return null;
-  if (replay.request_hash !== requestHash) {
+  if (replay.replay_request_hash !== requestHash) {
     throw conflict("OpenClaw crabbox request id already belongs to a different request");
   }
-  const row = await db
-    .selectFrom("interactive_sessions")
-    .selectAll()
-    .where("id", "=", replay.session_id)
-    .executeTakeFirst();
-  if (!row) {
+  if (!replay.id) {
     throw conflict("OpenClaw crabbox request already completed and is no longer available");
   }
+  const row = replay as InteractiveSessionRow;
   if (
     row.created_by !== "service:openclaw" ||
     row.openclaw_request_id !== requestId ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -3372,6 +3372,9 @@ async function readOpenClawRequestSession(
   if (row.created_by !== "service:openclaw" || row.openclaw_request_hash !== requestHash) {
     throw conflict("OpenClaw crabbox request id already belongs to a different request");
   }
+  if (row.preparation_pending !== 0) {
+    throw serviceUnavailable("OpenClaw crabbox request is still preparing");
+  }
   return interactiveSession(row, []);
 }
 
@@ -3456,6 +3459,10 @@ async function openClawMutateSessionRoot(
     .execute();
   const deadline = Date.now() + 60_000;
   let terminalReads = 0;
+  let pollDelayMs = 250;
+  let previousState = "";
+  const lifecycleAttempts = new Map<string, number>();
+  const nextLifecycleAttemptAt = new Map<string, number>();
   while (Date.now() < deadline) {
     let rows = await readOpenClawRootRows(env, root);
     const pending = rows.filter((row) => row.preparation_pending !== 0);
@@ -3466,10 +3473,22 @@ async function openClawMutateSessionRoot(
     });
     rows = await readOpenClawRootRows(env, root);
     const sessions = rows.map((row) => interactiveSession(row, []));
-    const active = sessions
+    const now = Date.now();
+    const actionable = sessions
       .filter((session) => !deadInteractiveSessionStatuses.includes(session.status))
+      .filter((session) => (nextLifecycleAttemptAt.get(session.id) ?? 0) <= now)
       .reverse();
-    await mapWithConcurrency(active, 4, async (session) => {
+    await mapWithConcurrency(actionable, 4, async (session) => {
+      const attempt = (lifecycleAttempts.get(session.id) ?? 0) + 1;
+      lifecycleAttempts.set(session.id, attempt);
+      nextLifecycleAttemptAt.set(
+        session.id,
+        now + Math.min(10_000, 500 * 2 ** Math.min(attempt - 1, 5)),
+      );
+      if (session.status === "stopping") {
+        await reconcileExternalInteractiveSessionById(env, session.id, now).catch(() => undefined);
+        return;
+      }
       await mutateInteractiveSession(request, env, serviceUser, session.id, "stop").catch(
         () => undefined,
       );
@@ -3493,7 +3512,12 @@ async function openClawMutateSessionRoot(
         ),
       };
     }
-    await sleep(250);
+    const currentState = rows
+      .map((row) => `${row.id}:${row.status}:${row.preparation_pending}`)
+      .join("|");
+    pollDelayMs = currentState === previousState ? Math.min(2_000, pollDelayMs * 2) : 250;
+    previousState = currentState;
+    await sleep(pollDelayMs);
   }
   throw serviceUnavailable("OpenClaw session root cleanup did not reach a terminal state");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -878,6 +878,14 @@ type InteractiveSessionTable = {
 
 type InteractiveSessionRow = Selectable<InteractiveSessionTable>;
 
+type OpenClawRequestReplayTable = {
+  request_id: string;
+  request_hash: string;
+  session_id: string;
+  created_at: number;
+  updated_at: number;
+};
+
 type RepoWorkflowTable = {
   repo: string;
   status: WorkflowStatus;
@@ -1004,6 +1012,7 @@ type Database = {
   cards: CardTable;
   run_attempts: RunAttemptTable;
   interactive_sessions: InteractiveSessionTable;
+  openclaw_request_replays: OpenClawRequestReplayTable;
   interactive_session_events: InteractiveSessionEventTable;
   interactive_session_log_archives: InteractiveSessionLogArchiveTable;
   interactive_session_credential_policies: InteractiveSessionCredentialPolicyTable;
@@ -3363,14 +3372,30 @@ async function readOpenClawRequestSession(
   requestId: string,
   requestHash: string,
 ): Promise<InteractiveSession | null> {
-  const row = await database(env)
+  const db = database(env);
+  const replay = await db
+    .selectFrom("openclaw_request_replays")
+    .selectAll()
+    .where("request_id", "=", requestId)
+    .executeTakeFirst();
+  if (!replay) return null;
+  if (replay.request_hash !== requestHash) {
+    throw conflict("OpenClaw crabbox request id already belongs to a different request");
+  }
+  const row = await db
     .selectFrom("interactive_sessions")
     .selectAll()
-    .where("openclaw_request_id", "=", requestId)
+    .where("id", "=", replay.session_id)
     .executeTakeFirst();
-  if (!row) return null;
-  if (row.created_by !== "service:openclaw" || row.openclaw_request_hash !== requestHash) {
-    throw conflict("OpenClaw crabbox request id already belongs to a different request");
+  if (!row) {
+    throw conflict("OpenClaw crabbox request already completed and is no longer available");
+  }
+  if (
+    row.created_by !== "service:openclaw" ||
+    row.openclaw_request_id !== requestId ||
+    row.openclaw_request_hash !== requestHash
+  ) {
+    throw serviceUnavailable("OpenClaw crabbox replay record is inconsistent");
   }
   if (row.preparation_pending !== 0) {
     throw serviceUnavailable("OpenClaw crabbox request is still preparing");
@@ -3465,19 +3490,21 @@ async function openClawMutateSessionRoot(
   const nextLifecycleAttemptAt = new Map<string, number>();
   while (Date.now() < deadline) {
     let rows = await readOpenClawRootRows(env, root);
-    const pending = rows.filter((row) => row.preparation_pending !== 0);
+    const pending = rows.filter((row) => row.preparation_pending !== 0).slice(0, 4);
     await mapWithConcurrency(pending, 4, async (row) => {
-      await rollbackInteractiveSessionReservation(env, row.id, row.created_at).catch(
-        () => undefined,
+      await runOpenClawRootOperationBeforeDeadline(deadline, () =>
+        rollbackInteractiveSessionReservation(env, row.id, row.created_at),
       );
     });
+    if (Date.now() >= deadline) break;
     rows = await readOpenClawRootRows(env, root);
     const sessions = rows.map((row) => interactiveSession(row, []));
     const now = Date.now();
     const actionable = sessions
       .filter((session) => !deadInteractiveSessionStatuses.includes(session.status))
       .filter((session) => (nextLifecycleAttemptAt.get(session.id) ?? 0) <= now)
-      .reverse();
+      .reverse()
+      .slice(0, 4);
     await mapWithConcurrency(actionable, 4, async (session) => {
       const attempt = (lifecycleAttempts.get(session.id) ?? 0) + 1;
       lifecycleAttempts.set(session.id, attempt);
@@ -3486,20 +3513,19 @@ async function openClawMutateSessionRoot(
         now + Math.min(10_000, 500 * 2 ** Math.min(attempt - 1, 5)),
       );
       if (session.status === "stopping") {
-        await reconcileExternalInteractiveSessionById(env, session.id, now).catch(() => undefined);
+        await runOpenClawRootOperationBeforeDeadline(deadline, () =>
+          reconcileExternalInteractiveSessionById(env, session.id, now),
+        );
         return;
       }
-      await mutateInteractiveSession(request, env, serviceUser, session.id, "stop").catch(
-        () => undefined,
+      await runOpenClawRootOperationBeforeDeadline(deadline, () =>
+        mutateInteractiveSession(request, env, serviceUser, session.id, "stop").then(() => undefined),
       );
     });
+    if (Date.now() >= deadline) break;
     rows = await readOpenClawRootRows(env, root);
-    const complete =
-      rows.length > 0 &&
-      rows.every(
-        (row) =>
-          row.preparation_pending === 0 && deadInteractiveSessionStatuses.includes(row.status),
-      );
+    const completion = await readOpenClawRootCompletion(env, root);
+    const complete = completion.remaining === 0;
     terminalReads = complete ? terminalReads + 1 : 0;
     if (terminalReads >= 2) {
       const sessions = rows.map((row) => interactiveSession(row, []));
@@ -3512,21 +3538,40 @@ async function openClawMutateSessionRoot(
         ),
       };
     }
-    const currentState = rows
+    const currentState = `${completion.total}:${completion.remaining}:${rows
       .map((row) => `${row.id}:${row.status}:${row.preparation_pending}`)
-      .join("|");
+      .join("|")}`;
     pollDelayMs = currentState === previousState ? Math.min(2_000, pollDelayMs * 2) : 250;
     previousState = currentState;
-    await sleep(pollDelayMs);
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await sleep(Math.min(pollDelayMs, remaining));
   }
   throw serviceUnavailable("OpenClaw session root cleanup did not reach a terminal state");
+}
+
+async function runOpenClawRootOperationBeforeDeadline(
+  deadline: number,
+  operation: () => Promise<void>,
+): Promise<void> {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, remaining);
+    void operation()
+      .catch(() => undefined)
+      .finally(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+  });
 }
 
 async function readOpenClawRootRows(
   env: RuntimeEnv,
   rootSessionId: string,
 ): Promise<InteractiveSessionRow[]> {
-  const rows = await database(env)
+  return database(env)
     .selectFrom("interactive_sessions")
     .selectAll()
     .where((expression) =>
@@ -3543,13 +3588,42 @@ async function readOpenClawRootRows(
     )
     .where("runtime", "!=", "github_actions")
     .where("work_key", "is", null)
+    .orderBy(
+      sql<number>`CASE
+        WHEN preparation_pending != 0 THEN 0
+        WHEN status NOT IN ('stopped', 'expired', 'failed') THEN 1
+        ELSE 2
+      END`,
+      "asc",
+    )
     .orderBy("created_at", "asc")
-    .limit(openClawRoomMaxSessions + 1)
+    .limit(openClawRoomMaxSessions)
     .execute();
-  if (rows.length > openClawRoomMaxSessions) {
-    throw serviceUnavailable("session root exceeds the supervision limit");
-  }
-  return rows;
+}
+
+async function readOpenClawRootCompletion(
+  env: RuntimeEnv,
+  rootSessionId: string,
+): Promise<{ total: number; remaining: number }> {
+  const result = await sql<{ total: number; remaining: number }>`
+    SELECT
+      count(*) AS total,
+      sum(
+        CASE
+          WHEN preparation_pending != 0 OR status NOT IN ('stopped', 'expired', 'failed') THEN 1
+          ELSE 0
+        END
+      ) AS remaining
+    FROM interactive_sessions
+    WHERE (root_session_id = ${rootSessionId} OR id = ${rootSessionId})
+      AND (created_by = 'service:openclaw' OR created_by LIKE 'session:%')
+      AND runtime != 'github_actions'
+      AND work_key IS NULL
+  `.execute(database(env));
+  return {
+    total: Number(result.rows[0]?.total ?? 0),
+    remaining: Number(result.rows[0]?.remaining ?? 0),
+  };
 }
 
 async function openClawReadCrabbox(
@@ -3837,6 +3911,10 @@ async function rollbackInteractiveSessionReservation(
       AND updated_at = ${insertedAt}
   )`;
   await executeBatch(env, [
+    db
+      .deleteFrom("openclaw_request_replays")
+      .where("session_id", "=", insertedSessionId)
+      .where(ownsReservation),
     db
       .deleteFrom("interactive_session_events")
       .where("session_id", "=", insertedSessionId)
@@ -5039,7 +5117,7 @@ async function createInteractiveSessionFromInput(
       ? JSON.stringify(adapterCreatePayload)
       : null;
     try {
-      await db
+      const insertSession = db
         .insertInto("interactive_sessions")
         .values({
           id,
@@ -5105,8 +5183,21 @@ async function createInteractiveSessionFromInput(
           codex_turn_id: null,
           last_heartbeat_at: null,
           completion_reason: null,
-        })
-        .execute();
+        });
+      if (options.openClawRequestId && options.openClawRequestHash) {
+        await executeBatch(env, [
+          db.insertInto("openclaw_request_replays").values({
+            request_id: options.openClawRequestId,
+            request_hash: options.openClawRequestHash,
+            session_id: id,
+            created_at: now,
+            updated_at: now,
+          }),
+          insertSession,
+        ]);
+      } else {
+        await insertSession.execute();
+      }
       if (supervisedRootSessionId) {
         await enforceOpenClawRoomSessionLimitAfterInsert(
           env,

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -370,6 +370,7 @@ test("OpenClaw crabbox requests reserve durable idempotency before provisioning"
 			endpointSource.indexOf("createInteractiveSessionFromInput"),
 	);
 	assert.match(source, /profile: clean\(body\.profile, 120\)/);
+	assert.match(source, /runtime,\s+profile: clean\(body\.profile, 120\)/);
 	assert.match(source, /githubTokenHash: githubToken \? await sha256\(githubToken\) : null/);
 	assert.match(replaySource, /row\.preparation_pending !== 0/);
 	assert.match(replaySource, /OpenClaw crabbox request is still preparing/);
@@ -379,7 +380,8 @@ test("OpenClaw crabbox requests reserve durable idempotency before provisioning"
 	assert.match(createSource, /openclaw_request_id: options\.openClawRequestId \?\? null/);
 	assert.match(createSource, /openclaw_request_hash: options\.openClawRequestHash \?\? null/);
 	assert.match(createSource, /\.insertInto\("openclaw_request_replays"\)/);
-	assert.match(createSource, /if \(isConstraintError\(error\) && options\.openClawRequestId/);
+	assert.match(createSource, /!reservationInserted &&\s+isConstraintError\(error\)/);
+	assert.match(createSource, /if \(reservationInserted \|\| !isConstraintError\(error\)/);
 	assert.match(rollbackSource, /\.deleteFrom\("openclaw_request_replays"\)/);
 });
 

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -412,7 +412,10 @@ test("OpenClaw root stop freezes admission and drives pending descendants termin
 	assert.match(stopSource, /terminalReads >= 2/);
 	assert.match(stopSource, /completion\.remaining === 0/);
 	assert.match(stopSource, /nextLifecycleAttemptAt/);
-	assert.match(stopSource, /session\.status === "stopping"/);
+	assert.match(
+		stopSource,
+		/session\.status === "stopping" && session\.adapter !== runtimeAdapterName/,
+	);
 	assert.match(stopSource, /reconcileExternalInteractiveSessionById/);
 	assert.match(stopSource, /runOpenClawRootOperationBeforeDeadline/);
 	assert.match(stopSource, /\.slice\(0, 4\)/);

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -184,7 +184,7 @@ test("OpenClaw transcript reads a sentinel event before reporting completeness",
 test("OpenClaw root reads are filtered, capped, D1-only, and log-free", async () => {
 	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
 	const readStart = source.indexOf("async function openClawReadSessionRoot");
-	const readEnd = source.indexOf("async function openClawReadCrabbox", readStart);
+	const readEnd = source.indexOf("async function openClawMutateSessionRoot", readStart);
 	const readSource = source.slice(readStart, readEnd);
 	const summaryStart = source.indexOf("function openClawCrabboxSummaryResponse");
 	const summaryEnd = source.indexOf("function openClawDecoratedCrabboxResponse", summaryStart);
@@ -336,4 +336,65 @@ test("invalid descendants below an OpenClaw root fail closed before insertion", 
 		/if \(createdBy === "service:openclaw" \|\| openClawRoomRootAllowed\(root\)\)/,
 	);
 	assert.match(lineageSource, /throw badRequest\("invalid OpenClaw room lineage"\)/);
+});
+
+test("OpenClaw crabbox requests reserve durable idempotency before provisioning", async () => {
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const migration = await readFile(
+		new URL("../migrations/0026_openclaw_lifecycle_guarantees.sql", import.meta.url),
+		"utf8",
+	);
+	const endpointStart = source.indexOf("async function openClawCreateCrabbox");
+	const endpointEnd = source.indexOf("async function openClawCrabboxRequestHash", endpointStart);
+	const endpointSource = source.slice(endpointStart, endpointEnd);
+	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
+	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
+	const createSource = source.slice(createStart, createEnd);
+
+	assert.match(migration, /ADD COLUMN openclaw_request_id TEXT/);
+	assert.match(migration, /UNIQUE INDEX IF NOT EXISTS idx_interactive_sessions_openclaw_request/);
+	assert.match(endpointSource, /readOpenClawRequestSession/);
+	assert.ok(
+		endpointSource.indexOf("readOpenClawRequestSession") <
+			endpointSource.indexOf("createInteractiveSessionFromInput"),
+	);
+	assert.match(createSource, /openclaw_request_id: options\.openClawRequestId \?\? null/);
+	assert.match(createSource, /openclaw_request_hash: options\.openClawRequestHash \?\? null/);
+	assert.match(createSource, /if \(isConstraintError\(error\) && options\.openClawRequestId/);
+});
+
+test("OpenClaw root stop freezes admission and drives pending descendants terminal", async () => {
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const routeStart = source.indexOf("const openClawSessionRootActionMatch");
+	const routeEnd = source.indexOf("const openClawCrabboxTranscriptMatch", routeStart);
+	const routeSource = source.slice(routeStart, routeEnd);
+	const stopStart = source.indexOf("async function openClawMutateSessionRoot");
+	const stopEnd = source.indexOf("async function openClawReadCrabbox", stopStart);
+	const stopSource = source.slice(stopStart, stopEnd);
+	const lineageStart = source.indexOf("async function openClawSupervisedRootForCreate");
+	const lineageEnd = source.indexOf("async function openClawRoomReservationLineageAllowed");
+	const lineageSource = source.slice(lineageStart, lineageEnd);
+
+	assert.match(routeSource, /openClawMutateSessionRoot/);
+	assert.match(stopSource, /openclaw_admission_closed: 1/);
+	assert.ok(
+		stopSource.indexOf("openclaw_admission_closed: 1") <
+			stopSource.indexOf("rollbackInteractiveSessionReservation"),
+	);
+	assert.ok(
+		stopSource.indexOf("rollbackInteractiveSessionReservation") <
+			stopSource.indexOf("mutateInteractiveSession"),
+	);
+	assert.match(stopSource, /terminalReads >= 2/);
+	assert.match(stopSource, /preparation_pending === 0/);
+	assert.doesNotMatch(stopSource, /openClawRoomSessionChainAllowed/);
+	assert.match(lineageSource, /openClawRootAdmissionOpen/);
+	assert.match(lineageSource, /room_root\.openclaw_admission_closed = 0/);
+});
+
+test("OpenClaw lifecycle guarantees are documented", async () => {
+	const docs = await readFile(new URL("../docs/api.md", import.meta.url), "utf8");
+	assert.match(docs, /requestId/);
+	assert.match(docs, /session-roots\/:rootSessionId\/actions/);
+	assert.match(docs, /freeze room-tree\s+admission/);
 });

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -347,6 +347,9 @@ test("OpenClaw crabbox requests reserve durable idempotency before provisioning"
 	const endpointStart = source.indexOf("async function openClawCreateCrabbox");
 	const endpointEnd = source.indexOf("async function openClawCrabboxRequestHash", endpointStart);
 	const endpointSource = source.slice(endpointStart, endpointEnd);
+	const replayStart = source.indexOf("async function readOpenClawRequestSession");
+	const replayEnd = source.indexOf("async function openClawReadSessionRoot", replayStart);
+	const replaySource = source.slice(replayStart, replayEnd);
 	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
 	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
 	const createSource = source.slice(createStart, createEnd);
@@ -360,6 +363,8 @@ test("OpenClaw crabbox requests reserve durable idempotency before provisioning"
 			endpointSource.indexOf("createInteractiveSessionFromInput"),
 	);
 	assert.match(source, /profile: clean\(body\.profile, 120\)/);
+	assert.match(replaySource, /row\.preparation_pending !== 0/);
+	assert.match(replaySource, /OpenClaw crabbox request is still preparing/);
 	assert.match(createSource, /openclaw_request_id: options\.openClawRequestId \?\? null/);
 	assert.match(createSource, /openclaw_request_hash: options\.openClawRequestHash \?\? null/);
 	assert.match(createSource, /if \(isConstraintError\(error\) && options\.openClawRequestId/);
@@ -393,6 +398,10 @@ test("OpenClaw root stop freezes admission and drives pending descendants termin
 	);
 	assert.match(stopSource, /terminalReads >= 2/);
 	assert.match(stopSource, /preparation_pending === 0/);
+	assert.match(stopSource, /nextLifecycleAttemptAt/);
+	assert.match(stopSource, /session\.status === "stopping"/);
+	assert.match(stopSource, /reconcileExternalInteractiveSessionById/);
+	assert.match(stopSource, /Math\.min\(2_000, pollDelayMs \* 2\)/);
 	assert.doesNotMatch(stopSource, /openClawRoomSessionChainAllowed/);
 	assert.match(lineageSource, /openClawRootAdmissionOpen/);
 	assert.match(lineageSource, /room_root\.openclaw_admission_closed = 0/);

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -353,9 +353,16 @@ test("OpenClaw crabbox requests reserve durable idempotency before provisioning"
 	const createStart = source.indexOf("async function createInteractiveSessionFromInput");
 	const createEnd = source.indexOf("function initialRuntimeAdapterWorkspaceId", createStart);
 	const createSource = source.slice(createStart, createEnd);
+	const rollbackStart = source.indexOf("async function rollbackInteractiveSessionReservation");
+	const rollbackEnd = source.indexOf(
+		"async function cleanupAbandonedInteractiveSessionPreparations",
+		rollbackStart,
+	);
+	const rollbackSource = source.slice(rollbackStart, rollbackEnd);
 
 	assert.match(migration, /ADD COLUMN openclaw_request_id TEXT/);
 	assert.match(migration, /UNIQUE INDEX IF NOT EXISTS idx_interactive_sessions_openclaw_request/);
+	assert.match(migration, /CREATE TABLE IF NOT EXISTS openclaw_request_replays/);
 	assert.match(endpointSource, /readOpenClawRequestSession/);
 	assert.match(endpointSource, /requestId must be at most 200 characters/);
 	assert.ok(
@@ -365,9 +372,13 @@ test("OpenClaw crabbox requests reserve durable idempotency before provisioning"
 	assert.match(source, /profile: clean\(body\.profile, 120\)/);
 	assert.match(replaySource, /row\.preparation_pending !== 0/);
 	assert.match(replaySource, /OpenClaw crabbox request is still preparing/);
+	assert.match(replaySource, /OpenClaw crabbox request already completed and is no longer available/);
+	assert.match(replaySource, /\.selectFrom\("openclaw_request_replays"\)/);
 	assert.match(createSource, /openclaw_request_id: options\.openClawRequestId \?\? null/);
 	assert.match(createSource, /openclaw_request_hash: options\.openClawRequestHash \?\? null/);
+	assert.match(createSource, /\.insertInto\("openclaw_request_replays"\)/);
 	assert.match(createSource, /if \(isConstraintError\(error\) && options\.openClawRequestId/);
+	assert.match(rollbackSource, /\.deleteFrom\("openclaw_request_replays"\)/);
 });
 
 test("OpenClaw root stop freezes admission and drives pending descendants terminal", async () => {
@@ -397,11 +408,14 @@ test("OpenClaw root stop freezes admission and drives pending descendants termin
 			stopSource.indexOf("mutateInteractiveSession"),
 	);
 	assert.match(stopSource, /terminalReads >= 2/);
-	assert.match(stopSource, /preparation_pending === 0/);
+	assert.match(stopSource, /completion\.remaining === 0/);
 	assert.match(stopSource, /nextLifecycleAttemptAt/);
 	assert.match(stopSource, /session\.status === "stopping"/);
 	assert.match(stopSource, /reconcileExternalInteractiveSessionById/);
+	assert.match(stopSource, /runOpenClawRootOperationBeforeDeadline/);
+	assert.match(stopSource, /\.slice\(0, 4\)/);
 	assert.match(stopSource, /Math\.min\(2_000, pollDelayMs \* 2\)/);
+	assert.doesNotMatch(stopSource, /session root exceeds the supervision limit/);
 	assert.doesNotMatch(stopSource, /openClawRoomSessionChainAllowed/);
 	assert.match(lineageSource, /openClawRootAdmissionOpen/);
 	assert.match(lineageSource, /room_root\.openclaw_admission_closed = 0/);

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -370,10 +370,12 @@ test("OpenClaw crabbox requests reserve durable idempotency before provisioning"
 			endpointSource.indexOf("createInteractiveSessionFromInput"),
 	);
 	assert.match(source, /profile: clean\(body\.profile, 120\)/);
+	assert.match(source, /githubTokenHash: githubToken \? await sha256\(githubToken\) : null/);
 	assert.match(replaySource, /row\.preparation_pending !== 0/);
 	assert.match(replaySource, /OpenClaw crabbox request is still preparing/);
 	assert.match(replaySource, /OpenClaw crabbox request already completed and is no longer available/);
-	assert.match(replaySource, /\.selectFrom\("openclaw_request_replays"\)/);
+	assert.match(replaySource, /\.selectFrom\("openclaw_request_replays as replay"\)/);
+	assert.match(replaySource, /\.leftJoin\("interactive_sessions as session"/);
 	assert.match(createSource, /openclaw_request_id: options\.openClawRequestId \?\? null/);
 	assert.match(createSource, /openclaw_request_hash: options\.openClawRequestHash \?\? null/);
 	assert.match(createSource, /\.insertInto\("openclaw_request_replays"\)/);

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -354,10 +354,12 @@ test("OpenClaw crabbox requests reserve durable idempotency before provisioning"
 	assert.match(migration, /ADD COLUMN openclaw_request_id TEXT/);
 	assert.match(migration, /UNIQUE INDEX IF NOT EXISTS idx_interactive_sessions_openclaw_request/);
 	assert.match(endpointSource, /readOpenClawRequestSession/);
+	assert.match(endpointSource, /requestId must be at most 200 characters/);
 	assert.ok(
 		endpointSource.indexOf("readOpenClawRequestSession") <
 			endpointSource.indexOf("createInteractiveSessionFromInput"),
 	);
+	assert.match(source, /profile: clean\(body\.profile, 120\)/);
 	assert.match(createSource, /openclaw_request_id: options\.openClawRequestId \?\? null/);
 	assert.match(createSource, /openclaw_request_hash: options\.openClawRequestHash \?\? null/);
 	assert.match(createSource, /if \(isConstraintError\(error\) && options\.openClawRequestId/);
@@ -378,6 +380,10 @@ test("OpenClaw root stop freezes admission and drives pending descendants termin
 	assert.match(routeSource, /openClawMutateSessionRoot/);
 	assert.match(stopSource, /openclaw_admission_closed: 1/);
 	assert.ok(
+		stopSource.indexOf("openclaw session root stop requested") <
+			stopSource.indexOf("openclaw_admission_closed: 1"),
+	);
+	assert.ok(
 		stopSource.indexOf("openclaw_admission_closed: 1") <
 			stopSource.indexOf("rollbackInteractiveSessionReservation"),
 	);
@@ -390,6 +396,10 @@ test("OpenClaw root stop freezes admission and drives pending descendants termin
 	assert.doesNotMatch(stopSource, /openClawRoomSessionChainAllowed/);
 	assert.match(lineageSource, /openClawRootAdmissionOpen/);
 	assert.match(lineageSource, /room_root\.openclaw_admission_closed = 0/);
+	assert.match(
+		lineageSource,
+		/if \(!position\) \{\s+await rollbackInteractiveSessionReservation[\s\S]+throw conflict\("OpenClaw room root is stopping"\)/,
+	);
 });
 
 test("OpenClaw lifecycle guarantees are documented", async () => {


### PR DESCRIPTION
## Summary

- make OpenClaw Crabbox creation idempotent with durable request IDs
- freeze root admission before recursively stopping room trees
- document and migrate the lifecycle contract used by MultiCodex

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm test` (198/198)
- `node --test --experimental-strip-types tests/openclaw-service.test.ts` (18/18)
- `git diff --check`

`pnpm check` still reports the repository's existing formatter baseline across untouched files; this branch does not bulk-format them.