### PR TITLE
chore(deps): update libterminal to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@cloudflare/sandbox": "0.12.0",
-    "@openclaw/libterminal": "0.1.0",
+    "@openclaw/libterminal": "0.1.2",
     "kysely": "^0.29.2",
     "lucide-static": "^1.17.0",
     "preact": "^10.29.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 0.12.0
         version: 0.12.0
       '@openclaw/libterminal':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: 0.1.2
+        version: 0.1.2
       kysely:
         specifier: ^0.29.2
         version: 0.29.2
@@ -535,8 +535,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@openclaw/libterminal@0.1.0':
-    resolution: {integrity: sha512-mqaiEmr6yyMfZYRHED2TdwEd6+Ubb3eMz9BmON3xVPhZ3jWVzXn3cePqLeKq7mkSaT//QgJAIPrVojfoMTUHGQ==}
+  '@openclaw/libterminal@0.1.2':
+    resolution: {integrity: sha512-a0efrWM8EMEUrPJ9gWgsEeWD/WstJbNjgTTUwq4sxJCyuDDWOjjvz1KjrCGZ83B+0gMstYXcQAFR7f9/URQpQQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
       node-pty: '>=1.0.0'
@@ -1807,7 +1807,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@openclaw/libterminal@0.1.0':
+  '@openclaw/libterminal@0.1.2':
     dependencies:
       ghostty-web: 0.4.0
 


### PR DESCRIPTION
## Summary
- update the shared terminal package from `@openclaw/libterminal@0.1.0` to `0.1.2`
- consume the release hardening and Ghostty browser-smoke-gated package

## Validation
- `pnpm test` (621 passed)
- `pnpm check` typecheck and lint passed; the macOS format step reports existing repository-wide formatting drift outside this dependency-only diff
- autoreview clean