### PR TITLE
[codex] add private macOS tailnet desktop sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add app-owned macOS desktop hosting with ScreenCaptureKit, bounded Tight/JPEG RFB streaming, Accessibility-authorized input, an exact active-tailnet bind, and same-user Tailscale peer admission without Apple Screen Sharing or a public relay.
 - Add atomically claimed recurring card intervals with constant-time catch-up, crash-recoverable leases, scheduler/API proof, and coalescing for active or capacity-blocked runs, thanks @Jhacarreiro.
 - Reuse `@openclaw/libterminal` for terminal protocol codecs, Worker relays, Ghostty assets, and browser hub transport while keeping Crabfleet authorization and session policy local.
 - Update `@openclaw/libterminal` to 0.3.1 for terminal lifecycle, Worker asset generation, and package-validation fixes.

--- a/docs/macos-native-client.md
+++ b/docs/macos-native-client.md
@@ -8,7 +8,8 @@ description: "Scope, integration boundary, and security notes for the native mac
 # Native macOS client experiment
 
 Status: early prototype. The app lives in `macos/CrabfleetMac` and provides a
-SwiftUI fleet browser plus an AppKit-hosted, Metal-rendered VNC surface.
+SwiftUI fleet browser, an AppKit-hosted Metal-rendered VNC surface, and an
+app-owned private desktop host for Mac-to-Mac access.
 
 ## Product shape
 
@@ -26,6 +27,13 @@ SwiftUI fleet browser plus an AppKit-hosted, Metal-rendered VNC surface.
 - RFB 3.3, 3.7, and 3.8 framing is supported, including server-selected RFB
   3.3 None and VNC-password authentication.
 - Client-side fit scaling and rendering use RoyalVNCKit's IOSurface/Metal path.
+- Share This Mac captures the primary display with ScreenCaptureKit and serves
+  RFB 3.8 Tight/JPEG frames without enabling Apple's Screen Sharing daemon.
+- The host binds port 5901 only to a verified Tailscale `100.64.0.0/10` address,
+  requires a valid identity on the active tailnet, and admits only a
+  Tailscale-authorized peer owned by that same user.
+- Remote control is forwarded through Accessibility-authorized CGEvents. Screen
+  Recording and Accessibility remain explicit macOS permissions.
 
 The fork exposes an externally managed clipboard mode, so no VNC connection
 polls or writes `NSPasteboard.general` directly. One app-owned coordinator sends
@@ -39,6 +47,34 @@ fingerprints prevent delayed server echoes from erasing a newer copy without
 retaining clipboard history. Inbound and outbound text is capped at 1 MiB;
 standard RFB clipboard text must encode losslessly as ISO-8859-1, and
 unsupported text is rejected instead of silently becoming empty data.
+
+## Share This Mac
+
+The host path is deliberately app-owned. It does not start, configure, proxy,
+or depend on `screensharingd`, Remote Management, a VNC password, a public
+relay, Cloudflare, or the Crabfleet Worker.
+
+1. Tailscale status must report `BackendState=Running`, a valid active tailnet,
+   an online signed-in user, and a CGNAT address in `100.64.0.0/10`.
+2. The app captures the main display at a bounded even resolution no larger
+   than 1600×1000 and encodes at most 15 Tight/JPEG frames per second.
+3. An RFB listener binds only to that exact Tailscale IPv4 address on port 5901.
+4. Before sending the RFB banner or any framebuffer data, the app resolves the
+   peer through `tailscale whois` and requires an authorized node with the same
+   user ID and login as the host.
+5. The receiving Crabfleet app uses Quick Connect with the displayed
+   `vnc://100.x.y.z:5901` address and no VNC password.
+
+After the first Screen Recording grant, restart the bundled app before starting
+the share. Ad-hoc development signatures do not provide a stable TCC identity,
+so a rebuilt prototype may need permission again; a production-signed build is
+required for durable permission state.
+
+Tailscale supplies the encrypted, ACL-controlled transport and peer identity;
+RFB None authentication is accepted only inside that already-authenticated
+channel. The listener is not reachable on Wi-Fi, Ethernet, loopback, or a public
+address. The host app must remain running, and stopping the share cancels the
+listener and capture stream.
 
 ## License boundary
 
@@ -74,13 +110,20 @@ from the build, or obtain written provenance approval.
 - No input method editor integration.
 - Server-driven framebuffer resize works; client-requested remote resize does
   not exist yet.
-- RoyalVNCKit provides raw TCP only. Production connections must remain bound
-  to loopback behind an authenticated SSH tunnel.
+- RoyalVNCKit provides raw TCP only. Generic production connections must remain
+  bound to loopback behind an authenticated SSH tunnel; Share This Mac is the
+  identity-gated tailnet exception.
 - The hardened prototype negotiates standard VNC password or no-auth security
   only. ARD Diffie-Hellman, UltraVNC MS Logon II, Tight security, and TLS remain
   disabled until their parsers and cryptography are replaced or fully tested.
 - Password authentication uses a process-global DES key schedule. The fork
   serializes that path; replace it before concurrent password-auth sessions.
+- App-owned hosting is primary-display only, single-client, lossy Tight/JPEG,
+  and capped at 1600×1000 and 15 fps.
+- Host-to-client clipboard, audio, multi-display selection, display resize, and
+  unattended launch-at-login are not implemented.
+- A connecting peer must be another device owned by the same Tailscale user.
+  Team-wide or named-user sharing is intentionally unsupported.
 
 ## Next RoyalVNCKit fork requirements
 
@@ -108,6 +151,9 @@ an ephemeral credential without placing secrets in argv, URLs, logs, files, or
 defaults. The process owning that connection should remain foreground and end
 when the viewer closes. Until then, the fleet deck is authoritative only for
 Crabfleet-registered sessions and desktop attachment remains manual.
+
+Share This Mac does not use this Worker/runtime-adapter boundary. It is a local
+Mac-to-Mac path whose only network dependency is the local Tailscale client.
 
 ## Build
 

--- a/macos/CrabfleetMac/README.md
+++ b/macos/CrabfleetMac/README.md
@@ -1,6 +1,7 @@
 # Crabfleet for macOS prototype
 
-Native fleet browser and Metal-backed VNC client experiment.
+Native fleet browser, Metal-backed VNC client, and private Mac-to-Mac desktop
+sharing experiment.
 
 The current prototype includes a saved generic-VNC library, Crabfleet-aware
 desktop deck, Quick Connect, a matched card-to-desktop transition, a persistent
@@ -8,6 +9,27 @@ focused session, paced multi-session card previews, full-screen controls, and
 stabilized optional text clipboard synchronization. Up to six user-opened
 sessions stay warm; only the focused desktop owns input and clipboard routing.
 See the design note for the remaining zero-copy live-mosaic work.
+
+`Share This Mac` adds the missing server half without using Apple's Screen
+Sharing service. ScreenCaptureKit captures the primary display, Crabfleet sends
+bounded Tight/JPEG RFB updates, and Accessibility-authorized CGEvents forward
+keyboard and pointer input. The listener binds only to the Mac's verified
+Tailscale `100.64.0.0/10` address after confirming a valid identity on the active
+tailnet. Before the RFB handshake, `tailscale whois` must identify the peer as
+another authorized device owned by the same Tailscale user.
+
+On the receiving Mac, choose Quick Connect, paste the `vnc://100.x.y.z:5901`
+address shown by the host, and leave the password blank. RFB's None security
+type is intentional here: admission and encrypted transport belong to
+Tailscale, and the RFB socket is never bound to Wi-Fi, Ethernet, loopback, or a
+public address. Crabfleet must remain running on the host. The prototype allows
+one peer, captures the primary display at up to 1600×1000 and 15 fps, and does
+not forward host clipboard contents or audio.
+
+The first Screen Recording grant requires restarting the bundled app before
+macOS makes captured frames available. Ad-hoc development signatures can cause
+macOS to ask again after a rebuild; production signing is required for a stable
+permission identity.
 
 ## Build
 
@@ -36,9 +58,11 @@ The cookie is accepted only from the process environment and is never persisted
 by the prototype. Production authentication should use a dedicated native OAuth
 or device authorization flow.
 
-The current connection sheet targets an already-open local VNC endpoint, such
+The generic connection sheet still targets an already-open VNC endpoint, such
 as the loopback port produced by a Crabbox SSH tunnel. A structured, secret-safe
-Crabbox desktop-connection API is required before automatic connection can ship.
+Crabbox desktop-connection API is required before automatic lease connection can
+ship. `Share This Mac` is independent of that lease contract and uses only the
+local active tailnet.
 
 ## License boundary
 

