### PR TITLE
feat(auth): add scoped terminal embed tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 - Make OpenClaw room trees recoverable with idempotent Crabbox creation and root-level admission freeze plus recursive stop.
 - Add root-fenced OpenClaw service supervision for Crabbox room trees, including current state, bounded transcript evidence, targeted terminal nudges, audited stop requests, and canonical browser URLs.
 - Allow MultiCodex to use a dedicated service capability without rotating the existing OpenClaw automation token.
-- Add root-fenced, short-lived terminal embed tickets signed with a Crabfleet-only key so MultiCodex participants can open their workspace without a second login.
 - Safely reserve room capacity and prepare missing service-requested branches from an explicit base branch before Crabbox provisioning.
 - Add deployment-configured Codex SSH handoffs for ready provider workspaces, with safe alias templating, manager-only session metadata, and copyable local setup commands that keep provider behavior outside Crabfleet.
 - Route generic runtime profiles to distinct versioned adapters through a validated deployment URL template, reject profile-rewriting responses, and preserve immutable lifecycle control-plane fences.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Make OpenClaw room trees recoverable with idempotent Crabbox creation and root-level admission freeze plus recursive stop.
 - Add root-fenced OpenClaw service supervision for Crabbox room trees, including current state, bounded transcript evidence, targeted terminal nudges, audited stop requests, and canonical browser URLs.
 - Allow MultiCodex to use a dedicated service capability without rotating the existing OpenClaw automation token.
+- Add root-fenced, short-lived terminal embed tickets so MultiCodex participants can open their Crabfleet workspace without a second login.
 - Safely reserve room capacity and prepare missing service-requested branches from an explicit base branch before Crabbox provisioning.
 - Add deployment-configured Codex SSH handoffs for ready provider workspaces, with safe alias templating, manager-only session metadata, and copyable local setup commands that keep provider behavior outside Crabfleet.
 - Route generic runtime profiles to distinct versioned adapters through a validated deployment URL template, reject profile-rewriting responses, and preserve immutable lifecycle control-plane fences.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Make OpenClaw room trees recoverable with idempotent Crabbox creation and root-level admission freeze plus recursive stop.
 - Add root-fenced OpenClaw service supervision for Crabbox room trees, including current state, bounded transcript evidence, targeted terminal nudges, audited stop requests, and canonical browser URLs.
 - Allow MultiCodex to use a dedicated service capability without rotating the existing OpenClaw automation token.
-- Add root-fenced, short-lived terminal embed tickets so MultiCodex participants can open their Crabfleet workspace without a second login.
+- Add root-fenced, short-lived terminal embed tickets signed with a Crabfleet-only key so MultiCodex participants can open their workspace without a second login.
 - Safely reserve room capacity and prepare missing service-requested branches from an explicit base branch before Crabbox provisioning.
 - Add deployment-configured Codex SSH handoffs for ready provider workspaces, with safe alias templating, manager-only session metadata, and copyable local setup commands that keep provider behavior outside Crabfleet.
 - Route generic runtime profiles to distinct versioned adapters through a validated deployment URL template, reject profile-rewriting responses, and preserve immutable lifecycle control-plane fences.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The Crabbox namespace cutover intentionally has no old-name compatibility. Exist
 - `CRABBOX_CLAWFLEET_PUBLIC_URL` – Optional public ClawFleet URL used when building attach/VNC links
 - `CRABBOX_OPENCLAW_TOKEN` – Internal bearer token for OpenClaw service crabbox and GitHub Actions session registration
 - `CRABBOX_MULTICODEX_TOKEN` – Optional dedicated bearer token for MultiCodex room supervision
+- `CRABBOX_EMBED_TICKET_SECRET` – Crabfleet-only signing key for short-lived terminal embed tickets
 - `CRABFLEET_SSH_GATEWAY_TOKEN` / `CRABBOX_SSH_GATEWAY_TOKEN` – Shared bearer token for the Go SSH gateway internal API
 - `CRABFLEET_LOCAL_SANDBOX_BACKUPS` – Optional Cloudflare Sandbox checkpoint mode override; defaults to R2 binding uploads, set `0` for SDK presigned R2 uploads
 - `CRABFLEET_LABEL` – Optional tenant label shown in the app, default `Crabfleet`

