### PR TITLE
fix(terminal): preserve embedded PTY readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Serve Ghostty's WASM runtime so embedded Codex workspaces mount the live interactive terminal instead of falling back to a static session transcript.
+- Serve Ghostty's WASM runtime and preserve embedded-session PTY readiness so Codex workspaces mount a live interactive terminal instead of a static session transcript.
 - De-duplicate the Go CLI and SSH gateway around shared control-plane models, authentication, lifecycle semantics, API calls, terminal operations, and terminal-safe session rendering.
 - Unify managed terminal clients on the multiplex `/api/terminal/ws` protocol, remove direct PTY routes, and share one framed Go transport across the CLI and SSH gateway.
 - Connect Crabfleet lifecycle and terminal traffic to Crabbox through a Cloudflare service binding and deploy an identical route-scoped credential atomically across both coordinators.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14521,7 +14521,7 @@ async function readSharedInteractiveSession(
       leaseId: null,
       attachUrl: null,
       vncUrl: null,
-      ptyAvailable: false,
+      ptyAvailable: interactiveSessionPtyAvailable(env, session, embedded),
       controller: activeController,
       controlGrantedAt: activeController ? session.controlGrantedAt : null,
       controlExpiresAt: activeController ? session.controlExpiresAt : null,
@@ -15855,6 +15855,25 @@ function sessionLogSummary(
   };
 }
 