--- a/macos/CrabfleetMac/Resources/Info.plist
+++ b/macos/CrabfleetMac/Resources/Info.plist
@@ -24,5 +24,7 @@
     <string>14.0</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>Crabfleet connects to and shares remote desktops only on your private Tailscale network.</string>
 </dict>
 </plist>

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/FleetRootView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/FleetRootView.swift
@@ -5,6 +5,7 @@ struct FleetRootView: View {
   @ObservedObject var store: FleetStore
   @ObservedObject var connections: ConnectionLibrary
   @ObservedObject var sessions: VNCSessionPool
+  @StateObject private var privateShare = PrivateMacShareController()
 
   @Namespace private var desktopTransition
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -14,6 +15,7 @@ struct FleetRootView: View {
   @State private var focusedTargetID: DesktopTarget.ID?
   @State private var connectionTarget: DesktopTarget?
   @State private var showingQuickConnect = false
+  @State private var showingPrivateShare = false
 
   private var allTargets: [DesktopTarget] {
     let saved = connections.profiles.map(DesktopTarget.init(profile:))
@@ -65,6 +67,7 @@ struct FleetRootView: View {
             targets: allTargets,
             currentUser: store.currentUser,
             notice: store.notice,
+            shareThisMac: { showingPrivateShare = true },
             quickConnect: { showingQuickConnect = true }
           )
           Divider().overlay(.white.opacity(0.07))
@@ -109,6 +112,9 @@ struct FleetRootView: View {
         connections.markConnected(profileID: profile.id)
         focus(target.id)
       }
+    }
+    .sheet(isPresented: $showingPrivateShare) {
+      PrivateMacShareSheet(controller: privateShare)
     }
     .onExitCommand(perform: closeFocus)
     .onChange(of: allTargets.map(\.id)) { _, targetIDs in
@@ -160,6 +166,7 @@ private struct DesktopSourceRail: View {
   let targets: [DesktopTarget]
   let currentUser: String
   let notice: String?
+  let shareThisMac: () -> Void
   let quickConnect: () -> Void
 
   var body: some View {
@@ -214,6 +221,24 @@ private struct DesktopSourceRail: View {
           .padding(.horizontal, 17)
           .padding(.bottom, 13)
       }
+
+      Button(action: shareThisMac) {
+        HStack(spacing: 8) {
+          Image(systemName: "display.and.arrow.down")
+          Text("Share This Mac")
+          Spacer()
+          Image(systemName: "lock.shield")
+            .font(.system(size: 10))
+            .foregroundStyle(.mint)
+        }
+        .font(.system(size: 12, weight: .semibold, design: .rounded))
+        .padding(.horizontal, 12)
+        .frame(height: 36)
+        .background(.mint.opacity(0.07), in: RoundedRectangle(cornerRadius: 8))
+      }
+      .buttonStyle(.plain)
+      .padding(.horizontal, 12)
+      .padding(.bottom, 5)
 
       Button(action: quickConnect) {
         HStack(spacing: 8) {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/MacRemoteInput.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/MacRemoteInput.swift
@@ -1,0 +1,209 @@
+import ApplicationServices
+import Carbon.HIToolbox
+import Foundation
+
+protocol RemoteInputForwarding: Sendable {
+  func keyEvent(down: Bool, keysym: UInt32)
+  func pointerEvent(buttonMask: UInt8, x: UInt16, y: UInt16)
+}
+
+final class MacRemoteInputController: RemoteInputForwarding, @unchecked Sendable {
+  private let descriptor: CapturedDisplayDescriptor
+  private let eventQueue = DispatchQueue(
+    label: "org.openclaw.crabfleet.remote-input",
+    qos: .userInteractive
+  )
+  private var previousButtonMask: UInt8 = 0
+
+  init(descriptor: CapturedDisplayDescriptor) {
+    self.descriptor = descriptor
+  }
+
+  static var isAccessibilityGranted: Bool {
+    AXIsProcessTrusted()
+  }
+
+  @discardableResult
+  static func requestAccessibility() -> Bool {
+    let options =
+      [
+        kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true
+      ] as CFDictionary
+    return AXIsProcessTrustedWithOptions(options)
+  }
+
+  func keyEvent(down: Bool, keysym: UInt32) {
+    eventQueue.async { [self] in
+      guard Self.isAccessibilityGranted else { return }
+      let event: CGEvent?
+      if let keyCode = Self.keyCode(for: keysym) {
+        event = CGEvent(keyboardEventSource: eventSource(), virtualKey: keyCode, keyDown: down)
+      } else if let scalar = UnicodeScalar(keysym) {
+        let candidate = CGEvent(keyboardEventSource: eventSource(), virtualKey: 0, keyDown: down)
+        var codeUnits = Array(String(scalar).utf16)
+        candidate?.keyboardSetUnicodeString(
+          stringLength: codeUnits.count,
+          unicodeString: &codeUnits
+        )
+        event = candidate
+      } else {
+        event = nil
+      }
+      event?.post(tap: .cghidEventTap)
+    }
+  }
+
+  func pointerEvent(buttonMask: UInt8, x: UInt16, y: UInt16) {
+    eventQueue.async { [self] in
+      guard Self.isAccessibilityGranted else { return }
+      let location = mappedLocation(x: x, y: y)
+      let changedButtons = previousButtonMask ^ buttonMask
+      var postedButtonChange = false
+
+      for button in Self.mouseButtons where changedButtons & button.mask != 0 {
+        let isDown = buttonMask & button.mask != 0
+        let type = isDown ? button.downType : button.upType
+        CGEvent(
+          mouseEventSource: eventSource(),
+          mouseType: type,
+          mouseCursorPosition: location,
+          mouseButton: button.button
+        )?.post(tap: .cghidEventTap)
+        postedButtonChange = true
+      }
+
+      if !postedButtonChange {
+        let moveType: CGEventType
+        if buttonMask & 0x01 != 0 {
+          moveType = .leftMouseDragged
+        } else if buttonMask & 0x04 != 0 {
+          moveType = .rightMouseDragged
+        } else if buttonMask & 0x02 != 0 {
+          moveType = .otherMouseDragged
+        } else {
+          moveType = .mouseMoved
+        }
+        CGEvent(
+          mouseEventSource: eventSource(),
+          mouseType: moveType,
+          mouseCursorPosition: location,
+          mouseButton: .left
+        )?.post(tap: .cghidEventTap)
+      }
+
+      let newWheelBits = buttonMask & ~previousButtonMask
+      if newWheelBits & 0x08 != 0 { postScroll(vertical: 1, horizontal: 0) }
+      if newWheelBits & 0x10 != 0 { postScroll(vertical: -1, horizontal: 0) }
+      if newWheelBits & 0x20 != 0 { postScroll(vertical: 0, horizontal: 1) }
+      if newWheelBits & 0x40 != 0 { postScroll(vertical: 0, horizontal: -1) }
+      previousButtonMask = buttonMask
+    }
+  }
+
+  private func eventSource() -> CGEventSource? {
+    CGEventSource(stateID: .hidSystemState)
+  }
+
+  private func mappedLocation(x: UInt16, y: UInt16) -> CGPoint {
+    let width = max(descriptor.frameWidth - 1, 1)
+    let height = max(descriptor.frameHeight - 1, 1)
+    let xRatio = min(max(CGFloat(x) / CGFloat(width), 0), 1)
+    let yRatio = min(max(CGFloat(y) / CGFloat(height), 0), 1)
+    return CGPoint(
+      x: descriptor.displayBounds.minX + xRatio * descriptor.displayBounds.width,
+      y: descriptor.displayBounds.minY + yRatio * descriptor.displayBounds.height
+    )
+  }
+
+  private func postScroll(vertical: Int32, horizontal: Int32) {
+    CGEvent(
+      scrollWheelEvent2Source: eventSource(),
+      units: .line,
+      wheelCount: 2,
+      wheel1: vertical,
+      wheel2: horizontal,
+      wheel3: 0
+    )?.post(tap: .cghidEventTap)
+  }
+
+  static func keyCode(for keysym: UInt32) -> CGKeyCode? {
+    if let ascii = UnicodeScalar(keysym), ascii.isASCII {
+      let character = Character(String(ascii).lowercased())
+      if let code = asciiKeyCodes[character] { return code }
+    }
+
+    switch keysym {
+    case 0xFF08: return CGKeyCode(kVK_Delete)
+    case 0xFF09: return CGKeyCode(kVK_Tab)
+    case 0xFF0D: return CGKeyCode(kVK_Return)
+    case 0xFF1B: return CGKeyCode(kVK_Escape)
+    case 0xFF50: return CGKeyCode(kVK_Home)
+    case 0xFF51: return CGKeyCode(kVK_LeftArrow)
+    case 0xFF52: return CGKeyCode(kVK_UpArrow)
+    case 0xFF53: return CGKeyCode(kVK_RightArrow)
+    case 0xFF54: return CGKeyCode(kVK_DownArrow)
+    case 0xFF55: return CGKeyCode(kVK_PageUp)
+    case 0xFF56: return CGKeyCode(kVK_PageDown)
+    case 0xFF57: return CGKeyCode(kVK_End)
+    case 0xFF63: return CGKeyCode(kVK_Help)
+    case 0xFFFF: return CGKeyCode(kVK_ForwardDelete)
+    case 0xFFE1: return CGKeyCode(kVK_Shift)
+    case 0xFFE2: return CGKeyCode(kVK_RightShift)
+    case 0xFFE3: return CGKeyCode(kVK_Control)
+    case 0xFFE4: return CGKeyCode(kVK_RightControl)
+    case 0xFFE7, 0xFFEB: return CGKeyCode(kVK_Command)
+    case 0xFFE8, 0xFFEC: return CGKeyCode(kVK_RightCommand)
+    case 0xFFE9: return CGKeyCode(kVK_Option)
+    case 0xFFEA: return CGKeyCode(kVK_RightOption)
+    case 0xFFBE...0xFFC9:
+      let functionKeys: [CGKeyCode] = [
+        CGKeyCode(kVK_F1), CGKeyCode(kVK_F2), CGKeyCode(kVK_F3), CGKeyCode(kVK_F4),
+        CGKeyCode(kVK_F5), CGKeyCode(kVK_F6), CGKeyCode(kVK_F7), CGKeyCode(kVK_F8),
+        CGKeyCode(kVK_F9), CGKeyCode(kVK_F10), CGKeyCode(kVK_F11), CGKeyCode(kVK_F12),
+      ]
+      return functionKeys[Int(keysym - 0xFFBE)]
+    default:
+      return nil
+    }
+  }
+
+  private static let asciiKeyCodes: [Character: CGKeyCode] = [
+    "a": CGKeyCode(kVK_ANSI_A), "b": CGKeyCode(kVK_ANSI_B),
+    "c": CGKeyCode(kVK_ANSI_C), "d": CGKeyCode(kVK_ANSI_D),
+    "e": CGKeyCode(kVK_ANSI_E), "f": CGKeyCode(kVK_ANSI_F),
+    "g": CGKeyCode(kVK_ANSI_G), "h": CGKeyCode(kVK_ANSI_H),
+    "i": CGKeyCode(kVK_ANSI_I), "j": CGKeyCode(kVK_ANSI_J),
+    "k": CGKeyCode(kVK_ANSI_K), "l": CGKeyCode(kVK_ANSI_L),
+    "m": CGKeyCode(kVK_ANSI_M), "n": CGKeyCode(kVK_ANSI_N),
+    "o": CGKeyCode(kVK_ANSI_O), "p": CGKeyCode(kVK_ANSI_P),
+    "q": CGKeyCode(kVK_ANSI_Q), "r": CGKeyCode(kVK_ANSI_R),
+    "s": CGKeyCode(kVK_ANSI_S), "t": CGKeyCode(kVK_ANSI_T),
+    "u": CGKeyCode(kVK_ANSI_U), "v": CGKeyCode(kVK_ANSI_V),
+    "w": CGKeyCode(kVK_ANSI_W), "x": CGKeyCode(kVK_ANSI_X),
+    "y": CGKeyCode(kVK_ANSI_Y), "z": CGKeyCode(kVK_ANSI_Z),
+    "0": CGKeyCode(kVK_ANSI_0), "1": CGKeyCode(kVK_ANSI_1),
+    "2": CGKeyCode(kVK_ANSI_2), "3": CGKeyCode(kVK_ANSI_3),
+    "4": CGKeyCode(kVK_ANSI_4), "5": CGKeyCode(kVK_ANSI_5),
+    "6": CGKeyCode(kVK_ANSI_6), "7": CGKeyCode(kVK_ANSI_7),
+    "8": CGKeyCode(kVK_ANSI_8), "9": CGKeyCode(kVK_ANSI_9),
+    " ": CGKeyCode(kVK_Space), "-": CGKeyCode(kVK_ANSI_Minus),
+    "=": CGKeyCode(kVK_ANSI_Equal), "[": CGKeyCode(kVK_ANSI_LeftBracket),
+    "]": CGKeyCode(kVK_ANSI_RightBracket), "\\": CGKeyCode(kVK_ANSI_Backslash),
+    ";": CGKeyCode(kVK_ANSI_Semicolon), "'": CGKeyCode(kVK_ANSI_Quote),
+    ",": CGKeyCode(kVK_ANSI_Comma), ".": CGKeyCode(kVK_ANSI_Period),
+    "/": CGKeyCode(kVK_ANSI_Slash), "`": CGKeyCode(kVK_ANSI_Grave),
+  ]
+
+  private static let mouseButtons: [MouseButtonMapping] = [
+    .init(mask: 0x01, button: .left, downType: .leftMouseDown, upType: .leftMouseUp),
+    .init(mask: 0x02, button: .center, downType: .otherMouseDown, upType: .otherMouseUp),
+    .init(mask: 0x04, button: .right, downType: .rightMouseDown, upType: .rightMouseUp),
+  ]
+}
+
+private struct MouseButtonMapping {
+  let mask: UInt8
+  let button: CGMouseButton
+  let downType: CGEventType
+  let upType: CGEventType
+}

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/MacScreenCapture.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/MacScreenCapture.swift
@@ -1,0 +1,196 @@
+import CoreImage
+import Foundation
+import ImageIO
+import ScreenCaptureKit
+import UniformTypeIdentifiers
+
+struct CapturedDesktopFrame: Sendable {
+  let jpegData: Data
+  let sequence: UInt64
+  let width: Int
+  let height: Int
+}
+
+actor CapturedDesktopFrameStore {
+  private var latestFrame: CapturedDesktopFrame?
+
+  func update(_ frame: CapturedDesktopFrame) {
+    guard frame.sequence >= (latestFrame?.sequence ?? 0) else { return }
+    latestFrame = frame
+  }
+
+  func latest() -> CapturedDesktopFrame? {
+    latestFrame
+  }
+
+  func clear() {
+    latestFrame = nil
+  }
+}
+
+struct CapturedDisplayDescriptor: Equatable, Sendable {
+  let displayID: CGDirectDisplayID
+  let displayBounds: CGRect
+  let frameWidth: Int
+  let frameHeight: Int
+}
+
+final class MacScreenCapture: NSObject, @unchecked Sendable {
+  let frameStore = CapturedDesktopFrameStore()
+
+  private let captureQueue = DispatchQueue(
+    label: "org.openclaw.crabfleet.screen-capture",
+    qos: .userInteractive
+  )
+  private let imageContext = CIContext(options: [
+    .cacheIntermediates: false
+  ])
+  private let frameLock = NSLock()
+  private var sequence: UInt64 = 0
+  private var consumerActive = false
+  private var stream: SCStream?
+
+  func start() async throws -> CapturedDisplayDescriptor {
+    guard CGPreflightScreenCaptureAccess() else {
+      throw PrivateMacShareError.screenRecordingDenied
+    }
+
+    let displayID = CGMainDisplayID()
+    let shareableContent = try await SCShareableContent.current
+    guard let display = shareableContent.displays.first(where: { $0.displayID == displayID }) else {
+      throw PrivateMacShareError.captureUnavailable
+    }
+
+    let dimensions = Self.captureDimensions(
+      sourceWidth: display.width, sourceHeight: display.height)
+    let configuration = SCStreamConfiguration()
+    configuration.width = dimensions.width
+    configuration.height = dimensions.height
+    configuration.pixelFormat = kCVPixelFormatType_32BGRA
+    configuration.minimumFrameInterval = CMTime(value: 1, timescale: 15)
+    configuration.queueDepth = 3
+    configuration.showsCursor = true
+    configuration.capturesAudio = false
+    configuration.colorSpaceName = CGColorSpace.sRGB
+
+    let filter = SCContentFilter(display: display, excludingWindows: [])
+    let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
+    try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: captureQueue)
+    try await stream.startCapture()
+    self.stream = stream
+
+    return CapturedDisplayDescriptor(
+      displayID: displayID,
+      displayBounds: CGDisplayBounds(displayID),
+      frameWidth: dimensions.width,
+      frameHeight: dimensions.height
+    )
+  }
+
+  func stop() async {
+    guard let stream else { return }
+    self.stream = nil
+    try? await stream.stopCapture()
+    await frameStore.clear()
+  }
+
+  func setConsumerActive(_ isActive: Bool) {
+    frameLock.lock()
+    consumerActive = isActive
+    frameLock.unlock()
+  }
+
+  static func captureDimensions(sourceWidth: Int, sourceHeight: Int) -> (
+    width: Int,
+    height: Int
+  ) {
+    let maximumWidth = 1_600.0
+    let maximumHeight = 1_000.0
+    let width = max(Double(sourceWidth), 1)
+    let height = max(Double(sourceHeight), 1)
+    let scale = min(1, maximumWidth / width, maximumHeight / height)
+    let scaledWidth = max(2, Int((width * scale).rounded(.down)) & ~1)
+    let scaledHeight = max(2, Int((height * scale).rounded(.down)) & ~1)
+    return (scaledWidth, scaledHeight)
+  }
+
+  private func nextSequence() -> UInt64 {
+    frameLock.lock()
+    defer { frameLock.unlock() }
+    sequence &+= 1
+    return sequence
+  }
+
+  private func shouldEncodeFrame() -> Bool {
+    frameLock.lock()
+    defer { frameLock.unlock() }
+    return consumerActive
+  }
+
+  private func encodeJPEG(_ pixelBuffer: CVPixelBuffer) -> Data? {
+    let width = CVPixelBufferGetWidth(pixelBuffer)
+    let height = CVPixelBufferGetHeight(pixelBuffer)
+    let image = CIImage(cvPixelBuffer: pixelBuffer)
+    guard
+      let cgImage = imageContext.createCGImage(
+        image,
+        from: CGRect(x: 0, y: 0, width: width, height: height)
+      )
+    else {
+      return nil
+    }
+
+    let data = NSMutableData()
+    guard
+      let destination = CGImageDestinationCreateWithData(
+        data,
+        UTType.jpeg.identifier as CFString,
+        1,
+        nil
+      )
+    else {
+      return nil
+    }
+    let properties =
+      [
+        kCGImageDestinationLossyCompressionQuality: 0.72
+      ] as CFDictionary
+    CGImageDestinationAddImage(destination, cgImage, properties)
+    guard CGImageDestinationFinalize(destination) else { return nil }
+    return data as Data
+  }
+}
+
+extension MacScreenCapture: SCStreamOutput, SCStreamDelegate {
+  func stream(
+    _ stream: SCStream,
+    didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+    of outputType: SCStreamOutputType
+  ) {
+    guard
+      outputType == .screen,
+      sampleBuffer.isValid,
+      shouldEncodeFrame(),
+      let attachmentsArray = CMSampleBufferGetSampleAttachmentsArray(
+        sampleBuffer,
+        createIfNecessary: false
+      ) as? [[SCStreamFrameInfo: Any]],
+      let attachments = attachmentsArray.first,
+      let statusRawValue = attachments[.status] as? Int,
+      SCFrameStatus(rawValue: statusRawValue) == .complete,
+      let pixelBuffer = sampleBuffer.imageBuffer,
+      let jpegData = encodeJPEG(pixelBuffer),
+      jpegData.count <= 4 * 1_024 * 1_024
+    else {
+      return
+    }
+
+    let frame = CapturedDesktopFrame(
+      jpegData: jpegData,
+      sequence: nextSequence(),
+      width: CVPixelBufferGetWidth(pixelBuffer),
+      height: CVPixelBufferGetHeight(pixelBuffer)
+    )
+    Task { await frameStore.update(frame) }
+  }
+}

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
@@ -1,0 +1,251 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+@MainActor
+final class PrivateMacShareController: ObservableObject {
+  enum Phase: Equatable {
+    case idle
+    case starting
+    case sharing
+    case authorizing
+    case connected
+    case stopping
+    case failed
+
+    var title: String {
+      switch self {
+      case .idle: "Off"
+      case .starting: "Starting"
+      case .sharing: "Ready"
+      case .authorizing: "Authenticating peer"
+      case .connected: "Connected"
+      case .stopping: "Stopping"
+      case .failed: "Failed"
+      }
+    }
+
+    var isRunning: Bool {
+      [.starting, .sharing, .authorizing, .connected].contains(self)
+    }
+  }
+
+  static let port: UInt16 = 5_901
+
+  @Published private(set) var identity: TailnetIdentity?
+  @Published private(set) var phase: Phase = .idle
+  @Published private(set) var screenRecordingGranted = CGPreflightScreenCaptureAccess()
+  @Published private(set) var accessibilityGranted = MacRemoteInputController
+    .isAccessibilityGranted
+  @Published private(set) var connectedPeer: String?
+  @Published private(set) var notice: String?
+  @Published private(set) var isRefreshing = false
+
+  private let runner: (any TailscaleCommandRunning)?
+  private let runnerInitializationError: Error?
+  private var capture: MacScreenCapture?
+  private var server: TailnetRFBServer?
+  private var serverGeneration: UUID?
+
+  init(runner: (any TailscaleCommandRunning)? = nil) {
+    if let runner {
+      self.runner = runner
+      runnerInitializationError = nil
+    } else {
+      do {
+        self.runner = try SystemTailscaleCommandRunner()
+        runnerInitializationError = nil
+      } catch {
+        self.runner = nil
+        runnerInitializationError = error
+      }
+    }
+  }
+
+  var connectionAddress: String? {
+    identity?.vncAddress(port: Int(Self.port))
+  }
+
+  var canStart: Bool {
+    phase == .idle && identity != nil && screenRecordingGranted && accessibilityGranted
+  }
+
+  func refresh() async {
+    guard !isRefreshing, phase != .starting, phase != .stopping else { return }
+    isRefreshing = true
+    notice = nil
+    await loadIdentity()
+    refreshPermissions()
+    isRefreshing = false
+  }
+
+  func requestScreenRecordingPermission() async {
+    guard !screenRecordingGranted else { return }
+    _ = CGRequestScreenCaptureAccess()
+    refreshPermissions()
+    if !screenRecordingGranted {
+      notice = PrivateMacShareError.screenRecordingDenied.localizedDescription
+    }
+  }
+
+  func requestAccessibilityPermission() {
+    guard !accessibilityGranted else { return }
+    _ = MacRemoteInputController.requestAccessibility()
+    refreshPermissions()
+    if !accessibilityGranted {
+      notice = PrivateMacShareError.accessibilityDenied.localizedDescription
+    }
+  }
+
+  func start() async {
+    guard phase == .idle else { return }
+    phase = .starting
+    notice = nil
+    connectedPeer = nil
+    await loadIdentity()
+    refreshPermissions()
+
+    guard let identity else {
+      phase = .failed
+      notice = notice ?? PrivateMacShareError.invalidTailnetIdentity.localizedDescription
+      return
+    }
+    guard screenRecordingGranted else {
+      phase = .idle
+      notice = PrivateMacShareError.screenRecordingDenied.localizedDescription
+      return
+    }
+    guard accessibilityGranted else {
+      phase = .idle
+      notice = PrivateMacShareError.accessibilityDenied.localizedDescription
+      return
+    }
+    guard let runner else {
+      phase = .failed
+      notice =
+        (runnerInitializationError ?? PrivateMacShareError.tailscaleNotInstalled)
+        .localizedDescription
+      return
+    }
+
+    let capture = MacScreenCapture()
+    do {
+      let descriptor = try await capture.start()
+      let input = MacRemoteInputController(descriptor: descriptor)
+      let generation = UUID()
+      serverGeneration = generation
+      let server = TailnetRFBServer(
+        identity: identity,
+        runner: runner,
+        capture: capture,
+        descriptor: descriptor,
+        input: input,
+        port: Self.port,
+        eventHandler: { [weak self] event in
+          Task { @MainActor in self?.handle(event, generation: generation) }
+        }
+      )
+      try server.start()
+      self.capture = capture
+      self.server = server
+    } catch {
+      serverGeneration = nil
+      await capture.stop()
+      phase = .failed
+      notice = error.localizedDescription
+    }
+  }
+
+  func stop() async {
+    guard phase.isRunning || phase == .failed else { return }
+    phase = .stopping
+    connectedPeer = nil
+    serverGeneration = nil
+    server?.stop()
+    server = nil
+    let capture = capture
+    self.capture = nil
+    await capture?.stop()
+    phase = .idle
+  }
+
+  func openPrivacySettings(_ pane: PrivacyPane) {
+    let value: String
+    switch pane {
+    case .screenRecording:
+      value = "Privacy_ScreenCapture"
+    case .accessibility:
+      value = "Privacy_Accessibility"
+    }
+    guard
+      let url = URL(
+        string: "x-apple.systempreferences:com.apple.preference.security?\(value)"
+      )
+    else { return }
+    NSWorkspace.shared.open(url)
+  }
+
+  enum PrivacyPane {
+    case screenRecording
+    case accessibility
+  }
+
+  private func loadIdentity() async {
+    guard let runner else {
+      identity = nil
+      notice =
+        (runnerInitializationError ?? PrivateMacShareError.tailscaleNotInstalled)
+        .localizedDescription
+      return
+    }
+    do {
+      let result = try await runner.run(arguments: ["status", "--json"])
+      let document = try JSONDecoder().decode(
+        TailscaleStatusDocument.self,
+        from: Data(result.standardOutput.utf8)
+      )
+      identity = try TailnetIdentityPolicy.identity(from: document)
+    } catch {
+      identity = nil
+      notice = error.localizedDescription
+    }
+  }
+
+  private func refreshPermissions() {
+    screenRecordingGranted = CGPreflightScreenCaptureAccess()
+    accessibilityGranted = MacRemoteInputController.isAccessibilityGranted
+  }
+
+  private func handle(_ event: TailnetRFBServerEvent, generation: UUID) {
+    guard serverGeneration == generation else { return }
+    switch event {
+    case .listening:
+      phase = .sharing
+      notice = nil
+    case .authorizing(let peer):
+      phase = .authorizing
+      connectedPeer = peer
+    case .connected(let peer):
+      phase = .connected
+      connectedPeer = peer
+      notice = nil
+    case .disconnected:
+      phase = .sharing
+      connectedPeer = nil
+    case .listenerFailed(let message):
+      phase = .failed
+      connectedPeer = nil
+      notice = PrivateMacShareError.listenerFailed(message).localizedDescription
+      serverGeneration = nil
+      server?.stop()
+      server = nil
+      let failedCapture = capture
+      capture = nil
+      Task { await failedCapture?.stop() }
+    case .sessionFailed(let message):
+      phase = .sharing
+      connectedPeer = nil
+      notice = message
+    }
+  }
+}

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
@@ -1,0 +1,181 @@
+import AppKit
+import SwiftUI
+
+struct PrivateMacShareSheet: View {
+  @ObservedObject var controller: PrivateMacShareController
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 20) {
+      HStack(spacing: 12) {
+        ZStack {
+          RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .fill(.mint.opacity(0.1))
+          Image(systemName: "display.and.arrow.down")
+            .font(.system(size: 20, weight: .light))
+            .foregroundStyle(.mint)
+        }
+        .frame(width: 42, height: 42)
+
+        VStack(alignment: .leading, spacing: 2) {
+          Text("Share This Mac")
+            .font(.title3.weight(.semibold))
+          Text("App-owned remote desktop, restricted to your current Tailscale identity.")
+            .foregroundStyle(.secondary)
+        }
+      }
+
+      VStack(spacing: 1) {
+        ShareStatusRow(
+          title: "Tailscale tailnet",
+          detail: controller.identity.map {
+            "\($0.tailnetName) · \($0.loginName) · \($0.ipv4Address)"
+          } ?? "Not verified",
+          isReady: controller.identity != nil
+        )
+        ShareStatusRow(
+          title: "Screen Recording",
+          detail: controller.screenRecordingGranted ? "Allowed" : "Permission required",
+          isReady: controller.screenRecordingGranted,
+          actionTitle: controller.screenRecordingGranted ? nil : "Allow"
+        ) {
+          Task { await controller.requestScreenRecordingPermission() }
+        }
+        ShareStatusRow(
+          title: "Remote control",
+          detail: controller.accessibilityGranted ? "Accessibility allowed" : "Permission required",
+          isReady: controller.accessibilityGranted,
+          actionTitle: controller.accessibilityGranted ? nil : "Allow"
+        ) {
+          controller.requestAccessibilityPermission()
+        }
+        ShareStatusRow(
+          title: "Private desktop",
+          detail: phaseDetail,
+          isReady: controller.phase.isRunning
+        )
+      }
+      .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+      if controller.phase.isRunning, let address = controller.connectionAddress {
+        VStack(alignment: .leading, spacing: 10) {
+          Text("CONNECT FROM YOUR OTHER MAC")
+            .font(.system(size: 9, weight: .bold, design: .monospaced))
+            .tracking(0.8)
+            .foregroundStyle(.secondary)
+          HStack(spacing: 10) {
+            Text(address)
+              .font(.system(.body, design: .monospaced))
+              .textSelection(.enabled)
+            Spacer()
+            Button("Copy", systemImage: "doc.on.doc") {
+              NSPasteboard.general.clearContents()
+              NSPasteboard.general.setString(address, forType: .string)
+            }
+          }
+          Text(
+            "Open Crabfleet, choose Quick Connect, paste this address, and leave the password blank."
+          )
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        }
+        .padding(14)
+        .background(.mint.opacity(0.07), in: RoundedRectangle(cornerRadius: 10))
+      }
+
+      if let notice = controller.notice {
+        Label(notice, systemImage: "exclamationmark.triangle")
+          .font(.caption)
+          .foregroundStyle(.orange)
+          .fixedSize(horizontal: false, vertical: true)
+      } else {
+        Label(
+          "No Apple Screen Sharing service is used. The listener binds only to this Mac’s Tailscale address and accepts only another device owned by the same Tailscale user.",
+          systemImage: "lock.shield"
+        )
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+      }
+
+      HStack {
+        Menu("Privacy Settings") {
+          Button("Screen Recording") {
+            controller.openPrivacySettings(.screenRecording)
+          }
+          Button("Accessibility") {
+            controller.openPrivacySettings(.accessibility)
+          }
+        }
+
+        Button("Refresh") {
+          Task { await controller.refresh() }
+        }
+        .disabled(controller.isRefreshing || controller.phase == .starting)
+
+        Spacer()
+
+        Button("Close") { dismiss() }
+          .keyboardShortcut(.cancelAction)
+
+        if controller.phase.isRunning || controller.phase == .failed {
+          Button("Stop Sharing", role: .destructive) {
+            Task { await controller.stop() }
+          }
+          .disabled(controller.phase == .stopping)
+        } else {
+          Button("Start Private Share") {
+            Task { await controller.start() }
+          }
+          .buttonStyle(.borderedProminent)
+          .keyboardShortcut(.defaultAction)
+          .disabled(!controller.canStart)
+        }
+      }
+
+      Text("Crabfleet must remain running on this Mac while you are connected.")
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
+    }
+    .padding(24)
+    .frame(width: 590)
+    .task { await controller.refresh() }
+  }
+
+  private var phaseDetail: String {
+    if let peer = controller.connectedPeer {
+      return "\(controller.phase.title) · \(peer)"
+    }
+    return controller.phase.title
+  }
+}
+
+private struct ShareStatusRow: View {
+  let title: String
+  let detail: String
+  let isReady: Bool
+  var actionTitle: String?
+  var action: () -> Void = {}
+
+  var body: some View {
+    HStack(spacing: 10) {
+      Image(systemName: isReady ? "checkmark.circle.fill" : "circle.dashed")
+        .foregroundStyle(isReady ? .mint : .orange)
+        .frame(width: 18)
+      Text(title)
+        .font(.system(size: 12, weight: .semibold, design: .rounded))
+      Spacer()
+      Text(detail)
+        .font(.system(size: 11, design: .rounded))
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+      if let actionTitle {
+        Button(actionTitle, action: action)
+          .controlSize(.small)
+      }
+    }
+    .padding(.horizontal, 12)
+    .frame(height: 42)
+    .background(.white.opacity(0.045))
+  }
+}

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/RFBWire.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/RFBWire.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+enum RFBVersion: Comparable, Sendable {
+  case v3Point3
+  case v3Point7
+  case v3Point8
+
+  static let serverBanner = Data("RFB 003.008\n".utf8)
+
+  init?(banner: Data) {
+    guard banner.count == 12 else { return nil }
+    switch String(decoding: banner, as: UTF8.self) {
+    case "RFB 003.003\n": self = .v3Point3
+    case "RFB 003.007\n": self = .v3Point7
+    case "RFB 003.008\n": self = .v3Point8
+    default: return nil
+    }
+  }
+}
+
+struct RFBPixelFormat: Equatable, Sendable {
+  let bitsPerPixel: UInt8
+  let depth: UInt8
+  let bigEndian: Bool
+  let trueColor: Bool
+  let redMax: UInt16
+  let greenMax: UInt16
+  let blueMax: UInt16
+  let redShift: UInt8
+  let greenShift: UInt8
+  let blueShift: UInt8
+
+  init(
+    bitsPerPixel: UInt8,
+    depth: UInt8,
+    bigEndian: Bool,
+    trueColor: Bool,
+    redMax: UInt16,
+    greenMax: UInt16,
+    blueMax: UInt16,
+    redShift: UInt8,
+    greenShift: UInt8,
+    blueShift: UInt8
+  ) {
+    self.bitsPerPixel = bitsPerPixel
+    self.depth = depth
+    self.bigEndian = bigEndian
+    self.trueColor = trueColor
+    self.redMax = redMax
+    self.greenMax = greenMax
+    self.blueMax = blueMax
+    self.redShift = redShift
+    self.greenShift = greenShift
+    self.blueShift = blueShift
+  }
+
+  static let bgra8888 = RFBPixelFormat(
+    bitsPerPixel: 32,
+    depth: 24,
+    bigEndian: false,
+    trueColor: true,
+    redMax: 255,
+    greenMax: 255,
+    blueMax: 255,
+    redShift: 16,
+    greenShift: 8,
+    blueShift: 0
+  )
+
+  init?(data: Data) {
+    guard data.count == 16 else { return nil }
+    bitsPerPixel = data[0]
+    depth = data[1]
+    bigEndian = data[2] != 0
+    trueColor = data[3] != 0
+    redMax = data.readUInt16(at: 4)
+    greenMax = data.readUInt16(at: 6)
+    blueMax = data.readUInt16(at: 8)
+    redShift = data[10]
+    greenShift = data[11]
+    blueShift = data[12]
+  }
+
+  var data: Data {
+    var value = Data()
+    value.append(bitsPerPixel)
+    value.append(depth)
+    value.append(bigEndian ? 1 : 0)
+    value.append(trueColor ? 1 : 0)
+    value.appendBigEndian(redMax)
+    value.appendBigEndian(greenMax)
+    value.appendBigEndian(blueMax)
+    value.append(redShift)
+    value.append(greenShift)
+    value.append(blueShift)
+    value.append(contentsOf: [0, 0, 0])
+    return value
+  }
+}
+
+enum RFBWire {
+  static let tightEncoding: Int32 = 7
+  static let maximumClipboardBytes = 1 * 1_024 * 1_024
+
+  static func serverInit(width: Int, height: Int, name: String) throws -> Data {
+    guard
+      (1...Int(UInt16.max)).contains(width),
+      (1...Int(UInt16.max)).contains(height)
+    else {
+      throw PrivateMacShareError.protocolError("invalid framebuffer dimensions")
+    }
+    let nameData = Data(name.utf8)
+    guard nameData.count <= 4_096 else {
+      throw PrivateMacShareError.protocolError("desktop name is too long")
+    }
+
+    var data = Data()
+    data.appendBigEndian(UInt16(width))
+    data.appendBigEndian(UInt16(height))
+    data.append(RFBPixelFormat.bgra8888.data)
+    data.appendBigEndian(UInt32(nameData.count))
+    data.append(nameData)
+    return data
+  }
+
+  static func tightJPEGUpdate(frame: CapturedDesktopFrame) throws -> Data {
+    guard
+      (1...Int(UInt16.max)).contains(frame.width),
+      (1...Int(UInt16.max)).contains(frame.height),
+      !frame.jpegData.isEmpty,
+      frame.jpegData.count < 1 << 22
+    else {
+      throw PrivateMacShareError.protocolError("invalid Tight JPEG frame")
+    }
+
+    var data = Data(capacity: frame.jpegData.count + 24)
+    data.append(0)  // FramebufferUpdate
+    data.append(0)  // padding
+    data.appendBigEndian(UInt16(1))
+    data.appendBigEndian(UInt16(0))
+    data.appendBigEndian(UInt16(0))
+    data.appendBigEndian(UInt16(frame.width))
+    data.appendBigEndian(UInt16(frame.height))
+    data.appendBigEndian(tightEncoding)
+    data.append(0x90)  // Tight JPEG subencoding
+    data.append(tightCompactLength(frame.jpegData.count))
+    data.append(frame.jpegData)
+    return data
+  }
+
+  static func tightCompactLength(_ length: Int) -> Data {
+    precondition((0..<(1 << 22)).contains(length))
+    var remaining = length
+    var data = Data()
+    var byte = UInt8(remaining & 0x7F)
+    remaining >>= 7
+    if remaining > 0 { byte |= 0x80 }
+    data.append(byte)
+    guard remaining > 0 else { return data }
+
+    byte = UInt8(remaining & 0x7F)
+    remaining >>= 7
+    if remaining > 0 { byte |= 0x80 }
+    data.append(byte)
+    if remaining > 0 { data.append(UInt8(remaining & 0xFF)) }
+    return data
+  }
+}
+
+extension Data {
+  mutating func appendBigEndian<T: FixedWidthInteger>(_ value: T) {
+    var bigEndian = value.bigEndian
+    Swift.withUnsafeBytes(of: &bigEndian) { append(contentsOf: $0) }
+  }
+
+  func readUInt16(at offset: Int) -> UInt16 {
+    (UInt16(self[offset]) << 8) | UInt16(self[offset + 1])
+  }
+
+  func readUInt32(at offset: Int) -> UInt32 {
+    (UInt32(self[offset]) << 24)
+      | (UInt32(self[offset + 1]) << 16)
+      | (UInt32(self[offset + 2]) << 8)
+      | UInt32(self[offset + 3])
+  }
+
+  func readInt32(at offset: Int) -> Int32 {
+    Int32(bitPattern: readUInt32(at: offset))
+  }
+}

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetIdentity.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetIdentity.swift
@@ -1,0 +1,358 @@
+import Foundation
+
+struct TailscaleCommandResult: Equatable, Sendable {
+  let standardOutput: String
+  let standardError: String
+}
+
+protocol TailscaleCommandRunning: Sendable {
+  func run(arguments: [String]) async throws -> TailscaleCommandResult
+}
+
+struct SystemTailscaleCommandRunner: TailscaleCommandRunning {
+  private static let maximumOutputBytes = 4 * 1_024 * 1_024
+  private static let executableCandidates = [
+    "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+    "/usr/local/bin/tailscale",
+    "/opt/homebrew/bin/tailscale",
+  ]
+
+  let executableURL: URL
+
+  init(fileManager: FileManager = .default) throws {
+    guard
+      let path = Self.executableCandidates.first(where: {
+        fileManager.isExecutableFile(atPath: $0)
+      })
+    else {
+      throw PrivateMacShareError.tailscaleNotInstalled
+    }
+    executableURL = URL(fileURLWithPath: path)
+  }
+
+  init(executableURL: URL) {
+    self.executableURL = executableURL
+  }
+
+  func run(arguments: [String]) async throws -> TailscaleCommandResult {
+    try await withCheckedThrowingContinuation { continuation in
+      DispatchQueue.global(qos: .userInitiated).async {
+        let process = Process()
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        let readGroup = DispatchGroup()
+        let capture = CommandCapture()
+
+        process.executableURL = executableURL
+        process.arguments = arguments
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+        process.qualityOfService = .userInitiated
+
+        var environment = ProcessInfo.processInfo.environment
+        for key in environment.keys
+        where key.hasPrefix("TS_") || key.hasPrefix("TAILSCALE_") {
+          environment.removeValue(forKey: key)
+        }
+        process.environment = environment
+
+        readGroup.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+          capture.setStandardOutput(outputPipe.fileHandleForReading.readDataToEndOfFile())
+          readGroup.leave()
+        }
+
+        readGroup.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+          capture.setStandardError(errorPipe.fileHandleForReading.readDataToEndOfFile())
+          readGroup.leave()
+        }
+
+        do {
+          try process.run()
+          process.waitUntilExit()
+          readGroup.wait()
+
+          let (outputData, errorData) = capture.values()
+          guard
+            outputData.count <= Self.maximumOutputBytes,
+            errorData.count <= Self.maximumOutputBytes
+          else {
+            continuation.resume(throwing: PrivateMacShareError.commandOutputTooLarge)
+            return
+          }
+
+          let result = TailscaleCommandResult(
+            standardOutput: String(decoding: outputData, as: UTF8.self),
+            standardError: String(decoding: errorData, as: UTF8.self)
+          )
+          guard process.terminationStatus == 0 else {
+            let message = result.standardError.trimmingCharacters(in: .whitespacesAndNewlines)
+            continuation.resume(
+              throwing: PrivateMacShareError.commandFailed(
+                status: process.terminationStatus,
+                message: String(message.prefix(500))
+              ))
+            return
+          }
+          continuation.resume(returning: result)
+        } catch {
+          outputPipe.fileHandleForWriting.closeFile()
+          errorPipe.fileHandleForWriting.closeFile()
+          readGroup.wait()
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+}
+
+private final class CommandCapture: @unchecked Sendable {
+  private let lock = NSLock()
+  private var standardOutput = Data()
+  private var standardError = Data()
+
+  func setStandardOutput(_ data: Data) {
+    lock.lock()
+    standardOutput = data
+    lock.unlock()
+  }
+
+  func setStandardError(_ data: Data) {
+    lock.lock()
+    standardError = data
+    lock.unlock()
+  }
+
+  func values() -> (Data, Data) {
+    lock.lock()
+    defer { lock.unlock() }
+    return (standardOutput, standardError)
+  }
+}
+
+struct TailscaleStatusDocument: Decodable, Sendable {
+  struct Node: Decodable, Sendable {
+    let dnsName: String
+    let hostName: String
+    let online: Bool
+    let tailscaleIPs: [String]
+    let userID: Int64
+
+    enum CodingKeys: String, CodingKey {
+      case dnsName = "DNSName"
+      case hostName = "HostName"
+      case online = "Online"
+      case tailscaleIPs = "TailscaleIPs"
+      case userID = "UserID"
+    }
+  }
+
+  struct Tailnet: Decodable, Sendable {
+    let name: String
+
+    enum CodingKeys: String, CodingKey {
+      case name = "Name"
+    }
+  }
+
+  struct User: Decodable, Sendable {
+    let loginName: String
+
+    enum CodingKeys: String, CodingKey {
+      case loginName = "LoginName"
+    }
+  }
+
+  let backendState: String
+  let currentTailnet: Tailnet?
+  let selfNode: Node?
+  let users: [String: User]
+
+  enum CodingKeys: String, CodingKey {
+    case backendState = "BackendState"
+    case currentTailnet = "CurrentTailnet"
+    case selfNode = "Self"
+    case users = "User"
+  }
+}
+
+struct TailnetIdentity: Equatable, Sendable {
+  let tailnetName: String
+  let loginName: String
+  let dnsName: String
+  let hostName: String
+  let ipv4Address: String
+  let userID: Int64
+
+  func vncAddress(port: Int) -> String {
+    "vnc://\(ipv4Address):\(port)"
+  }
+}
+
+enum TailnetIdentityPolicy {
+  static func identity(from document: TailscaleStatusDocument) throws
+    -> TailnetIdentity
+  {
+    guard document.backendState == "Running" else {
+      throw PrivateMacShareError.tailscaleNotRunning
+    }
+    guard
+      let rawTailnetName = document.currentTailnet?.name,
+      isValidTailnetName(rawTailnetName)
+    else {
+      throw PrivateMacShareError.invalidTailnetIdentity
+    }
+    let tailnetName = rawTailnetName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let node = document.selfNode, node.online else {
+      throw PrivateMacShareError.tailscaleOffline
+    }
+    guard
+      let user = document.users[String(node.userID)],
+      isValidLogin(user.loginName)
+    else {
+      throw PrivateMacShareError.invalidTailnetUser
+    }
+    guard let ipv4Address = node.tailscaleIPs.first(where: isTailscaleIPv4) else {
+      throw PrivateMacShareError.missingTailnetAddress
+    }
+
+    return TailnetIdentity(
+      tailnetName: tailnetName,
+      loginName: user.loginName.trimmingCharacters(in: .whitespacesAndNewlines),
+      dnsName: node.dnsName.trimmingCharacters(in: CharacterSet(charactersIn: ".")),
+      hostName: node.hostName,
+      ipv4Address: ipv4Address,
+      userID: node.userID
+    )
+  }
+
+  static func isValidTailnetName(_ value: String) -> Bool {
+    isValidIdentityField(value, maximumUTF8Bytes: 253)
+  }
+
+  static func isValidLogin(_ value: String) -> Bool {
+    isValidIdentityField(value, maximumUTF8Bytes: 320)
+  }
+
+  static func isTailscaleIPv4(_ value: String) -> Bool {
+    let parts = value.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 4 else { return false }
+    let octets = parts.compactMap { UInt8($0) }
+    return octets.count == 4 && octets[0] == 100 && (64...127).contains(octets[1])
+  }
+
+  private static func isValidIdentityField(_ value: String, maximumUTF8Bytes: Int) -> Bool {
+    guard
+      !value.isEmpty,
+      value.utf8.count <= maximumUTF8Bytes,
+      value == value.trimmingCharacters(in: .whitespacesAndNewlines)
+    else { return false }
+    return value.unicodeScalars.allSatisfy {
+      !CharacterSet.controlCharacters.contains($0)
+    }
+  }
+}
+
+struct TailscaleWhoisDocument: Decodable, Sendable {
+  struct Node: Decodable, Sendable {
+    let addresses: [String]
+    let machineAuthorized: Bool
+    let userID: Int64
+
+    enum CodingKeys: String, CodingKey {
+      case addresses = "Addresses"
+      case machineAuthorized = "MachineAuthorized"
+      case userID = "User"
+    }
+  }
+
+  struct UserProfile: Decodable, Sendable {
+    let loginName: String
+
+    enum CodingKeys: String, CodingKey {
+      case loginName = "LoginName"
+    }
+  }
+
+  let node: Node
+  let userProfile: UserProfile
+
+  enum CodingKeys: String, CodingKey {
+    case node = "Node"
+    case userProfile = "UserProfile"
+  }
+}
+
+struct TailnetPeerAuthorizer: Sendable {
+  let runner: any TailscaleCommandRunning
+  let expectedIdentity: TailnetIdentity
+
+  func authorize(remoteAddress: String) async -> Bool {
+    guard TailnetIdentityPolicy.isTailscaleIPv4(remoteAddress) else { return false }
+    do {
+      let result = try await runner.run(arguments: ["whois", "--json", remoteAddress])
+      let document = try JSONDecoder().decode(
+        TailscaleWhoisDocument.self,
+        from: Data(result.standardOutput.utf8)
+      )
+      let addressMatches = document.node.addresses.contains("\(remoteAddress)/32")
+      let userMatches =
+        document.node.userID == expectedIdentity.userID
+        && document.userProfile.loginName.caseInsensitiveCompare(expectedIdentity.loginName)
+          == .orderedSame
+      return document.node.machineAuthorized && addressMatches && userMatches
+    } catch {
+      return false
+    }
+  }
+}
+
+enum PrivateMacShareError: LocalizedError, Equatable {
+  case tailscaleNotInstalled
+  case tailscaleNotRunning
+  case tailscaleOffline
+  case invalidTailnetIdentity
+  case invalidTailnetUser
+  case missingTailnetAddress
+  case screenRecordingDenied
+  case accessibilityDenied
+  case commandFailed(status: Int32, message: String)
+  case commandOutputTooLarge
+  case captureUnavailable
+  case listenerFailed(String)
+  case protocolError(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .tailscaleNotInstalled:
+      "Tailscale is not installed. Install Tailscale first."
+    case .tailscaleNotRunning:
+      "Tailscale is not running."
+    case .tailscaleOffline:
+      "This Mac is offline in Tailscale."
+    case .invalidTailnetIdentity:
+      "Tailscale did not report a valid active tailnet."
+    case .invalidTailnetUser:
+      "Tailscale did not report a valid signed-in user."
+    case .missingTailnetAddress:
+      "Tailscale did not provide a private 100.64.0.0/10 address for this Mac."
+    case .screenRecordingDenied:
+      "Crabfleet needs Screen Recording permission to stream this display."
+    case .accessibilityDenied:
+      "Crabfleet needs Accessibility permission to forward keyboard and pointer input."
+    case .commandFailed(let status, let message):
+      message.isEmpty
+        ? "Tailscale exited with status \(status)."
+        : "Tailscale exited with status \(status): \(message)"
+    case .commandOutputTooLarge:
+      "Tailscale returned more status data than Crabfleet will accept."
+    case .captureUnavailable:
+      "Crabfleet could not capture the main display."
+    case .listenerFailed(let message):
+      "The private desktop listener failed: \(message)"
+    case .protocolError(let message):
+      "The remote desktop connection was rejected: \(message)"
+    }
+  }
+}

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetRFBServer.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetRFBServer.swift
@@ -1,0 +1,415 @@
+import Foundation
+import Network
+
+enum TailnetRFBServerEvent: Equatable, Sendable {
+  case listening
+  case authorizing(String)
+  case connected(String)
+  case disconnected
+  case listenerFailed(String)
+  case sessionFailed(String)
+}
+
+final class TailnetRFBServer: @unchecked Sendable {
+  typealias EventHandler = @Sendable (TailnetRFBServerEvent) -> Void
+
+  private let identity: TailnetIdentity
+  private let runner: any TailscaleCommandRunning
+  private let capture: MacScreenCapture
+  private let descriptor: CapturedDisplayDescriptor
+  private let input: any RemoteInputForwarding
+  private let port: UInt16
+  private let queue = DispatchQueue(label: "org.openclaw.crabfleet.rfb-listener")
+  private let lock = NSLock()
+  private let eventHandler: EventHandler
+  private var listener: NWListener?
+  private var session: RFBHostSession?
+
+  init(
+    identity: TailnetIdentity,
+    runner: any TailscaleCommandRunning,
+    capture: MacScreenCapture,
+    descriptor: CapturedDisplayDescriptor,
+    input: any RemoteInputForwarding,
+    port: UInt16,
+    eventHandler: @escaping EventHandler
+  ) {
+    self.identity = identity
+    self.runner = runner
+    self.capture = capture
+    self.descriptor = descriptor
+    self.input = input
+    self.port = port
+    self.eventHandler = eventHandler
+  }
+
+  func start() throws {
+    let parameters = NWParameters.tcp
+    guard let listenerPort = NWEndpoint.Port(rawValue: port) else {
+      throw PrivateMacShareError.listenerFailed("invalid port")
+    }
+    parameters.requiredLocalEndpoint = .hostPort(
+      host: NWEndpoint.Host(identity.ipv4Address),
+      port: listenerPort
+    )
+    let listener = try NWListener(using: parameters)
+    listener.stateUpdateHandler = { [weak self] state in
+      guard let self else { return }
+      switch state {
+      case .ready:
+        eventHandler(.listening)
+      case .failed(let error):
+        eventHandler(.listenerFailed(error.localizedDescription))
+      case .cancelled:
+        break
+      default:
+        break
+      }
+    }
+    listener.newConnectionHandler = { [weak self] connection in
+      self?.accept(connection)
+    }
+    self.listener = listener
+    listener.start(queue: queue)
+  }
+
+  func stop() {
+    let values = withLock { () -> (NWListener?, RFBHostSession?) in
+      defer {
+        listener = nil
+        session = nil
+      }
+      return (listener, session)
+    }
+    values.0?.cancel()
+    values.1?.stop()
+    capture.setConsumerActive(false)
+  }
+
+  private func accept(_ connection: NWConnection) {
+    let hasActiveSession = withLock { self.session != nil }
+    guard !hasActiveSession else {
+      connection.cancel()
+      return
+    }
+
+    let authorizer = TailnetPeerAuthorizer(
+      runner: runner,
+      expectedIdentity: identity
+    )
+    let newSession = RFBHostSession(
+      connection: connection,
+      authorizer: authorizer,
+      frameStore: capture.frameStore,
+      descriptor: descriptor,
+      input: input,
+      desktopName: "Crabfleet — \(identity.hostName)",
+      didAuthorize: { [weak capture] in capture?.setConsumerActive(true) },
+      eventHandler: eventHandler,
+      didFinish: { [weak self] finishedSession in
+        self?.clear(finishedSession)
+      }
+    )
+    withLock { self.session = newSession }
+    newSession.start()
+  }
+
+  private func clear(_ finishedSession: RFBHostSession) {
+    withLock {
+      if session === finishedSession {
+        session = nil
+        capture.setConsumerActive(false)
+      }
+    }
+  }
+
+  private func withLock<T>(_ body: () -> T) -> T {
+    lock.lock()
+    defer { lock.unlock() }
+    return body()
+  }
+}
+
+private final class RFBHostSession: @unchecked Sendable {
+  private let connection: NWConnection
+  private let authorizer: TailnetPeerAuthorizer
+  private let frameStore: CapturedDesktopFrameStore
+  private let descriptor: CapturedDisplayDescriptor
+  private let input: any RemoteInputForwarding
+  private let desktopName: String
+  private let didAuthorize: @Sendable () -> Void
+  private let queue = DispatchQueue(label: "org.openclaw.crabfleet.rfb-session")
+  private let eventHandler: TailnetRFBServer.EventHandler
+  private let didFinish: @Sendable (RFBHostSession) -> Void
+  private let lock = NSLock()
+  private var started = false
+  private var finished = false
+  private var task: Task<Void, Never>?
+
+  init(
+    connection: NWConnection,
+    authorizer: TailnetPeerAuthorizer,
+    frameStore: CapturedDesktopFrameStore,
+    descriptor: CapturedDisplayDescriptor,
+    input: any RemoteInputForwarding,
+    desktopName: String,
+    didAuthorize: @escaping @Sendable () -> Void,
+    eventHandler: @escaping TailnetRFBServer.EventHandler,
+    didFinish: @escaping @Sendable (RFBHostSession) -> Void
+  ) {
+    self.connection = connection
+    self.authorizer = authorizer
+    self.frameStore = frameStore
+    self.descriptor = descriptor
+    self.input = input
+    self.desktopName = desktopName
+    self.didAuthorize = didAuthorize
+    self.eventHandler = eventHandler
+    self.didFinish = didFinish
+  }
+
+  func start() {
+    connection.stateUpdateHandler = { [weak self] state in
+      guard let self else { return }
+      switch state {
+      case .ready:
+        beginProtocolIfNeeded()
+      case .failed(let error):
+        finish(event: .sessionFailed(error.localizedDescription))
+      case .cancelled:
+        finish(event: .disconnected)
+      default:
+        break
+      }
+    }
+    connection.start(queue: queue)
+  }
+
+  func stop() {
+    task?.cancel()
+    connection.cancel()
+    finish(event: .disconnected)
+  }
+
+  private func beginProtocolIfNeeded() {
+    lock.lock()
+    guard !started else {
+      lock.unlock()
+      return
+    }
+    started = true
+    lock.unlock()
+
+    task = Task { [weak self] in
+      guard let self else { return }
+      do {
+        try await runProtocol()
+        finish(event: .disconnected)
+      } catch is CancellationError {
+        finish(event: .disconnected)
+      } catch {
+        finish(event: .sessionFailed(error.localizedDescription))
+      }
+    }
+  }
+
+  private func runProtocol() async throws {
+    guard let remoteAddress = Self.remoteAddress(from: connection.endpoint) else {
+      throw PrivateMacShareError.protocolError("missing peer address")
+    }
+    eventHandler(.authorizing(remoteAddress))
+    let isAuthorized = await authorizer.authorize(remoteAddress: remoteAddress)
+    try Task.checkCancellation()
+    guard isAuthorized else {
+      throw PrivateMacShareError.protocolError("peer is not another device for this Tailscale user")
+    }
+    didAuthorize()
+
+    let io = RFBConnectionIO(connection: connection)
+    try await handshake(io: io)
+    eventHandler(.connected(remoteAddress))
+    try await messageLoop(io: io)
+  }
+
+  private func handshake(io: RFBConnectionIO) async throws {
+    try await io.send(RFBVersion.serverBanner)
+    let clientBanner = try await io.readExactly(12)
+    guard let version = RFBVersion(banner: clientBanner) else {
+      throw PrivateMacShareError.protocolError("unsupported RFB version")
+    }
+
+    if version == .v3Point3 {
+      var security = Data()
+      security.appendBigEndian(UInt32(1))
+      try await io.send(security)
+    } else {
+      try await io.send(Data([1, 1]))
+      guard try await io.readUInt8() == 1 else {
+        throw PrivateMacShareError.protocolError("unsupported security selection")
+      }
+      if version >= .v3Point8 {
+        var securityResult = Data()
+        securityResult.appendBigEndian(UInt32(0))
+        try await io.send(securityResult)
+      }
+    }
+
+    _ = try await io.readUInt8()  // ClientInit shared flag
+    try await io.send(
+      try RFBWire.serverInit(
+        width: descriptor.frameWidth,
+        height: descriptor.frameHeight,
+        name: desktopName
+      ))
+  }
+
+  private func messageLoop(io: RFBConnectionIO) async throws {
+    var supportsTightEncoding = false
+    var hasSentFrame = false
+
+    while !Task.isCancelled {
+      let messageType = try await io.readUInt8()
+      switch messageType {
+      case 0:  // SetPixelFormat
+        let payload = try await io.readExactly(19)
+        let format = RFBPixelFormat(data: Data(payload[3..<19]))
+        guard format == .bgra8888 else {
+          throw PrivateMacShareError.protocolError("only 24-bit true-color pixels are supported")
+        }
+
+      case 2:  // SetEncodings
+        let header = try await io.readExactly(3)
+        let count = Int(header.readUInt16(at: 1))
+        guard count <= 256 else {
+          throw PrivateMacShareError.protocolError("too many requested encodings")
+        }
+        let encodingData = try await io.readExactly(count * 4)
+        supportsTightEncoding = (0..<count).contains {
+          encodingData.readInt32(at: $0 * 4) == RFBWire.tightEncoding
+        }
+
+      case 3:  // FramebufferUpdateRequest
+        _ = try await io.readExactly(9)
+        guard supportsTightEncoding else {
+          throw PrivateMacShareError.protocolError("the client did not offer Tight encoding")
+        }
+        if hasSentFrame {
+          try await Task.sleep(for: .milliseconds(66))
+        }
+        let frame = try await waitForFrame()
+        try await io.send(try RFBWire.tightJPEGUpdate(frame: frame))
+        hasSentFrame = true
+
+      case 4:  // KeyEvent
+        let payload = try await io.readExactly(7)
+        input.keyEvent(down: payload[0] != 0, keysym: payload.readUInt32(at: 3))
+
+      case 5:  // PointerEvent
+        let payload = try await io.readExactly(5)
+        input.pointerEvent(
+          buttonMask: payload[0],
+          x: payload.readUInt16(at: 1),
+          y: payload.readUInt16(at: 3)
+        )
+
+      case 6:  // ClientCutText; consume but do not touch the host clipboard.
+        let header = try await io.readExactly(7)
+        let length = Int(header.readUInt32(at: 3))
+        guard length <= RFBWire.maximumClipboardBytes else {
+          throw PrivateMacShareError.protocolError("clipboard payload is too large")
+        }
+        _ = try await io.readExactly(length)
+
+      default:
+        throw PrivateMacShareError.protocolError("unsupported client message \(messageType)")
+      }
+    }
+  }
+
+  private func waitForFrame() async throws -> CapturedDesktopFrame {
+    for _ in 0..<150 {
+      if let frame = await frameStore.latest() { return frame }
+      try await Task.sleep(for: .milliseconds(20))
+    }
+    throw PrivateMacShareError.captureUnavailable
+  }
+
+  private func finish(event: TailnetRFBServerEvent) {
+    lock.lock()
+    guard !finished else {
+      lock.unlock()
+      return
+    }
+    finished = true
+    lock.unlock()
+    connection.cancel()
+    eventHandler(event)
+    didFinish(self)
+  }
+
+  private static func remoteAddress(from endpoint: NWEndpoint) -> String? {
+    guard case .hostPort(let host, _) = endpoint else { return nil }
+    let value = String(describing: host)
+    return value.split(separator: "%", maxSplits: 1).first.map(String.init)
+  }
+}
+
+private struct RFBConnectionIO: Sendable {
+  let connection: NWConnection
+
+  func readUInt8() async throws -> UInt8 {
+    try await readExactly(1)[0]
+  }
+
+  func readExactly(_ count: Int) async throws -> Data {
+    guard count >= 0 else {
+      throw PrivateMacShareError.protocolError("invalid read size")
+    }
+    guard count > 0 else { return Data() }
+
+    var result = Data(capacity: count)
+    while result.count < count {
+      let remaining = count - result.count
+      let chunk = try await receive(maximumLength: remaining)
+      guard !chunk.isEmpty else {
+        throw PrivateMacShareError.protocolError("peer closed the connection")
+      }
+      result.append(chunk)
+    }
+    return result
+  }
+
+  func send(_ data: Data) async throws {
+    try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<Void, Error>) in
+      connection.send(
+        content: data,
+        completion: .contentProcessed { error in
+          if let error {
+            continuation.resume(throwing: error)
+          } else {
+            continuation.resume(returning: ())
+          }
+        })
+    }
+  }
+
+  private func receive(maximumLength: Int) async throws -> Data {
+    try await withCheckedThrowingContinuation { continuation in
+      connection.receive(minimumIncompleteLength: 1, maximumLength: maximumLength) {
+        data, _, isComplete, error in
+        if let error {
+          continuation.resume(throwing: error)
+        } else if let data, !data.isEmpty {
+          continuation.resume(returning: data)
+        } else if isComplete {
+          continuation.resume(
+            throwing: PrivateMacShareError.protocolError("peer closed the connection")
+          )
+        } else {
+          continuation.resume(returning: Data())
+        }
+      }
+    }
+  }
+}

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
@@ -1,0 +1,304 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import CrabfleetMac
+
+struct PrivateMacShareTests {
+  @Test
+  func acceptsOnlineUserOnActiveTailnet() throws {
+    let identity = try TailnetIdentityPolicy.identity(from: statusDocument())
+
+    #expect(identity.tailnetName == "example.com")
+    #expect(identity.loginName == "operator@example.com")
+    #expect(identity.ipv4Address == "100.64.12.34")
+    #expect(identity.vncAddress(port: 5901) == "vnc://100.64.12.34:5901")
+  }
+
+  @Test
+  func rejectsInvalidTailnetAndIdentityFields() throws {
+    var value = statusJSON()
+    value = value.replacingOccurrences(
+      of: #""Name": "example.com""#, with: #""Name": """#)
+    let missingTailnet = try JSONDecoder().decode(
+      TailscaleStatusDocument.self,
+      from: Data(value.utf8)
+    )
+    #expect(throws: PrivateMacShareError.invalidTailnetIdentity) {
+      try TailnetIdentityPolicy.identity(from: missingTailnet)
+    }
+
+    value = statusJSON().replacingOccurrences(
+      of: "operator@example.com",
+      with: ""
+    )
+    let missingUser = try JSONDecoder().decode(
+      TailscaleStatusDocument.self,
+      from: Data(value.utf8)
+    )
+    #expect(throws: PrivateMacShareError.invalidTailnetUser) {
+      try TailnetIdentityPolicy.identity(from: missingUser)
+    }
+  }
+
+  @Test
+  func recognizesOnlyTailscaleIPv4Range() {
+    #expect(TailnetIdentityPolicy.isTailscaleIPv4("100.64.0.1"))
+    #expect(TailnetIdentityPolicy.isTailscaleIPv4("100.127.255.254"))
+    #expect(!TailnetIdentityPolicy.isTailscaleIPv4("100.63.255.255"))
+    #expect(!TailnetIdentityPolicy.isTailscaleIPv4("100.128.0.1"))
+    #expect(!TailnetIdentityPolicy.isTailscaleIPv4("10.0.0.1"))
+    #expect(!TailnetIdentityPolicy.isTailscaleIPv4("100.64.invalid.1.2"))
+    #expect(!TailnetIdentityPolicy.isTailscaleIPv4("100.64..1"))
+  }
+
+  @Test
+  func validatesBoundedTailnetIdentityFields() {
+    #expect(TailnetIdentityPolicy.isValidTailnetName("example.com"))
+    #expect(TailnetIdentityPolicy.isValidTailnetName("example.github"))
+    #expect(!TailnetIdentityPolicy.isValidTailnetName(""))
+    #expect(!TailnetIdentityPolicy.isValidTailnetName(" example.com"))
+    #expect(!TailnetIdentityPolicy.isValidTailnetName("bad\nname"))
+    #expect(!TailnetIdentityPolicy.isValidTailnetName(String(repeating: "a", count: 254)))
+
+    #expect(TailnetIdentityPolicy.isValidLogin("operator@example.com"))
+    #expect(TailnetIdentityPolicy.isValidLogin("github-user"))
+    #expect(!TailnetIdentityPolicy.isValidLogin(""))
+    #expect(!TailnetIdentityPolicy.isValidLogin("github-user "))
+    #expect(!TailnetIdentityPolicy.isValidLogin("bad\u{0}login"))
+    #expect(!TailnetIdentityPolicy.isValidLogin(String(repeating: "a", count: 321)))
+  }
+
+  @Test
+  func authorizesOnlySameTailnetUserAndExactPeerAddress() async throws {
+    let identity = try TailnetIdentityPolicy.identity(from: statusDocument())
+    let accepted = TailnetPeerAuthorizer(
+      runner: StaticTailscaleRunner(output: whoisJSON(login: identity.loginName)),
+      expectedIdentity: identity
+    )
+    #expect(await accepted.authorize(remoteAddress: "100.100.10.20"))
+
+    let otherUser = TailnetPeerAuthorizer(
+      runner: StaticTailscaleRunner(output: whoisJSON(login: "other@example.com")),
+      expectedIdentity: identity
+    )
+    let otherUserID = TailnetPeerAuthorizer(
+      runner: StaticTailscaleRunner(
+        output: whoisJSON(login: identity.loginName, userID: 43)),
+      expectedIdentity: identity
+    )
+    let otherAddress = TailnetPeerAuthorizer(
+      runner: StaticTailscaleRunner(
+        output: whoisJSON(login: identity.loginName, addresses: ["100.100.10.21/32"])),
+      expectedIdentity: identity
+    )
+    let unauthorizedNode = TailnetPeerAuthorizer(
+      runner: StaticTailscaleRunner(
+        output: whoisJSON(login: identity.loginName, machineAuthorized: false)),
+      expectedIdentity: identity
+    )
+    #expect(!(await otherUser.authorize(remoteAddress: "100.100.10.20")))
+    #expect(!(await otherUserID.authorize(remoteAddress: "100.100.10.20")))
+    #expect(!(await otherAddress.authorize(remoteAddress: "100.100.10.20")))
+    #expect(!(await unauthorizedNode.authorize(remoteAddress: "100.100.10.20")))
+    #expect(!(await accepted.authorize(remoteAddress: "192.168.1.4")))
+  }
+
+  @Test
+  func keepsNewestCapturedFrameWhenUpdatesArriveOutOfOrder() async throws {
+    let store = CapturedDesktopFrameStore()
+    await store.update(.init(jpegData: Data([2]), sequence: 2, width: 2, height: 2))
+    await store.update(.init(jpegData: Data([1]), sequence: 1, width: 2, height: 2))
+
+    #expect(await store.latest()?.sequence == 2)
+  }
+
+  @Test
+  func buildsTightJPEGFramebufferUpdate() throws {
+    let jpeg = Data([0xFF, 0xD8, 0xFF, 0xD9])
+    let frame = CapturedDesktopFrame(jpegData: jpeg, sequence: 7, width: 1_600, height: 900)
+    let packet = try RFBWire.tightJPEGUpdate(frame: frame)
+
+    #expect(packet[0] == 0)
+    #expect(packet.readUInt16(at: 2) == 1)
+    #expect(packet.readUInt16(at: 8) == 1_600)
+    #expect(packet.readUInt16(at: 10) == 900)
+    #expect(packet.readInt32(at: 12) == RFBWire.tightEncoding)
+    #expect(packet[16] == 0x90)
+    #expect(packet[17] == 4)
+    #expect(packet.suffix(4) == jpeg)
+  }
+
+  @Test
+  func encodesTightCompactLengths() {
+    #expect(RFBWire.tightCompactLength(0) == Data([0x00]))
+    #expect(RFBWire.tightCompactLength(127) == Data([0x7F]))
+    #expect(RFBWire.tightCompactLength(128) == Data([0x80, 0x01]))
+    #expect(RFBWire.tightCompactLength(16_383) == Data([0xFF, 0x7F]))
+    #expect(RFBWire.tightCompactLength(16_384) == Data([0x80, 0x80, 0x01]))
+  }
+
+  @Test
+  func scalesCaptureWithinBoundedEvenDimensions() {
+    let retina = MacScreenCapture.captureDimensions(sourceWidth: 5_120, sourceHeight: 2_880)
+    #expect(retina.width == 1_600)
+    #expect(retina.height == 900)
+    #expect(retina.width.isMultiple(of: 2))
+    #expect(retina.height.isMultiple(of: 2))
+
+    let small = MacScreenCapture.captureDimensions(sourceWidth: 1_280, sourceHeight: 800)
+    #expect(small.width == 1_280)
+    #expect(small.height == 800)
+  }
+
+  @Test
+  func mapsRFBKeysymsToMacKeys() {
+    #expect(MacRemoteInputController.keyCode(for: 0x61) != nil)
+    #expect(MacRemoteInputController.keyCode(for: 0xFF51) != nil)
+    #expect(MacRemoteInputController.keyCode(for: 0xFFE7) != nil)
+    #expect(MacRemoteInputController.keyCode(for: 0x1F980) == nil)
+  }
+
+  @Test @MainActor
+  func servesRoyalVNCKitOverTheCurrentTailnet() async throws {
+    guard ProcessInfo.processInfo.environment["CRABFLEET_TAILNET_RFB_SMOKE"] == "1" else {
+      return
+    }
+
+    let runner = try SystemTailscaleCommandRunner()
+    let status = try await runner.run(arguments: ["status", "--json"])
+    let document = try JSONDecoder().decode(
+      TailscaleStatusDocument.self,
+      from: Data(status.standardOutput.utf8)
+    )
+    let identity = try TailnetIdentityPolicy.identity(from: document)
+    let capture = MacScreenCapture()
+    let jpeg = try #require(testJPEG())
+    await capture.frameStore.update(
+      .init(jpegData: jpeg, sequence: 1, width: 64, height: 64)
+    )
+
+    let port: UInt16 = 5_909
+    let server = TailnetRFBServer(
+      identity: identity,
+      runner: runner,
+      capture: capture,
+      descriptor: .init(
+        displayID: 0,
+        displayBounds: CGRect(x: 0, y: 0, width: 64, height: 64),
+        frameWidth: 64,
+        frameHeight: 64
+      ),
+      input: NoopRemoteInput(),
+      port: port,
+      eventHandler: { _ in }
+    )
+    try server.start()
+    defer { server.stop() }
+    try await Task.sleep(for: .milliseconds(250))
+
+    let session = VNCSessionController()
+    session.connect(
+      host: identity.ipv4Address,
+      port: port,
+      username: "",
+      password: "",
+      clipboardEnabled: false
+    )
+    defer { session.disconnect() }
+
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: .seconds(15))
+    while clock.now < deadline {
+      if session.phase == .connected && session.framebufferUpdateCount > 0 { break }
+      try await Task.sleep(for: .milliseconds(25))
+    }
+    #expect(session.phase == .connected)
+    #expect(session.framebufferUpdateCount > 0)
+    #expect(session.framebuffer?.size.width == 64)
+    #expect(session.framebuffer?.size.height == 64)
+  }
+
+  private func statusDocument() throws -> TailscaleStatusDocument {
+    try JSONDecoder().decode(TailscaleStatusDocument.self, from: Data(statusJSON().utf8))
+  }
+
+  private func statusJSON() -> String {
+    """
+    {
+      "BackendState": "Running",
+      "CurrentTailnet": { "Name": "example.com" },
+      "Self": {
+        "DNSName": "workstation.example.ts.net.",
+        "HostName": "Workstation",
+        "Online": true,
+        "TailscaleIPs": ["100.64.12.34", "fd7a:115c:a1e0::1"],
+        "UserID": 42
+      },
+      "User": {
+        "42": { "LoginName": "operator@example.com" }
+      }
+    }
+    """
+  }
+
+  private func whoisJSON(
+    login: String,
+    userID: Int64 = 42,
+    addresses: [String] = ["100.100.10.20/32"],
+    machineAuthorized: Bool = true
+  ) -> String {
+    let encodedAddresses = addresses.map { "\"\($0)\"" }.joined(separator: ", ")
+    return """
+      {
+        "Node": {
+          "Addresses": [\(encodedAddresses)],
+          "MachineAuthorized": \(machineAuthorized),
+          "User": \(userID)
+        },
+        "UserProfile": { "LoginName": "\(login)" }
+      }
+      """
+  }
+
+  private func testJPEG() -> Data? {
+    guard
+      let bitmap = NSBitmapImageRep(
+        bitmapDataPlanes: nil,
+        pixelsWide: 64,
+        pixelsHigh: 64,
+        bitsPerSample: 8,
+        samplesPerPixel: 4,
+        hasAlpha: true,
+        isPlanar: false,
+        colorSpaceName: .deviceRGB,
+        bytesPerRow: 0,
+        bitsPerPixel: 0
+      )
+    else { return nil }
+    bitmap.setColor(
+      NSColor(deviceRed: 0.25, green: 0.9, blue: 0.7, alpha: 1),
+      atX: 16,
+      y: 16
+    )
+    bitmap.setColor(
+      NSColor(deviceRed: 1, green: 0.55, blue: 0.2, alpha: 1),
+      atX: 48,
+      y: 48
+    )
+    return bitmap.representation(using: .jpeg, properties: [.compressionFactor: 0.8])
+  }
+}
+
+private struct StaticTailscaleRunner: TailscaleCommandRunning {
+  let output: String
+
+  func run(arguments: [String]) async throws -> TailscaleCommandResult {
+    .init(standardOutput: output, standardError: "")
+  }
+}
+
+private struct NoopRemoteInput: RemoteInputForwarding {
+  func keyEvent(down: Bool, keysym: UInt32) {}
+  func pointerEvent(buttonMask: UInt8, x: UInt16, y: UInt16) {}
+}


### PR DESCRIPTION
## What

- Add a **Share This Mac** flow to the native macOS app.
- Capture the primary display with ScreenCaptureKit and serve bounded RFB 3.8 Tight/JPEG frames.
- Forward keyboard and pointer input through Accessibility-authorized CGEvents.
- Bind the listener only to the active Tailscale `100.64.0.0/10` address.
- Admit a peer only when `tailscale whois` reports an authorized node owned by the exact same Tailscale user.

## Why

The macOS app could consume VNC desktops but could not host its own desktop. This adds a private Mac-to-Mac path without enabling Apple's Screen Sharing service, configuring Remote Management, using a public relay, or storing a VNC password.

## Impact

- Adds an app-owned, single-client desktop host on port 5901.
- Requires explicit Screen Recording and Accessibility permissions.
- Uses the current authenticated tailnet and user at runtime; no organization, tailnet, or email domain is hardcoded.
- Keeps capture primary-display only, lossy, and capped at 1600×1000 and 15 fps.
- Leaves host clipboard contents and audio out of scope.

## Root cause

The native app had a hardened VNC client and renderer but no server-side capture, admission, RFB framing, or remote-input path.

## Checks

- `pnpm macos:test` — 20 vendored protocol tests and 29 app tests pass.
- `CRABFLEET_TAILNET_RFB_SMOKE=1 swift test --package-path macos/CrabfleetMac --filter PrivateMacShareTests.servesRoyalVNCKitOverTheCurrentTailnet` — real local-tailnet server/client smoke passes.
- `xcrun swift-format lint --strict …` — passes for all changed Swift sources.
- Release bundle built with `CONFIGURATION=release`.
- `codesign --verify --deep --strict macos/CrabfleetMac/.build/Crabfleet.app` — passes.
- `git diff --check` — clean.