--- a/docs/api.md
+++ b/docs/api.md
@@ -592,6 +592,8 @@ using browser cookies or an individual session's agent token:
 - `GET /api/openclaw/crabboxes/:id/transcript`: read a bounded recent transcript.
 - `POST /api/openclaw/crabboxes/:id/message`: send one terminal message/nudge.
 - `POST /api/openclaw/crabboxes/:id/actions`: request the supported `stop` action.
+- `POST /api/openclaw/crabboxes/:id/embed-ticket`: mint a short-lived browser URL
+  that can view and control only that crabbox terminal without a Crabfleet login.
 - `POST /api/openclaw/session-roots/:rootSessionId/actions`: freeze room-tree
   admission and recursively stop every pending or active descendant.
 
@@ -616,6 +618,12 @@ as not found. Creation rejects a supervised descendant that would exceed the
 responses contain at most the newest 240 events and
 64 KiB of UTF-8 text and report whether evidence was truncated. Every message
 and stop request writes an audit event.
+
+Embed-ticket bodies require `rootSessionId` and may include `ttlSeconds`.
+Lifetimes default to one hour and are clamped between one minute and four
+hours. The returned signed bearer is scoped to one terminal session and never
+exposes the room service credential. It cannot read fleet state, manage the
+session, paste files, or access sibling sessions.
 
 Message request:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -623,7 +623,9 @@ Embed-ticket bodies require `rootSessionId` and may include `ttlSeconds`.
 Lifetimes default to one hour and are clamped between one minute and four
 hours. The returned signed bearer is scoped to one terminal session and never
 exposes the room service credential. It cannot read fleet state, manage the
-session, paste files, or access sibling sessions.
+session, paste files, or access sibling sessions. Ticket signing requires the
+Crabfleet-only `CRABBOX_EMBED_TICKET_SECRET`; room-service consumers must never
+receive that signing secret.
 
 Message request:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,13 +135,16 @@ import { obsoleteSessionArchiveObjectKeys, sessionArchiveAttemptKeys } from "./s
 import { readBoundedResponseText } from "./bounded-response";
 import {
   boundedUtf8Tail,
+	createOpenClawEmbedTicket,
   openClawBranchPreparationCanDefer,
+	openClawEmbedTicketTtlSeconds,
   openClawGitBranchAllowed,
   openClawGitHubRepoParts,
   openClawRoomMaxSessions,
   openClawRoomRootAllowed,
   openClawRoomSessionChainAllowed,
   openClawServiceAuthorized,
+	verifyOpenClawEmbedTicket,
 } from "./openclaw-service";
 import {
   inspectTrustedProxyAssertion,
@@ -2362,6 +2365,20 @@ async function api(
     );
   }
 