+function interactiveSessionPtyAvailable(
+  env: RuntimeEnv,
+  session: InteractiveSession,
+  canControl: boolean,
+): boolean {
+  const routeKind = interactivePtyRouteKind(env, session);
+  const routeAvailable =
+    session.runtime === githubActionsRuntime ||
+    (routeKind === "sandbox"
+      ? Boolean(env.SANDBOX)
+      : Boolean(interactiveTerminalTarget(env, session, routeKind)));
+  const ptyAvailable =
+    canControl &&
+    session.capabilities.terminal &&
+    ["ready", "attached", "detached"].includes(session.status) &&
+    routeAvailable;
+  return ptyAvailable;
+}
+
 function decorateInteractiveSession(
   session: InteractiveSession,
   user: User,
@@ -15873,17 +15892,7 @@ function decorateInteractiveSession(
     session.adapter === runtimeAdapterName &&
     (session.capabilities.vnc || session.capabilities.desktop);
   const legacyDesktopUrl = desktopActive ? safeDesktopUrl(session.vncUrl) : null;
-  const routeKind = interactivePtyRouteKind(env, session);
-  const routeAvailable =
-    session.runtime === githubActionsRuntime ||
-    (routeKind === "sandbox"
-      ? Boolean(env.SANDBOX)
-      : Boolean(interactiveTerminalTarget(env, session, routeKind)));
-  const ptyAvailable =
-    canControl &&
-    session.capabilities.terminal &&
-    ["ready", "attached", "detached"].includes(session.status) &&
-    routeAvailable;
+  const ptyAvailable = interactiveSessionPtyAvailable(env, session, canControl);
   const attachUrl = ptyAvailable ? "/api/terminal/ws" : null;
   const codexSshReady =
     session.adapter === runtimeAdapterName &&

--- a/tests/openclaw-service.test.ts
+++ b/tests/openclaw-service.test.ts
@@ -256,17 +256,32 @@ test("OpenClaw embed ticket minting stays root fenced and terminal scoped", asyn
 	const end = source.indexOf("async function openClawRootScopedCrabbox", start);
 	const mintSource = source.slice(start, end);
 	const inputStart = source.indexOf("function terminalInputGrant");
-	const inputEnd = source.indexOf("function terminalSubscriptionReconciler", inputStart);
+  const inputEnd = source.indexOf("function terminalSubscriptionReconciler", inputStart);
   const inputSource = source.slice(inputStart, inputEnd);
+  const sharedStart = source.indexOf("async function readSharedInteractiveSession");
+  const sharedEnd = source.indexOf("async function openClawReadSessionChain", sharedStart);
+  const sharedSource = source.slice(sharedStart, sharedEnd);
+  const ptyStart = source.indexOf("function interactiveSessionPtyAvailable");
+  const ptyEnd = source.indexOf("function decorateInteractiveSession", ptyStart);
+  const ptySource = source.slice(ptyStart, ptyEnd);
   const secretStart = source.indexOf("function openClawEmbedTicketSecret");
   const secretEnd = source.indexOf("function requireOpenClawServiceToken", secretStart);
   const secretSource = source.slice(secretStart, secretEnd);
 
   assert.match(mintSource, /requireOpenClawRoomService/);
 	assert.match(mintSource, /openClawRootScopedCrabbox\(request, env, id, body\.rootSessionId\)/);
-	assert.match(mintSource, /createOpenClawEmbedTicket/);
+  assert.match(mintSource, /createOpenClawEmbedTicket/);
   assert.match(mintSource, /session does not advertise terminal access/);
   assert.match(inputSource, /canControlEmbeddedTerminalRequest/);
+  assert.match(
+    sharedSource,
+    /ptyAvailable: interactiveSessionPtyAvailable\(env, session, embedded\)/,
+  );
+  assert.match(sharedSource, /canControl: embedded/);
+  assert.match(sharedSource, /sharedReadOnly: !embedded/);
+  assert.match(ptySource, /interactivePtyRouteKind/);
+  assert.match(ptySource, /interactiveTerminalTarget/);
+  assert.match(ptySource, /\["ready", "attached", "detached"\]\.includes\(session\.status\)/);
   assert.match(secretSource, /CRABBOX_EMBED_TICKET_SECRET/);
   assert.doesNotMatch(secretSource, /CRABBOX_MULTICODEX_TOKEN|CRABBOX_OPENCLAW_TOKEN/);
 });

--- a/tests/runtime-adapter.test.ts
+++ b/tests/runtime-adapter.test.ts
@@ -1743,15 +1743,18 @@ test("terminal endpoints enforce current runtime capabilities", async () => {
     decorateStart,
   );
   const decorateSource = source.slice(decorateStart, decorateEnd);
+  const ptyStart = source.indexOf("function interactiveSessionPtyAvailable");
+  const ptySource = source.slice(ptyStart, decorateStart);
 
   assert.match(source, /type InteractiveSession = \{[\s\S]*ptyAvailable\?: boolean;/);
   assert.match(source, /if \(!session\.capabilities\.terminal\)/);
   assert.match(source, /runtimeCapabilities\(row\.runtime, row\.capabilities_json\)\.terminal/);
   assert.match(source, /runtimeAdapterTerminalFailureStatus\(existing\.adapter\) === "detached"/);
   assert.match(source, /attachUrl: capabilities\.terminal \? row\.attach_url : null/);
-  assert.match(decorateSource, /const routeKind = interactivePtyRouteKind\(env, session\)/);
-  assert.match(decorateSource, /interactiveTerminalTarget\(env, session, routeKind\)/);
-  assert.match(decorateSource, /routeAvailable/);
+  assert.match(ptySource, /const routeKind = interactivePtyRouteKind\(env, session\)/);
+  assert.match(ptySource, /interactiveTerminalTarget\(env, session, routeKind\)/);
+  assert.match(ptySource, /routeAvailable/);
+  assert.match(decorateSource, /interactiveSessionPtyAvailable\(env, session, canControl\)/);
   assert.match(decorateSource, /const attachUrl = ptyAvailable \? "\/api\/terminal\/ws" : null/);
   assert.match(decorateSource, /attachUrl,/);
   assert.doesNotMatch(
@@ -2151,8 +2154,11 @@ test("runtime adapter terminals use the server-side adapter bearer", async () =>
     decorateStart,
   );
   const decorateSource = source.slice(decorateStart, decorateEnd);
-  assert.match(decorateSource, /interactiveTerminalTarget\(env, session, routeKind\)/);
-  assert.match(decorateSource, /routeAvailable/);
+  const ptyStart = source.indexOf("function interactiveSessionPtyAvailable");
+  const ptySource = source.slice(ptyStart, decorateStart);
+  assert.match(ptySource, /interactiveTerminalTarget\(env, session, routeKind\)/);
+  assert.match(ptySource, /routeAvailable/);
+  assert.match(decorateSource, /interactiveSessionPtyAvailable\(env, session, canControl\)/);
 });
 
 test("runtime adapter terminal upgrades use the coordinator service binding", async () => {


### PR DESCRIPTION
## Summary
- derive embedded-session PTY readiness from the real terminal route
- keep ordinary shared links read-only while allowing signed MultiCodex embeds to attach and send input
- update terminal capability regression coverage

## Verification
- pnpm test
- pnpm build
- pnpm lint
- pnpm exec wrangler deploy --dry-run --containers-rollout=none
- live root cause reproduced against a signed embed