### PR TITLE
chore(deps): update libterminal to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add atomically claimed recurring card intervals with constant-time catch-up, crash-recoverable leases, scheduler/API proof, and coalescing for active or capacity-blocked runs, thanks @Jhacarreiro.
 - Reuse `@openclaw/libterminal` for terminal protocol codecs, Worker relays, Ghostty assets, and browser hub transport while keeping Crabfleet authorization and session policy local.
+- Update `@openclaw/libterminal` to 0.3.1 for terminal lifecycle, Worker asset generation, and package-validation fixes.
 - Fix automated Worker deployments by converging the app Custom Domain with the DNS-scoped deployment token instead of requiring zone-route access from the Worker token.
 
 ## 0.2.0 - 2026-06-15

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@cloudflare/sandbox": "0.12.0",
-    "@openclaw/libterminal": "0.3.0",
+    "@openclaw/libterminal": "0.3.1",
     "kysely": "^0.29.2",
     "lucide-static": "^1.17.0",
     "preact": "^10.29.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 0.12.0
         version: 0.12.0
       '@openclaw/libterminal':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.1
+        version: 0.3.1
       kysely:
         specifier: ^0.29.2
         version: 0.29.2
@@ -535,8 +535,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@openclaw/libterminal@0.3.0':
-    resolution: {integrity: sha512-Us3bRnwHI34lgqhhUog8HWA0+l2HY2JwVwISUJM8aaATODVfjsaK/FrjPZPztD1FJx+3TRvqwMBhZJkZpVSrSQ==}
+  '@openclaw/libterminal@0.3.1':
+    resolution: {integrity: sha512-nKEreLY6sdRvn+9UEcZhFpLYg3mJA4tmqNLZiYSMfislU11skiPWJfT7fn6ERsgAJsVMOSxeiVjBb5AX7dLKdQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
       node-pty: '>=1.0.0'
@@ -1807,7 +1807,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@openclaw/libterminal@0.3.0':
+  '@openclaw/libterminal@0.3.1':
     dependencies:
       ghostty-web: 0.4.0
 


### PR DESCRIPTION
## Summary

- update `@openclaw/libterminal` to 0.3.1
- record the terminal lifecycle, Worker asset generation, and package-validation update in the changelog

## Compatibility And Security

- no application API changes

## Validation

- `pnpm check`
- `pnpm test`
- `pnpm format`
- `git diff --check`