+	const openClawCrabboxEmbedTicketMatch = url.pathname.match(
+		/^\/api\/openclaw\/crabboxes\/([^/]+)\/embed-ticket$/,
+	);
+	if (request.method === "POST" && openClawCrabboxEmbedTicketMatch) {
+		return json(
+			await openClawCreateCrabboxEmbedTicket(
+				request,
+				env,
+				decodeURIComponent(openClawCrabboxEmbedTicketMatch[1] ?? ""),
+			),
+			{ status: 201 },
+		);
+	}
+
   const openClawCrabboxReadMatch = url.pathname.match(/^\/api\/openclaw\/crabboxes\/([^/]+)$/);
   if (request.method === "GET" && openClawCrabboxReadMatch) {
     return json(
@@ -3741,6 +3758,36 @@ async function openClawMutateCrabbox(
   return openClawCrabboxSummaryResponse(env, serviceUser, result.session);
 }
 
+async function openClawCreateCrabboxEmbedTicket(
+	request: Request,
+	env: RuntimeEnv,
+	id: string,
+): Promise<{ browserUrl: string; expiresAt: number }> {
+	requireOpenClawRoomService(request, env);
+	const body = await readJson<{ rootSessionId?: string; ttlSeconds?: number }>(request);
+	if (
+		body.ttlSeconds !== undefined &&
+		(typeof body.ttlSeconds !== "number" || !Number.isFinite(body.ttlSeconds))
+	) {
+		throw badRequest("ttlSeconds must be a finite number");
+	}
+	const session = await openClawRootScopedCrabbox(request, env, id, body.rootSessionId);
+	if (["stopping", "stopped", "expired", "failed"].includes(session.status)) {
+		throw badRequest(`session is ${session.status}`);
+	}
+	if (!session.capabilities.terminal) {
+		throw badRequest("session does not advertise terminal access");
+	}
+	const secret = openClawEmbedTicketSecret(env);
+	if (!secret) throw serviceUnavailable("OpenClaw embed ticket secret is not configured");
+	const expiresAt = Date.now() + openClawEmbedTicketTtlSeconds(body.ttlSeconds) * 1000;
+	const token = await createOpenClawEmbedTicket(secret, session.id, expiresAt);
+	return {
+		browserUrl: `${browserAppOrigin(env)}/app/sessions/${encodeURIComponent(session.id)}?token=${encodeURIComponent(token)}`,
+		expiresAt,
+	};
+}
+
 async function openClawRootScopedCrabbox(
   request: Request,
   env: RuntimeEnv,
@@ -4223,6 +4270,10 @@ function requireOpenClawAutomationService(request: Request, env: RuntimeEnv): vo
 
 function requireOpenClawRoomService(request: Request, env: RuntimeEnv): void {
   requireOpenClawServiceToken(request, [env.CRABBOX_OPENCLAW_TOKEN, env.CRABBOX_MULTICODEX_TOKEN]);
+}
+
+function openClawEmbedTicketSecret(env: RuntimeEnv): string {
+	return env.CRABBOX_MULTICODEX_TOKEN || env.CRABBOX_OPENCLAW_TOKEN || "";
 }
 
 function requireOpenClawServiceToken(
@@ -8234,7 +8285,7 @@ async function subscribeTerminalHubSession(
   }
 
   try {
-    const canInput = terminalInputGrant(env, user, session);
+		const canInput = terminalInputGrant(request, env, user, session);
     const canInputNow = await canInput();
     const canView = terminalViewGrant(request, env, user, session);
     const reconcileSubscription = terminalSubscriptionReconciler(env, id);
@@ -8674,12 +8725,17 @@ async function readClipboardUploadBytes(request: Request): Promise<Uint8Array> {
 }
 
 function terminalInputGrant(
+	request: Request,
   env: RuntimeEnv,
   user: User | null,
   session: InteractiveSession,
 ): () => Promise<boolean> {
-  if (!user || !session.capabilities.terminal) return async () => false;
-  return cachedBooleanGrant(() => canControlInteractiveSessionById(env, user, session.id));
+	if (!session.capabilities.terminal) return async () => false;
+	return cachedBooleanGrant(() =>
+		user
+			? canControlInteractiveSessionById(env, user, session.id)
+			: canControlEmbeddedTerminalRequest(request, env, session.id),
+	);
 }
 
 function terminalSubscriptionReconciler(env: RuntimeEnv, id: string): () => void {
@@ -8722,6 +8778,17 @@ async function canViewSharedTerminalRequest(
   return (!shareSession || shareSession === id) && (await isSharedSessionToken(env, id, token));
 }
 
+async function canControlEmbeddedTerminalRequest(
+	request: Request,
+	env: RuntimeEnv,
+	id: string,
+): Promise<boolean> {
+	const url = new URL(request.url);
+	const shareSession = url.searchParams.get("shareSession") ?? "";
+	const token = url.searchParams.get("token") ?? "";
+	return shareSession === id && (await isOpenClawEmbedSessionToken(env, id, token));
+}
+
 async function canOpenAnonymousTerminalHub(request: Request, env: RuntimeEnv): Promise<boolean> {
   const url = new URL(request.url);
   const shareSession = url.searchParams.get("shareSession") ?? "";
@@ -8744,6 +8811,7 @@ async function canViewTerminalSession(
 
 async function isSharedSessionToken(env: RuntimeEnv, id: string, token: string): Promise<boolean> {
   if (!token) return false;
+	if (await isOpenClawEmbedSessionToken(env, id, token)) return true;
   const row = await database(env)
     .selectFrom("interactive_sessions")
     .select(["share_token_hash", "share_mode", "status", "runtime", "capabilities_json"])
@@ -8756,6 +8824,15 @@ async function isSharedSessionToken(env: RuntimeEnv, id: string, token: string):
     runtimeCapabilities(row.runtime, row.capabilities_json).terminal &&
     (await sha256(token)) === row.share_token_hash,
   );
+}
+
+async function isOpenClawEmbedSessionToken(
+	env: RuntimeEnv,
+	id: string,
+	token: string,
+): Promise<boolean> {
+	const secret = openClawEmbedTicketSecret(env);
+	return Boolean(secret && (await verifyOpenClawEmbedTicket(secret, token, id)));
 }
 
 function sendTerminalFrame(
@@ -14394,10 +14471,14 @@ async function readSharedInteractiveSession(
     .selectAll()
     .where("id", "=", id)
     .where("preparation_pending", "=", 0)
-    .where("share_mode", "=", "link_read")
     .executeTakeFirst();
-  if (!row || !row.share_token_hash || !token) throw notFound("shared session not found");
-  if ((await sha256(token)) !== row.share_token_hash) throw notFound("shared session not found");
+	const embedded = await isOpenClawEmbedSessionToken(env, id, token);
+	const shared =
+		row?.share_mode === "link_read" &&
+		Boolean(row.share_token_hash) &&
+		Boolean(token) &&
+		(await sha256(token)) === row.share_token_hash;
+	if (!row || (!embedded && !shared)) throw notFound("shared session not found");
   const logs = await readInteractiveSessionLogs(env, [id]);
   const archives = await readInteractiveSessionLogArchives(env, [id]);
   const session = interactiveSession(row, logs.get(id) ?? [], archives.get(id) ?? null);
@@ -14419,10 +14500,10 @@ async function readSharedInteractiveSession(
       controlGrantedAt: activeController ? session.controlGrantedAt : null,
       controlExpiresAt: activeController ? session.controlExpiresAt : null,
       multiplayerMode: session.multiplayerMode,
-      canControl: false,
+			canControl: embedded,
       canManage: false,
       canRequestControl: false,
-      sharedReadOnly: true,
+			sharedReadOnly: !embedded,
     },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,7 @@ type RuntimeEnv = Env & {
   CRABFLEET_SSH_GATEWAY_TOKEN?: string;
   CRABBOX_OPENCLAW_TOKEN?: string;
   CRABBOX_MULTICODEX_TOKEN?: string;
+  CRABBOX_EMBED_TICKET_SECRET?: string;
   CRABBOX_TOKEN_ENCRYPTION_KEY?: string;
   BACKUP_BUCKET_NAME?: string;
   CLOUDFLARE_ACCOUNT_ID?: string;
@@ -4273,7 +4274,7 @@ function requireOpenClawRoomService(request: Request, env: RuntimeEnv): void {
 }
 
 function openClawEmbedTicketSecret(env: RuntimeEnv): string {
-	return env.CRABBOX_MULTICODEX_TOKEN || env.CRABBOX_OPENCLAW_TOKEN || "";
+  return env.CRABBOX_EMBED_TICKET_SECRET || "";
 }
 
 function requireOpenClawServiceToken(

--- a/src/openclaw-service.ts
+++ b/src/openclaw-service.ts
@@ -3,6 +3,11 @@ const decoder = new TextDecoder();
 
 export const openClawTranscriptMaxBytes = 64 * 1024;
 export const openClawRoomMaxSessions = 64;
+export const openClawEmbedTicketDefaultSeconds = 60 * 60;
+export const openClawEmbedTicketMaxSeconds = 4 * 60 * 60;
+
+const openClawEmbedTicketVersion = "v1";
+const openClawEmbedTicketAudience = "crabfleet-embed";
 
 type OpenClawSessionFence = {
   id: string;
@@ -18,6 +23,70 @@ export function openClawServiceAuthorized(
   tokens: Array<string | null | undefined>,
 ): boolean {
   return tokens.some((token) => Boolean(token) && authorization === `Bearer ${token}`);
+}
+
+export function openClawEmbedTicketTtlSeconds(value?: number): number {
+	if (value === undefined) return openClawEmbedTicketDefaultSeconds;
+	return Math.max(60, Math.min(openClawEmbedTicketMaxSeconds, Math.floor(value)));
+}
+
+export async function createOpenClawEmbedTicket(
+	secret: string,
+	sessionId: string,
+	expiresAt: number,
+): Promise<string> {
+	if (!secret || !sessionId || !Number.isSafeInteger(expiresAt)) {
+		throw new Error("invalid OpenClaw embed ticket input");
+	}
+	const payload = base64UrlFromBytes(
+		encoder.encode(
+			JSON.stringify({
+				aud: openClawEmbedTicketAudience,
+				sessionId,
+				expiresAt,
+			}),
+		),
+	);
+	const message = `${openClawEmbedTicketVersion}.${payload}`;
+	const signature = await crypto.subtle.sign(
+		"HMAC",
+		await openClawEmbedTicketKey(secret),
+		encoder.encode(message),
+	);
+	return `${message}.${base64UrlFromBytes(new Uint8Array(signature))}`;
+}
+
+export async function verifyOpenClawEmbedTicket(
+	secret: string,
+	token: string,
+	sessionId: string,
+	now = Date.now(),
+): Promise<boolean> {
+	if (!secret || !token || !sessionId) return false;
+	const parts = token.split(".");
+	if (parts.length !== 3 || parts[0] !== openClawEmbedTicketVersion) return false;
+	try {
+		const message = `${parts[0]}.${parts[1]}`;
+		const signatureValid = await crypto.subtle.verify(
+			"HMAC",
+			await openClawEmbedTicketKey(secret),
+			bytesFromBase64Url(parts[2]!),
+			encoder.encode(message),
+		);
+		if (!signatureValid) return false;
+		const payload = JSON.parse(decoder.decode(bytesFromBase64Url(parts[1]!))) as unknown;
+		if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+		const fields = payload as Record<string, unknown>;
+		return (
+			fields.aud === openClawEmbedTicketAudience &&
+			fields.sessionId === sessionId &&
+			typeof fields.expiresAt === "number" &&
+			Number.isSafeInteger(fields.expiresAt) &&
+			fields.expiresAt > now
+		);
+	} catch {
+		return false;
+	}
 }
 
 export function sessionBelongsToRoot(
@@ -129,4 +198,26 @@ export function boundedUtf8Tail(
   while (start < bytes.byteLength && (bytes[start]! & 0xc0) === 0x80) start += 1;
   const tail = decoder.decode(bytes.slice(start));
   return { text: tail, truncated: true };
+}
+
+async function openClawEmbedTicketKey(secret: string): Promise<CryptoKey> {
+	return crypto.subtle.importKey(
+		"raw",
+		encoder.encode(secret),
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		["sign", "verify"],
+	);
+}
+
+function base64UrlFromBytes(bytes: Uint8Array): string {
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/g, "");
+}
+
+function bytesFromBase64Url(value: string): Uint8Array {
+	const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+	const binary = atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "="));
+	return Uint8Array.from(binary, (character) => character.charCodeAt(0));
 }

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -251,19 +251,24 @@ test("OpenClaw target authorization precedes targeted reconciliation", async () 
 });
 
 test("OpenClaw embed ticket minting stays root fenced and terminal scoped", async () => {
-	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
 	const start = source.indexOf("async function openClawCreateCrabboxEmbedTicket");
 	const end = source.indexOf("async function openClawRootScopedCrabbox", start);
 	const mintSource = source.slice(start, end);
 	const inputStart = source.indexOf("function terminalInputGrant");
 	const inputEnd = source.indexOf("function terminalSubscriptionReconciler", inputStart);
-	const inputSource = source.slice(inputStart, inputEnd);
+  const inputSource = source.slice(inputStart, inputEnd);
+  const secretStart = source.indexOf("function openClawEmbedTicketSecret");
+  const secretEnd = source.indexOf("function requireOpenClawServiceToken", secretStart);
+  const secretSource = source.slice(secretStart, secretEnd);
 
-	assert.match(mintSource, /requireOpenClawRoomService/);
+  assert.match(mintSource, /requireOpenClawRoomService/);
 	assert.match(mintSource, /openClawRootScopedCrabbox\(request, env, id, body\.rootSessionId\)/);
 	assert.match(mintSource, /createOpenClawEmbedTicket/);
-	assert.match(mintSource, /session does not advertise terminal access/);
-	assert.match(inputSource, /canControlEmbeddedTerminalRequest/);
+  assert.match(mintSource, /session does not advertise terminal access/);
+  assert.match(inputSource, /canControlEmbeddedTerminalRequest/);
+  assert.match(secretSource, /CRABBOX_EMBED_TICKET_SECRET/);
+  assert.doesNotMatch(secretSource, /CRABBOX_MULTICODEX_TOKEN|CRABBOX_OPENCLAW_TOKEN/);
 });
 
 test("interactive lineage rejects caller-claimed roots without a parent", async () => {

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -4,7 +4,11 @@ import test from "node:test";
 
 import {
   boundedUtf8Tail,
+	createOpenClawEmbedTicket,
   openClawBranchPreparationCanDefer,
+	openClawEmbedTicketDefaultSeconds,
+	openClawEmbedTicketMaxSeconds,
+	openClawEmbedTicketTtlSeconds,
   openClawGitBranchAllowed,
   openClawGitHubRepoParts,
   openClawRoomMaxSessions,
@@ -14,6 +18,7 @@ import {
   openClawServiceAuthorized,
   openClawTranscriptMaxBytes,
   sessionBelongsToRoot,
+	verifyOpenClawEmbedTicket,
 } from "../src/openclaw-service.ts";
 
 test("OpenClaw service authorization accepts dedicated scoped consumers", () => {
@@ -21,6 +26,30 @@ test("OpenClaw service authorization accepts dedicated scoped consumers", () => 
   assert.equal(openClawServiceAuthorized("Bearer multicodex", ["openclaw", "multicodex"]), true);
   assert.equal(openClawServiceAuthorized("Bearer public", ["openclaw", "multicodex"]), false);
   assert.equal(openClawServiceAuthorized(null, [undefined, null]), false);
+});
+
+test("OpenClaw embed tickets are signed, session scoped, and expiring", async () => {
+	const now = 1_800_000_000_000;
+	const token = await createOpenClawEmbedTicket("dedicated-secret", "IS-10", now + 60_000);
+	assert.equal(await verifyOpenClawEmbedTicket("dedicated-secret", token, "IS-10", now), true);
+	assert.equal(await verifyOpenClawEmbedTicket("other-secret", token, "IS-10", now), false);
+	assert.equal(await verifyOpenClawEmbedTicket("dedicated-secret", token, "IS-11", now), false);
+	assert.equal(
+		await verifyOpenClawEmbedTicket("dedicated-secret", token, "IS-10", now + 60_000),
+		false,
+	);
+	assert.equal(
+		await verifyOpenClawEmbedTicket("dedicated-secret", `${token}x`, "IS-10", now),
+		false,
+	);
+	assert.equal(await verifyOpenClawEmbedTicket("dedicated-secret", "invalid", "IS-10", now), false);
+});
+
+test("OpenClaw embed ticket lifetimes stay short and bounded", () => {
+	assert.equal(openClawEmbedTicketTtlSeconds(), openClawEmbedTicketDefaultSeconds);
+	assert.equal(openClawEmbedTicketTtlSeconds(1), 60);
+	assert.equal(openClawEmbedTicketTtlSeconds(3_600.9), 3_600);
+	assert.equal(openClawEmbedTicketTtlSeconds(99_999), openClawEmbedTicketMaxSeconds);
 });
 
 test("OpenClaw branch preparation defers masked control-plane permission failures", () => {
@@ -219,6 +248,22 @@ test("OpenClaw target authorization precedes targeted reconciliation", async () 
   assert.match(scopedSource, /const session = await readInteractiveSession/);
   assert.match(scopedSource, /const root = await readInteractiveSession/);
   assert.doesNotMatch(chainSource, /readFreshInteractiveSession/);
+});
+
+test("OpenClaw embed ticket minting stays root fenced and terminal scoped", async () => {
+	const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+	const start = source.indexOf("async function openClawCreateCrabboxEmbedTicket");
+	const end = source.indexOf("async function openClawRootScopedCrabbox", start);
+	const mintSource = source.slice(start, end);
+	const inputStart = source.indexOf("function terminalInputGrant");
+	const inputEnd = source.indexOf("function terminalSubscriptionReconciler", inputStart);
+	const inputSource = source.slice(inputStart, inputEnd);
+
+	assert.match(mintSource, /requireOpenClawRoomService/);
+	assert.match(mintSource, /openClawRootScopedCrabbox\(request, env, id, body\.rootSessionId\)/);
+	assert.match(mintSource, /createOpenClawEmbedTicket/);
+	assert.match(mintSource, /session does not advertise terminal access/);
+	assert.match(inputSource, /canControlEmbeddedTerminalRequest/);
 });
 
 test("interactive lineage rejects caller-claimed roots without a parent", async () => {


### PR DESCRIPTION
## Summary

- mint short-lived, HMAC-signed embed tickets for one root-fenced Crabfleet terminal session
- keep ticket signing behind a separate Crabfleet-only secret that room-service consumers never receive
- let ticketed session pages and terminal WebSockets view and control that session without a Crabfleet login
- reject sibling-session reuse and keep fleet/admin/clipboard capabilities unavailable
- document the service contract and ticket lifetime bounds

## Validation

- `pnpm test` (204 tests)
- `pnpm build`
- changed-file `oxlint` and `git diff --check`
- deployed Worker version `ecd25d6a-77cd-411e-8934-4af4086c408b`
- live proof after isolated signing-key deployment: session endpoint `200`, `canControl=true`, `sharedReadOnly=false`, sibling reuse `404`, terminal WebSocket open