### PR TITLE
[codex] register private macOS desktop hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add private per-user desktop-host registration so native macOS shares appear in Fleet with direct same-tailnet VNC endpoints.
 - Add app-owned macOS desktop hosting with ScreenCaptureKit, bounded Tight/JPEG RFB streaming, Accessibility-authorized input, an exact active-tailnet bind, and same-user Tailscale peer admission without Apple Screen Sharing or a public relay.
 - Add atomically claimed recurring card intervals with constant-time catch-up, crash-recoverable leases, scheduler/API proof, and coalescing for active or capacity-blocked runs, thanks @Jhacarreiro.
 - Reuse `@openclaw/libterminal` for terminal protocol codecs, Worker relays, Ghostty assets, and browser hub transport while keeping Crabfleet authorization and session policy local.

--- a/docs/api.md
+++ b/docs/api.md
@@ -793,8 +793,33 @@ Includes:
 - `egress`
 - `totals`
 - `sessions`
+- `desktopHosts`: private registered Tailscale VNC endpoints owned by the signed-in stable subject
 
 Secrets, ciphertext, and token values are never returned.
+
+### PUT /api/desktop-hosts/:id
+
+Registers or updates one private desktop owned by the signed-in viewer. The ID
+is a stable 1-80 character machine identifier. The address must be a canonical
+IPv4 address in Tailscale's `100.64.0.0/10` range; arbitrary LAN and public
+addresses are rejected.
+
+```json
+{
+  "name": "Studio",
+  "address": "100.64.12.34",
+  "port": 5901
+}
+```
+
+The host is visible only to the same stable user, regardless of shared or
+private session-tenancy mode. Re-registering the same ID updates its name,
+address, port, and timestamp while preserving its creation time.
+
+### DELETE /api/desktop-hosts/:id
+
+Removes one registered desktop owned by the signed-in viewer. The route cannot
+remove another user's record with the same ID.
 
 ## Static Routes
 

--- a/docs/macos-native-client.md
+++ b/docs/macos-native-client.md
@@ -62,8 +62,10 @@ relay, Cloudflare, or the Crabfleet Worker.
 4. Before sending the RFB banner or any framebuffer data, the app resolves the
    peer through `tailscale whois` and requires an authorized node with the same
    user ID and login as the host.
-5. The receiving Crabfleet app uses Quick Connect with the displayed
-   `vnc://100.x.y.z:5901` address and no VNC password.
+5. With an authenticated Crabfleet API configuration, the host registers its
+   stable endpoint in the signed-in user's private Fleet registry. The receiving
+   app discovers and directly connects that card with no VNC password. Quick
+   Connect with the displayed `vnc://100.x.y.z:5901` address remains a fallback.
 
 After the first Screen Recording grant, restart the bundled app before starting
 the share. Ad-hoc development signatures do not provide a stable TCC identity,

--- a/macos/CrabfleetMac/README.md
+++ b/macos/CrabfleetMac/README.md
@@ -18,9 +18,12 @@ Tailscale `100.64.0.0/10` address after confirming a valid identity on the activ
 tailnet. Before the RFB handshake, `tailscale whois` must identify the peer as
 another authorized device owned by the same Tailscale user.
 
-On the receiving Mac, choose Quick Connect, paste the `vnc://100.x.y.z:5901`
-address shown by the host, and leave the password blank. RFB's None security
-type is intentional here: admission and encrypted transport belong to
+When the app has `CRABFLEET_API_URL` and `CRABFLEET_SESSION_COOKIE`, starting a
+share publishes the host's stable Tailscale endpoint to the signed-in user's
+private Fleet registry. The receiving Mac discovers that card and connects
+directly with a blank RFB password. Quick Connect with the displayed
+`vnc://100.x.y.z:5901` address remains available as a fallback. RFB's None
+security type is intentional here: admission and encrypted transport belong to
 Tailscale, and the RFB socket is never bound to Wi-Fi, Ethernet, loopback, or a
 public address. Crabfleet must remain running on the host. The prototype allows
 one peer, captures the primary display at up to 1600×1000 and 15 fps, and does
@@ -55,8 +58,9 @@ swift run --package-path macos/CrabfleetMac CrabfleetMac
 ```
 
 The cookie is accepted only from the process environment and is never persisted
-by the prototype. Production authentication should use a dedicated native OAuth
-or device authorization flow.
+by the prototype. It authenticates both Fleet reads and host registration.
+Production authentication should use a dedicated native OAuth or device
+authorization flow.
 
 The generic connection sheet still targets an already-open VNC endpoint, such
 as the loopback port produced by a Crabbox SSH tunnel. A structured, secret-safe

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/CrabfleetDesktopRegistration.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/CrabfleetDesktopRegistration.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+protocol DesktopHostRegistering: Sendable {
+  func register(identity: TailnetIdentity, port: UInt16) async throws
+}
+
+struct CrabfleetDesktopRegistration: DesktopHostRegistering, Sendable {
+  private struct RegistrationBody: Encodable {
+    let name: String
+    let address: String
+    let port: UInt16
+  }
+
+  private let baseURL: URL
+  private let sessionCookie: String
+  private let session: URLSession
+
+  init?(
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    session: URLSession = .shared
+  ) {
+    guard
+      let rawURL = environment["CRABFLEET_API_URL"],
+      let configuredURL = URL(string: rawURL),
+      Self.isSecureAPIURL(configuredURL),
+      let cookie = environment["CRABFLEET_SESSION_COOKIE"],
+      !cookie.isEmpty,
+      cookie.utf8.count <= 4_096,
+      !cookie.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains)
+    else { return nil }
+
+    var normalizedURL = configuredURL
+    if normalizedURL.path == "/api/fleet" {
+      normalizedURL.deleteLastPathComponent()
+      normalizedURL.deleteLastPathComponent()
+    }
+    guard normalizedURL.path.isEmpty || normalizedURL.path == "/" else { return nil }
+    self.baseURL = normalizedURL
+    self.sessionCookie = cookie
+    self.session = session
+  }
+
+  func register(identity: TailnetIdentity, port: UInt16) async throws {
+    let request = try registrationRequest(identity: identity, port: port)
+    let (_, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      throw DesktopHostRegistrationError.invalidResponse
+    }
+    guard (200..<300).contains(http.statusCode) else {
+      throw DesktopHostRegistrationError.httpStatus(http.statusCode)
+    }
+  }
+
+  func registrationRequest(identity: TailnetIdentity, port: UInt16) throws -> URLRequest {
+    let hostID = Self.hostID(identity: identity)
+    let url =
+      baseURL
+      .appending(path: "api")
+      .appending(path: "desktop-hosts")
+      .appending(path: hostID)
+    var request = URLRequest(url: url)
+    request.httpMethod = "PUT"
+    request.timeoutInterval = 15
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue(sessionCookie, forHTTPHeaderField: "Cookie")
+    request.httpBody = try JSONEncoder().encode(
+      RegistrationBody(
+        name: identity.hostName.isEmpty ? identity.dnsName : identity.hostName,
+        address: identity.ipv4Address,
+        port: port
+      ))
+    return request
+  }
+
+  static func hostID(identity: TailnetIdentity) -> String {
+    let dnsLabel = identity.dnsName.split(separator: ".").first.map(String.init) ?? ""
+    let normalized = dnsLabel.lowercased().filter {
+      $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "." || $0 == "_" || $0 == "-")
+    }
+    let trimmed = normalized.trimmingCharacters(in: CharacterSet(charactersIn: "._-"))
+    if !trimmed.isEmpty { return String(trimmed.prefix(80)) }
+    return "mac-\(identity.ipv4Address.replacingOccurrences(of: ".", with: "-"))"
+  }
+
+  static func isSecureAPIURL(_ url: URL) -> Bool {
+    guard
+      url.user == nil,
+      url.password == nil,
+      url.query == nil,
+      url.fragment == nil,
+      let scheme = url.scheme?.lowercased(),
+      let host = url.host?.lowercased()
+    else { return false }
+    if scheme == "https" { return true }
+    return scheme == "http" && (host == "127.0.0.1" || host == "::1")
+  }
+}
+
+enum DesktopHostRegistrationError: LocalizedError {
+  case invalidResponse
+  case httpStatus(Int)
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidResponse:
+      "Crabfleet returned an invalid registration response."
+    case .httpStatus(let status):
+      "Crabfleet registration returned HTTP \(status)."
+    }
+  }
+}

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/DesktopModels.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/DesktopModels.swift
@@ -179,6 +179,22 @@ struct DesktopTarget: Identifiable, Hashable {
     profileID = profile.id
   }
 
+  init(host: RegisteredDesktopHost) {
+    id = "host:\(host.id)"
+    title = host.name
+    subtitle = "\(host.address):\(host.port)"
+    detail = "Registered private desktop"
+    source = .crabfleet
+    status = nil
+    owner = host.owner
+    repository = nil
+    branch = nil
+    updatedAt = host.updatedAt
+    endpoint = .init(host: host.address, port: host.port, username: "")
+    desktopAvailable = true
+    profileID = nil
+  }
+
   func matches(_ query: String) -> Bool {
     let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     guard !normalized.isEmpty else { return true }

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/FleetModels.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/FleetModels.swift
@@ -147,6 +147,39 @@ struct FleetAPIState: Decodable {
   let registryAvailable: Bool
   let totals: FleetAPITotals
   let sessions: [FleetAPISession]
+  let desktopHosts: [FleetAPIDesktopHost]?
+}
+
+struct FleetAPIDesktopHost: Decodable {
+  let id: String
+  let owner: String
+  let name: String
+  let address: String
+  let port: Int
+  let createdAt: Double
+  let updatedAt: Double
+
+  func desktopHost() -> RegisteredDesktopHost {
+    .init(
+      id: id,
+      owner: owner,
+      name: name,
+      address: address,
+      port: port,
+      createdAt: Date(timeIntervalSince1970: createdAt / 1_000),
+      updatedAt: Date(timeIntervalSince1970: updatedAt / 1_000)
+    )
+  }
+}
+
+struct RegisteredDesktopHost: Identifiable, Hashable {
+  let id: String
+  let owner: String
+  let name: String
+  let address: String
+  let port: Int
+  let createdAt: Date
+  let updatedAt: Date
 }
 
 struct FleetAPITotals: Decodable {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/FleetRootView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/FleetRootView.swift
@@ -20,7 +20,8 @@ struct FleetRootView: View {
   private var allTargets: [DesktopTarget] {
     let saved = connections.profiles.map(DesktopTarget.init(profile:))
     let fleet = store.leases.map(DesktopTarget.init(lease:))
-    return (saved + fleet).sorted(by: targetSort)
+    let hosts = store.desktopHosts.map(DesktopTarget.init(host:))
+    return (saved + hosts + fleet).sorted(by: targetSort)
   }
 
   private var visibleTargets: [DesktopTarget] {
@@ -30,7 +31,8 @@ struct FleetRootView: View {
       case .all:
         isVisible = true
       case .mine:
-        isVisible = target.source == .saved || target.owner == store.currentUser
+        isVisible =
+          target.source == .saved || target.endpoint != nil || target.owner == store.currentUser
       case .fleet:
         isVisible = target.source == .crabfleet
       case .saved:
@@ -54,7 +56,7 @@ struct FleetRootView: View {
           session: sessions.session(for: target.id),
           sessions: sessions,
           namespace: desktopTransition,
-          connect: { connectionTarget = target },
+          connect: { connect(target) },
           disconnect: { sessions.disconnect(targetID: target.id) },
           switchTo: focus,
           close: closeFocus
@@ -139,12 +141,36 @@ struct FleetRootView: View {
 
   private func focus(_ targetID: DesktopTarget.ID) {
     sessions.focus(targetID: targetID)
+    if let target = allTargets.first(where: { $0.id == targetID }),
+      target.source == .crabfleet,
+      target.endpoint != nil,
+      !sessions.session(for: targetID).phase.isConnectedOrConnecting
+    {
+      connect(target)
+    }
     let animation: Animation =
       reduceMotion
       ? .easeOut(duration: 0.12)
       : .spring(response: 0.24, dampingFraction: 0.9)
     withAnimation(animation) {
       focusedTargetID = targetID
+    }
+  }
+
+  private func connect(_ target: DesktopTarget) {
+    if target.source == .crabfleet, let endpoint = target.endpoint {
+      sessions.connect(
+        targetID: target.id,
+        request: .init(
+          host: endpoint.host,
+          port: endpoint.port,
+          username: endpoint.username,
+          password: "",
+          clipboardEnabled: false
+        )
+      )
+    } else {
+      connectionTarget = target
     }
   }
 
@@ -265,7 +291,8 @@ private struct DesktopSourceRail: View {
   private func count(for scope: DesktopScope) -> Int {
     switch scope {
     case .all: targets.count
-    case .mine: targets.filter { $0.source == .saved || $0.owner == currentUser }.count
+    case .mine:
+      targets.filter { $0.source == .saved || $0.endpoint != nil || $0.owner == currentUser }.count
     case .fleet: targets.filter { $0.source == .crabfleet }.count
     case .saved: targets.filter { $0.source == .saved }.count
     }

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/FleetStore.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/FleetStore.swift
@@ -3,6 +3,7 @@ import Foundation
 @MainActor
 final class FleetStore: ObservableObject {
   @Published private(set) var leases: [CrabboxLease] = []
+  @Published private(set) var desktopHosts: [RegisteredDesktopHost] = []
   @Published private(set) var isRefreshing = false
   @Published private(set) var lastUpdated: Date?
   @Published private(set) var notice: String?
@@ -22,7 +23,9 @@ final class FleetStore: ObservableObject {
 
     do {
       if let endpoint = environment["CRABFLEET_API_URL"], !endpoint.isEmpty {
-        leases = try await fetchFleet(endpoint: endpoint)
+        let fleet = try await fetchFleet(endpoint: endpoint)
+        leases = fleet.leases
+        desktopHosts = fleet.desktopHosts
         notice = nil
       } else {
         leases = CrabboxLease.fixtures(currentUser: currentUser)
@@ -37,8 +40,14 @@ final class FleetStore: ObservableObject {
     }
   }
 
-  private func fetchFleet(endpoint: String) async throws -> [CrabboxLease] {
-    guard var url = URL(string: endpoint) else { throw FleetClientError.invalidURL }
+  private func fetchFleet(endpoint: String) async throws -> (
+    leases: [CrabboxLease],
+    desktopHosts: [RegisteredDesktopHost]
+  ) {
+    guard
+      var url = URL(string: endpoint),
+      CrabfleetDesktopRegistration.isSecureAPIURL(url)
+    else { throw FleetClientError.invalidURL }
     if url.path.isEmpty || url.path == "/" {
       url.append(path: "api/fleet")
     }
@@ -56,7 +65,10 @@ final class FleetStore: ObservableObject {
       throw FleetClientError.httpStatus(http.statusCode)
     }
     let envelope = try JSONDecoder().decode(FleetAPIEnvelope.self, from: data)
-    return envelope.fleet.sessions.map { $0.lease() }
+    return (
+      envelope.fleet.sessions.map { $0.lease() },
+      (envelope.fleet.desktopHosts ?? []).map { $0.desktopHost() }
+    )
   }
 }
 

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
@@ -4,6 +4,24 @@ import Foundation
 
 @MainActor
 final class PrivateMacShareController: ObservableObject {
+  enum RegistryPhase: Equatable {
+    case notConfigured
+    case registering
+    case registered
+    case failed(String)
+
+    var detail: String {
+      switch self {
+      case .notConfigured: "Not configured"
+      case .registering: "Registering"
+      case .registered: "Published"
+      case .failed(let message): message
+      }
+    }
+
+    var isReady: Bool { self == .registered }
+  }
+
   enum Phase: Equatable {
     case idle
     case starting
@@ -40,14 +58,22 @@ final class PrivateMacShareController: ObservableObject {
   @Published private(set) var connectedPeer: String?
   @Published private(set) var notice: String?
   @Published private(set) var isRefreshing = false
+  @Published private(set) var registryPhase: RegistryPhase
 
   private let runner: (any TailscaleCommandRunning)?
+  private let desktopRegistration: (any DesktopHostRegistering)?
   private let runnerInitializationError: Error?
   private var capture: MacScreenCapture?
   private var server: TailnetRFBServer?
   private var serverGeneration: UUID?
+  private var registrationTask: Task<Void, Never>?
 
-  init(runner: (any TailscaleCommandRunning)? = nil) {
+  init(
+    runner: (any TailscaleCommandRunning)? = nil,
+    desktopRegistration: (any DesktopHostRegistering)? = CrabfleetDesktopRegistration()
+  ) {
+    self.desktopRegistration = desktopRegistration
+    registryPhase = desktopRegistration == nil ? .notConfigured : .registering
     if let runner {
       self.runner = runner
       runnerInitializationError = nil
@@ -102,6 +128,7 @@ final class PrivateMacShareController: ObservableObject {
     phase = .starting
     notice = nil
     connectedPeer = nil
+    registryPhase = desktopRegistration == nil ? .notConfigured : .registering
     await loadIdentity()
     refreshPermissions()
 
@@ -160,6 +187,8 @@ final class PrivateMacShareController: ObservableObject {
     guard phase.isRunning || phase == .failed else { return }
     phase = .stopping
     connectedPeer = nil
+    registrationTask?.cancel()
+    registrationTask = nil
     serverGeneration = nil
     server?.stop()
     server = nil
@@ -222,6 +251,7 @@ final class PrivateMacShareController: ObservableObject {
     case .listening:
       phase = .sharing
       notice = nil
+      registerDesktopHost(generation: generation)
     case .authorizing(let peer):
       phase = .authorizing
       connectedPeer = peer
@@ -233,6 +263,8 @@ final class PrivateMacShareController: ObservableObject {
       phase = .sharing
       connectedPeer = nil
     case .listenerFailed(let message):
+      registrationTask?.cancel()
+      registrationTask = nil
       phase = .failed
       connectedPeer = nil
       notice = PrivateMacShareError.listenerFailed(message).localizedDescription
@@ -246,6 +278,27 @@ final class PrivateMacShareController: ObservableObject {
       phase = .sharing
       connectedPeer = nil
       notice = message
+    }
+  }
+
+  private func registerDesktopHost(generation: UUID) {
+    registrationTask?.cancel()
+    guard let desktopRegistration, let identity else {
+      registryPhase = .notConfigured
+      return
+    }
+    registryPhase = .registering
+    registrationTask = Task { [weak self] in
+      do {
+        try await desktopRegistration.register(identity: identity, port: Self.port)
+        guard !Task.isCancelled, self?.serverGeneration == generation else { return }
+        self?.registryPhase = .registered
+      } catch is CancellationError {
+        return
+      } catch {
+        guard self?.serverGeneration == generation else { return }
+        self?.registryPhase = .failed(error.localizedDescription)
+      }
     }
   }
 }

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
@@ -54,6 +54,11 @@ struct PrivateMacShareSheet: View {
           detail: phaseDetail,
           isReady: controller.phase.isRunning
         )
+        ShareStatusRow(
+          title: "Crabfleet registry",
+          detail: controller.registryPhase.detail,
+          isReady: controller.registryPhase.isReady
+        )
       }
       .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
 

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/FleetModelsTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/FleetModelsTests.swift
@@ -78,6 +78,15 @@ struct FleetModelsTests {
           "generatedAt": 1770000000000,
           "registryAvailable": true,
           "totals": { "active": 1, "sessions": 1, "vnc": 1 },
+          "desktopHosts": [{
+            "id": "studio",
+            "owner": "operator",
+            "name": "Mac Studio",
+            "address": "100.68.201.40",
+            "port": 5901,
+            "createdAt": 1769999900000,
+            "updatedAt": 1770000000000
+          }],
           "sessions": [{
             "id": "IS-1",
             "repo": "openclaw/crabfleet",
@@ -104,6 +113,16 @@ struct FleetModelsTests {
     #expect(lease.displayName == "blue-lobster")
     #expect(lease.desktopAvailable)
     #expect(lease.updatedAt.timeIntervalSince1970 == 1_770_000_000)
+    let host = try #require(response.fleet.desktopHosts?.first?.desktopHost())
+    #expect(host.id == "studio")
+    #expect(host.name == "Mac Studio")
+    #expect(host.address == "100.68.201.40")
+    #expect(host.port == 5901)
+
+    let target = DesktopTarget(host: host)
+    #expect(target.endpoint?.host == "100.68.201.40")
+    #expect(target.endpoint?.port == 5901)
+    #expect(target.desktopAvailable)
   }
 
   @Test @MainActor

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
@@ -16,6 +16,75 @@ struct PrivateMacShareTests {
   }
 
   @Test
+  func derivesGenericStableDesktopHostID() {
+    let identity = TailnetIdentity(
+      tailnetName: "example.com",
+      loginName: "operator@example.com",
+      dnsName: "workstation-1.example.ts.net",
+      hostName: "Workstation",
+      ipv4Address: "100.64.12.34",
+      userID: 42
+    )
+    #expect(CrabfleetDesktopRegistration.hostID(identity: identity) == "workstation-1")
+
+    let fallback = TailnetIdentity(
+      tailnetName: identity.tailnetName,
+      loginName: identity.loginName,
+      dnsName: "",
+      hostName: identity.hostName,
+      ipv4Address: identity.ipv4Address,
+      userID: identity.userID
+    )
+    #expect(CrabfleetDesktopRegistration.hostID(identity: fallback) == "mac-100-64-12-34")
+  }
+
+  @Test
+  func acceptsOnlySecureCrabfleetAPIURLs() throws {
+    #expect(
+      CrabfleetDesktopRegistration.isSecureAPIURL(
+        try #require(URL(string: "https://fleet.example/api/fleet"))))
+    #expect(
+      CrabfleetDesktopRegistration.isSecureAPIURL(
+        try #require(URL(string: "http://127.0.0.1:8787"))))
+    #expect(
+      !CrabfleetDesktopRegistration.isSecureAPIURL(
+        try #require(URL(string: "http://fleet.example"))))
+    #expect(
+      !CrabfleetDesktopRegistration.isSecureAPIURL(
+        try #require(URL(string: "https://user@fleet.example"))))
+    #expect(
+      !CrabfleetDesktopRegistration.isSecureAPIURL(
+        try #require(URL(string: "https://fleet.example?token=value"))))
+  }
+
+  @Test
+  func buildsAuthenticatedDesktopRegistrationRequest() throws {
+    let registration = try #require(
+      CrabfleetDesktopRegistration(environment: [
+        "CRABFLEET_API_URL": "https://fleet.example/api/fleet",
+        "CRABFLEET_SESSION_COOKIE": "crabbox_session=secret",
+      ]))
+    let identity = TailnetIdentity(
+      tailnetName: "example.com",
+      loginName: "operator@example.com",
+      dnsName: "workstation-1.example.ts.net",
+      hostName: "Workstation",
+      ipv4Address: "100.64.12.34",
+      userID: 42
+    )
+
+    let request = try registration.registrationRequest(identity: identity, port: 5901)
+    #expect(request.url?.absoluteString == "https://fleet.example/api/desktop-hosts/workstation-1")
+    #expect(request.httpMethod == "PUT")
+    #expect(request.value(forHTTPHeaderField: "Cookie") == "crabbox_session=secret")
+    let body = try #require(request.httpBody)
+    let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+    #expect(json["name"] as? String == "Workstation")
+    #expect(json["address"] as? String == "100.64.12.34")
+    #expect(json["port"] as? Int == 5901)
+  }
+
+  @Test
   func rejectsInvalidTailnetAndIdentityFields() throws {
     var value = statusJSON()
     value = value.replacingOccurrences(

--- a/migrations/0030_desktop_hosts.sql
+++ b/migrations/0030_desktop_hosts.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS desktop_hosts (
+  owner_subject TEXT NOT NULL,
+  id TEXT NOT NULL,
+  owner TEXT NOT NULL,
+  name TEXT NOT NULL,
+  address TEXT NOT NULL,
+  port INTEGER NOT NULL CHECK (port >= 1 AND port <= 65535),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (owner_subject, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_desktop_hosts_owner_updated
+  ON desktop_hosts(owner_subject, updated_at DESC);

--- a/src/fleet-state.ts
+++ b/src/fleet-state.ts
@@ -72,6 +72,17 @@ export type FleetStateOptions = {
   productUrl: string;
   registryAvailable?: boolean;
   sandboxAvailable?: boolean | undefined;
+  desktopHosts?: FleetDesktopHostSummary[];
+};
+
+export type FleetDesktopHostSummary = {
+  id: string;
+  owner: string;
+  name: string;
+  address: string;
+  port: number;
+  createdAt: number;
+  updatedAt: number;
 };
 
 export type FleetSessionSummary = {
@@ -122,6 +133,7 @@ export type FleetState = {
   canonicalUrl: string;
   productUrl: string;
   generatedAt: number;
+  desktopHosts: FleetDesktopHostSummary[];
   registryAvailable: boolean;
   egress: {
     defaultHostCount: number;
@@ -206,6 +218,9 @@ export function buildFleetState(
     canonicalUrl: options.canonicalUrl,
     productUrl: options.productUrl,
     generatedAt: options.generatedAt,
+    desktopHosts: [...(options.desktopHosts ?? [])].sort(
+      (a, b) => b.updatedAt - a.updatedAt || a.id.localeCompare(b.id),
+    ),
     registryAvailable: options.registryAvailable ?? true,
     egress: {
       defaultHostCount: options.defaultEgressHosts.length,

--- a/src/worker/database.ts
+++ b/src/worker/database.ts
@@ -62,6 +62,17 @@ export type SessionTable = {
   github_token_ciphertext: string | null;
 };
 
+export type DesktopHostTable = {
+  owner_subject: string;
+  id: string;
+  owner: string;
+  name: string;
+  address: string;
+  port: number;
+  created_at: number;
+  updated_at: number;
+};
+
 export type CardTable = {
   id: string;
   title: string;
@@ -327,6 +338,7 @@ export type Database = {
   repos: RepoTable;
   users: UserTable;
   sessions: SessionTable;
+  desktop_hosts: DesktopHostTable;
   cards: CardTable;
   run_attempts: RunAttemptTable;
   interactive_sessions: InteractiveSessionTable;

--- a/src/worker/desktop-host-repository.ts
+++ b/src/worker/desktop-host-repository.ts
@@ -1,0 +1,98 @@
+import { database } from "./database.ts";
+import type { RuntimeEnv } from "./env.ts";
+
+export type DesktopHostRow = {
+  ownerSubject: string;
+  id: string;
+  owner: string;
+  name: string;
+  address: string;
+  port: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type DesktopHostWrite = DesktopHostRow;
+
+export interface DesktopHostStore {
+  list(ownerSubject: string): Promise<DesktopHostRow[]>;
+  upsert(host: DesktopHostWrite): Promise<DesktopHostRow>;
+  remove(ownerSubject: string, id: string): Promise<void>;
+}
+
+export class DesktopHostRepository implements DesktopHostStore {
+  private readonly env: RuntimeEnv;
+
+  constructor(env: RuntimeEnv) {
+    this.env = env;
+  }
+
+  async list(ownerSubject: string): Promise<DesktopHostRow[]> {
+    const rows = await database(this.env)
+      .selectFrom("desktop_hosts")
+      .selectAll()
+      .where("owner_subject", "=", ownerSubject)
+      .orderBy("updated_at", "desc")
+      .orderBy("id")
+      .execute();
+    return rows.map((row) => ({
+      ownerSubject: row.owner_subject,
+      id: row.id,
+      owner: row.owner,
+      name: row.name,
+      address: row.address,
+      port: row.port,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  }
+
+  async upsert(host: DesktopHostWrite): Promise<DesktopHostRow> {
+    await database(this.env)
+      .insertInto("desktop_hosts")
+      .values({
+        owner_subject: host.ownerSubject,
+        id: host.id,
+        owner: host.owner,
+        name: host.name,
+        address: host.address,
+        port: host.port,
+        created_at: host.createdAt,
+        updated_at: host.updatedAt,
+      })
+      .onConflict((conflict) =>
+        conflict.columns(["owner_subject", "id"]).doUpdateSet({
+          owner: host.owner,
+          name: host.name,
+          address: host.address,
+          port: host.port,
+          updated_at: host.updatedAt,
+        }),
+      )
+      .execute();
+    const row = await database(this.env)
+      .selectFrom("desktop_hosts")
+      .selectAll()
+      .where("owner_subject", "=", host.ownerSubject)
+      .where("id", "=", host.id)
+      .executeTakeFirstOrThrow();
+    return {
+      ownerSubject: row.owner_subject,
+      id: row.id,
+      owner: row.owner,
+      name: row.name,
+      address: row.address,
+      port: row.port,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  async remove(ownerSubject: string, id: string): Promise<void> {
+    await database(this.env)
+      .deleteFrom("desktop_hosts")
+      .where("owner_subject", "=", ownerSubject)
+      .where("id", "=", id)
+      .execute();
+  }
+}

--- a/src/worker/desktop-host-service.ts
+++ b/src/worker/desktop-host-service.ts
@@ -1,0 +1,123 @@
+import { badRequest } from "./http.ts";
+import type { User } from "./models.ts";
+import { tenantSubject } from "./tenancy.ts";
+import type { DesktopHostRow, DesktopHostStore } from "./desktop-host-repository.ts";
+
+export type DesktopHostInput = {
+  name?: unknown;
+  address?: unknown;
+  port?: unknown;
+};
+
+export type DesktopHost = {
+  id: string;
+  owner: string;
+  name: string;
+  address: string;
+  port: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export class DesktopHostService {
+  private readonly store: DesktopHostStore;
+  private readonly now: () => number;
+
+  constructor(store: DesktopHostStore, now: () => number = Date.now) {
+    this.store = store;
+    this.now = now;
+  }
+
+  async list(user: User): Promise<DesktopHost[]> {
+    const rows = await this.store.list(tenantSubject(user));
+    return rows.map(presentDesktopHost);
+  }
+
+  async register(user: User, rawID: string, input: DesktopHostInput): Promise<DesktopHost> {
+    const id = desktopHostID(rawID);
+    const name = boundedText(input.name, "name", 100);
+    const address = tailscaleIPv4(input.address);
+    const port = desktopHostPort(input.port);
+    const now = this.now();
+    const host: DesktopHostRow = {
+      ownerSubject: tenantSubject(user),
+      id,
+      owner: user.login || user.email || user.name || user.subject,
+      name,
+      address,
+      port,
+      createdAt: now,
+      updatedAt: now,
+    };
+    return presentDesktopHost(await this.store.upsert(host));
+  }
+
+  async remove(user: User, rawID: string): Promise<void> {
+    await this.store.remove(tenantSubject(user), desktopHostID(rawID));
+  }
+}
+
+function presentDesktopHost(row: DesktopHostRow): DesktopHost {
+  return {
+    id: row.id,
+    owner: row.owner,
+    name: row.name,
+    address: row.address,
+    port: row.port,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function desktopHostID(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!/^[a-z0-9](?:[a-z0-9._-]{0,78}[a-z0-9])?$/.test(normalized)) {
+    throw badRequest(
+      "desktop host id must contain 1-80 lowercase letters, numbers, dots, dashes, or underscores",
+    );
+  }
+  return normalized;
+}
+
+function boundedText(value: unknown, field: string, maximum: number): string {
+  if (typeof value !== "string") throw badRequest(`${field} is required`);
+  const normalized = value.trim();
+  if (
+    normalized.length === 0 ||
+    new TextEncoder().encode(normalized).byteLength > maximum ||
+    [...normalized].some((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint <= 0x1f || codePoint === 0x7f;
+    })
+  ) {
+    throw badRequest(`${field} is invalid`);
+  }
+  return normalized;
+}
+
+function tailscaleIPv4(value: unknown): string {
+  if (typeof value !== "string") throw badRequest("address is required");
+  const parts = value.split(".");
+  if (parts.length !== 4 || parts.some((part) => !/^(?:0|[1-9][0-9]{0,2})$/.test(part))) {
+    throw badRequest("address must be a Tailscale IPv4 address");
+  }
+  const octets = parts.map(Number);
+  const firstOctet = octets[0] ?? -1;
+  const secondOctet = octets[1] ?? -1;
+  if (
+    octets.some((octet) => octet < 0 || octet > 255) ||
+    firstOctet !== 100 ||
+    secondOctet < 64 ||
+    secondOctet > 127
+  ) {
+    throw badRequest("address must be in 100.64.0.0/10");
+  }
+  return octets.join(".");
+}
+
+function desktopHostPort(value: unknown): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1 || value > 65_535) {
+    throw badRequest("port must be an integer from 1 to 65535");
+  }
+  return value;
+}

--- a/src/worker/routes/control-plane.ts
+++ b/src/worker/routes/control-plane.ts
@@ -5,12 +5,15 @@ import type {
   AdminRepoInput,
   AdminWorkflowInput,
 } from "../admin-service.ts";
+import type { DesktopHost, DesktopHostInput } from "../desktop-host-service.ts";
 import { json, notFound, readJson } from "../http.ts";
 import type { User } from "../models.ts";
 
 export type ControlPlaneRouteDependencies = {
   readState(request: Request, user: User): Promise<unknown>;
   readFleet(user: User): Promise<unknown>;
+  registerDesktopHost(user: User, id: string, input: DesktopHostInput): Promise<DesktopHost>;
+  removeDesktopHost(user: User, id: string): Promise<void>;
   searchGitHubRefs(number: unknown): Promise<unknown>;
   createCard(request: Request, user: User): Promise<unknown>;
   readCardRuns(user: User, cardId: string): Promise<unknown[] | null>;
@@ -36,6 +39,22 @@ export async function handleControlPlaneRoute(
   if (request.method === "GET" && url.pathname === "/api/fleet") {
     requireRole(user, "viewer");
     return json({ fleet: await dependencies.readFleet(user) });
+  }
+
+  const desktopHostMatch = url.pathname.match(/^\/api\/desktop-hosts\/([^/]+)$/);
+  if (request.method === "PUT" && desktopHostMatch) {
+    requireRole(user, "viewer");
+    const host = await dependencies.registerDesktopHost(
+      user,
+      decoded(desktopHostMatch[1]),
+      await readJson<DesktopHostInput>(request),
+    );
+    return json({ host });
+  }
+  if (request.method === "DELETE" && desktopHostMatch) {
+    requireRole(user, "viewer");
+    await dependencies.removeDesktopHost(user, decoded(desktopHostMatch[1]));
+    return json({ ok: true });
   }
   if (request.method === "GET" && url.pathname === "/api/github/refs") {
     requireRole(user, "maintainer");

--- a/src/worker/worker-application.ts
+++ b/src/worker/worker-application.ts
@@ -16,6 +16,8 @@ import { GitHubReferenceService } from "./github-reference-service.ts";
 import { readJson } from "./http.ts";
 import { InteractiveSessionApplication } from "./interactive-session-application.ts";
 import { createInteractiveDesktopService } from "./interactive-desktop-service.ts";
+import { DesktopHostRepository } from "./desktop-host-repository.ts";
+import { DesktopHostService } from "./desktop-host-service.ts";
 import { InteractiveTerminalService } from "./interactive-terminal-service.ts";
 import type { User } from "./models.ts";
 import { isOpenClawEmbedSessionToken } from "./openclaw-embed-access.ts";
@@ -47,6 +49,7 @@ const services = {
   browserSessionCreation: Symbol("browser-session-creation"),
   cardLifecycle: Symbol("card-lifecycle"),
   desktop: Symbol("desktop"),
+  desktopHosts: Symbol("desktop-hosts"),
   githubReference: Symbol("github-reference"),
   sandboxResources: Symbol("sandbox-resources"),
   sharedSessions: Symbol("shared-sessions"),
@@ -136,6 +139,8 @@ export class WorkerApplication {
     return {
       readState: (request, user) => this.readState(request, user, context),
       readFleet: (user) => this.readFleetState(user, undefined, context),
+      registerDesktopHost: (user, id, input) => this.desktopHosts().register(user, id, input),
+      removeDesktopHost: (user, id) => this.desktopHosts().remove(user, id),
       searchGitHubRefs: (number) => this.githubReferenceService().search(number),
       createCard: async (request, user) =>
         this.cardLifecycleService().create(await readJson<CardCreateInput>(request), user),
@@ -295,9 +300,10 @@ export class WorkerApplication {
     if (!sessionRows) {
       await this.runtime.reconcileSessions(Date.now(), context);
     }
-    const [interactiveSessions, policyResult] = await Promise.all([
+    const [interactiveSessions, policyResult, desktopHosts] = await Promise.all([
       sessionRows ? Promise.resolve(sessionRows) : this.sessions.readAll(user),
       readSandboxFleetPolicies(this.env),
+      this.desktopHosts().list(user),
     ]);
     return buildFleetState(interactiveSessions, policyResult.policies, {
       canonicalUrl: browserAppOrigin(this.env),
@@ -306,6 +312,7 @@ export class WorkerApplication {
       generatedAt: Date.now(),
       registryAvailable: policyResult.available,
       sandboxAvailable: Boolean(this.env.SANDBOX),
+      desktopHosts,
     });
   }
 
@@ -443,6 +450,13 @@ export class WorkerApplication {
 
   private adminRepository(): AdminRepository {
     return this.registry.get(services.adminRepository, () => new AdminRepository(this.env));
+  }
+
+  private desktopHosts(): DesktopHostService {
+    return this.registry.get(
+      services.desktopHosts,
+      () => new DesktopHostService(new DesktopHostRepository(this.env)),
+    );
   }
 
   private adminService(): AdminService {

--- a/tests/control-plane-routes.test.ts
+++ b/tests/control-plane-routes.test.ts
@@ -41,6 +41,21 @@ function dependencies(calls: string[]): ControlPlaneRouteDependencies {
       calls.push(`fleet:${user.login}`);
       return { handler: "fleet" };
     },
+    async registerDesktopHost(user, id, input) {
+      calls.push(`desktop-host:register:${user.login}:${id}:${input.name}`);
+      return {
+        id,
+        owner: user.login ?? user.subject,
+        name: String(input.name),
+        address: String(input.address),
+        port: Number(input.port),
+        createdAt: 1,
+        updatedAt: 1,
+      };
+    },
+    async removeDesktopHost(user, id) {
+      calls.push(`desktop-host:remove:${user.login}:${id}`);
+    },
     async searchGitHubRefs(number) {
       calls.push(`github-refs:${number}`);
       return { handler: "github-refs" };
@@ -131,6 +146,42 @@ test("control-plane read and card routes enforce their role boundaries", async (
     assert.equal(status(error), 403);
     return true;
   });
+});
+
+test("desktop host routes register and remove only the authenticated user's host", async () => {
+  const calls: string[] = [];
+  const registered = await dispatch(
+    request("PUT", "/api/desktop-hosts/mac%2Dstudio", {
+      name: "Mac Studio",
+      address: "100.64.1.2",
+      port: 5901,
+    }),
+    viewer,
+    calls,
+  );
+  assert.equal(registered?.status, 200);
+  assert.deepEqual(await registered?.json(), {
+    host: {
+      id: "mac-studio",
+      owner: "viewer",
+      name: "Mac Studio",
+      address: "100.64.1.2",
+      port: 5901,
+      createdAt: 1,
+      updatedAt: 1,
+    },
+  });
+
+  const removed = await dispatch(
+    request("DELETE", "/api/desktop-hosts/mac%2Dstudio"),
+    viewer,
+    calls,
+  );
+  assert.equal(removed?.status, 200);
+  assert.deepEqual(calls, [
+    "desktop-host:register:viewer:mac-studio:Mac Studio",
+    "desktop-host:remove:viewer:mac-studio",
+  ]);
 });
 
 test("card actions derive viewer or maintainer authorization from the action", async () => {

--- a/tests/desktop-host-migration.test.ts
+++ b/tests/desktop-host-migration.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+
+test("desktop host migration creates an owner-scoped registry with bounded ports", () => {
+  const database = new DatabaseSync(":memory:");
+  const migration = readFileSync(
+    new URL("../migrations/0030_desktop_hosts.sql", import.meta.url),
+    "utf8",
+  );
+  database.exec(migration);
+  database.exec(migration);
+
+  const insert = database.prepare(`
+    INSERT INTO desktop_hosts
+      (owner_subject, id, owner, name, address, port, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  insert.run("github:1", "studio", "alice", "Alice's Studio", "100.64.1.2", 5901, 1, 1);
+  insert.run("github:2", "studio", "bob", "Bob's Studio", "100.64.1.3", 5901, 1, 1);
+
+  assert.equal(
+    database.prepare("SELECT count(*) AS count FROM desktop_hosts WHERE id = 'studio'").get()
+      ?.count,
+    2,
+  );
+  assert.throws(
+    () => insert.run("github:3", "bad", "bad", "Bad", "100.64.1.4", 0, 1, 1),
+    /constraint/i,
+  );
+  assert.equal(
+    database
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?")
+      .get("idx_desktop_hosts_owner_updated")?.name,
+    "idx_desktop_hosts_owner_updated",
+  );
+});

--- a/tests/desktop-host-repository.test.ts
+++ b/tests/desktop-host-repository.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { DesktopHostRepository } from "../src/worker/desktop-host-repository.ts";
+import type { RuntimeEnv } from "../src/worker/env.ts";
+
+test("desktop host repository scopes reads, upserts, and deletes by owner subject", async () => {
+  const executions: Array<{ sql: string; parameters: unknown[] }> = [];
+  const stored = {
+    owner_subject: "github:1",
+    id: "studio",
+    owner: "alice",
+    name: "Studio",
+    address: "100.64.1.2",
+    port: 5901,
+    created_at: 1,
+    updated_at: 2,
+  };
+  const env = {
+    DB: {
+      prepare(sql: string) {
+        return {
+          bind(...parameters: unknown[]) {
+            executions.push({ sql, parameters });
+            return {
+              async all() {
+                return { results: [stored], meta: { changes: 0 } };
+              },
+              async run() {
+                return { meta: { changes: 1 } };
+              },
+            };
+          },
+        };
+      },
+    } as unknown as D1Database,
+  } as RuntimeEnv;
+  const repository = new DesktopHostRepository(env);
+
+  assert.deepEqual(await repository.list("github:1"), [
+    {
+      ownerSubject: "github:1",
+      id: "studio",
+      owner: "alice",
+      name: "Studio",
+      address: "100.64.1.2",
+      port: 5901,
+      createdAt: 1,
+      updatedAt: 2,
+    },
+  ]);
+  assert.match(executions[0]?.sql ?? "", /where "owner_subject" = \?/i);
+  assert.deepEqual(executions[0]?.parameters, ["github:1"]);
+
+  const upserted = await repository.upsert({
+    ownerSubject: "github:1",
+    id: "studio",
+    owner: "alice",
+    name: "Studio",
+    address: "100.64.1.2",
+    port: 5901,
+    createdAt: 1,
+    updatedAt: 2,
+  });
+  assert.equal(upserted.id, "studio");
+  assert.match(executions[1]?.sql ?? "", /^insert into "desktop_hosts"/i);
+  assert.match(executions[2]?.sql ?? "", /where "owner_subject" = \? and "id" = \?/i);
+  assert.deepEqual(executions[2]?.parameters, ["github:1", "studio"]);
+
+  await repository.remove("github:1", "studio");
+  assert.match(executions[3]?.sql ?? "", /^delete from "desktop_hosts"/i);
+  assert.deepEqual(executions[3]?.parameters, ["github:1", "studio"]);
+});

--- a/tests/desktop-host-service.test.ts
+++ b/tests/desktop-host-service.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { DesktopHostRow, DesktopHostStore } from "../src/worker/desktop-host-repository.ts";
+import { DesktopHostService } from "../src/worker/desktop-host-service.ts";
+import type { User } from "../src/worker/models.ts";
+
+const alice: User = {
+  subject: "github:1",
+  login: "alice",
+  email: null,
+  name: "Alice",
+  role: "viewer",
+  allowed: true,
+  teams: [],
+};
+
+const bob: User = {
+  ...alice,
+  subject: "github:2",
+  login: "bob",
+};
+
+class MemoryDesktopHostStore implements DesktopHostStore {
+  readonly rows = new Map<string, DesktopHostRow>();
+
+  async list(ownerSubject: string): Promise<DesktopHostRow[]> {
+    return [...this.rows.values()].filter((row) => row.ownerSubject === ownerSubject);
+  }
+
+  async upsert(host: DesktopHostRow): Promise<DesktopHostRow> {
+    const key = `${host.ownerSubject}:${host.id}`;
+    const existing = this.rows.get(key);
+    const stored = { ...host, createdAt: existing?.createdAt ?? host.createdAt };
+    this.rows.set(key, stored);
+    return stored;
+  }
+
+  async remove(ownerSubject: string, id: string): Promise<void> {
+    this.rows.delete(`${ownerSubject}:${id}`);
+  }
+}
+
+test("desktop hosts are canonicalized and isolated to their stable owner", async () => {
+  const store = new MemoryDesktopHostStore();
+  let now = 42;
+  const service = new DesktopHostService(store, () => now);
+  const host = await service.register(alice, " Studio.ONE ", {
+    name: " Peter's Mac Studio ",
+    address: "100.68.201.40",
+    port: 5901,
+  });
+
+  assert.deepEqual(host, {
+    id: "studio.one",
+    owner: "alice",
+    name: "Peter's Mac Studio",
+    address: "100.68.201.40",
+    port: 5901,
+    createdAt: 42,
+    updatedAt: 42,
+  });
+  assert.deepEqual(await service.list(alice), [host]);
+  assert.deepEqual(await service.list(bob), []);
+
+  now = 84;
+  const updated = await service.register(alice, host.id, {
+    name: "Renamed Studio",
+    address: host.address,
+    port: host.port,
+  });
+  assert.equal(updated.createdAt, 42);
+  assert.equal(updated.updatedAt, 84);
+  assert.equal(updated.name, "Renamed Studio");
+
+  await service.remove(bob, host.id);
+  assert.deepEqual(await service.list(alice), [updated]);
+  await service.remove(alice, host.id);
+  assert.deepEqual(await service.list(alice), []);
+});
+
+test("desktop hosts accept only bounded metadata and Tailscale IPv4 endpoints", async () => {
+  const service = new DesktopHostService(new MemoryDesktopHostStore());
+  const valid = { name: "Studio", address: "100.127.255.254", port: 65_535 };
+  await service.register(alice, "a", valid);
+
+  for (const id of ["", "-host", "host-", "host/path", "a".repeat(81)]) {
+    await assert.rejects(service.register(alice, id, valid), /desktop host id/);
+  }
+  for (const address of [
+    "100.63.255.255",
+    "100.128.0.1",
+    "192.168.1.2",
+    "100.064.1.2",
+    "100.64.1.2.extra",
+  ]) {
+    await assert.rejects(service.register(alice, "studio", { ...valid, address }), /address/);
+  }
+  await assert.rejects(service.register(alice, "studio", { ...valid, name: "bad\nname" }), /name/);
+  await assert.rejects(service.register(alice, "studio", { ...valid, port: 0 }), /port/);
+});

--- a/tests/fleet-state.test.ts
+++ b/tests/fleet-state.test.ts
@@ -74,6 +74,17 @@ test("fleet state aggregates sessions and redacted sandbox policies", () => {
       generatedAt: 100,
       productUrl: "https://crabfleet.ai",
       sandboxAvailable: true,
+      desktopHosts: [
+        {
+          id: "studio",
+          owner: "steipete",
+          name: "Studio",
+          address: "100.64.1.2",
+          port: 5901,
+          createdAt: 10,
+          updatedAt: 50,
+        },
+      ],
     },
   );
 
@@ -99,6 +110,17 @@ test("fleet state aggregates sessions and redacted sandbox policies", () => {
   assert.equal(fleet.sessions[1]?.policy.hasGithubToken, true);
   assert.equal(fleet.sessions[1]?.policy.githubCredentialSource, "worker");
   assert.equal(fleet.sessions[1]?.policy.allowedHostCount, 3);
+  assert.deepEqual(fleet.desktopHosts, [
+    {
+      id: "studio",
+      owner: "steipete",
+      name: "Studio",
+      address: "100.64.1.2",
+      port: 5901,
+      createdAt: 10,
+      updatedAt: 50,
+    },
+  ]);
 });
 
 test("GitHub Actions sessions are attachable through the Worker relay", () => {


### PR DESCRIPTION
## What

- Add a first-class, D1-backed desktop-host registry scoped to the authenticated stable user.
- Add authenticated `PUT` and `DELETE /api/desktop-hosts/:id` routes.
- Return private registered hosts from `/api/fleet`.
- Restrict registered endpoints to canonical Tailscale `100.64.0.0/10` IPv4 addresses and bounded ports/metadata.
- Publish the native Mac's endpoint when **Share This Mac** starts with an authenticated API configuration.
- Turn registered hosts into direct-connect native Fleet cards with no VNC password.
- Add migration, repository, service, route, model, request, and live protocol coverage.

## Why

The macOS host could serve an app-owned desktop, but Crabfleet had no persistent host model. The fleet API exposed only ephemeral Codex sessions, and native fleet session entries intentionally carried no direct endpoint, so another Mac could not discover or directly connect to the shared Mac.

## Security and impact

- Hosts are always queried, updated, and deleted by exact stable owner subject, even when session tenancy is configured as shared.
- Registration rejects LAN, loopback, malformed, and public addresses; only canonical Tailscale CGNAT IPv4 addresses are accepted.
- The native client sends its existing session cookie only to HTTPS origins or literal loopback HTTP, with credentials, queries, fragments, and control characters rejected.
- The RFB listener remains bound to the exact tailnet address and still authorizes the connecting peer with `tailscale whois` before sending the RFB banner.
- No organization, tailnet, domain, or email suffix is hardcoded.

## Checks

- 18 focused Worker route/service/repository/migration/fleet tests pass.
- Full dependency-independent Node run: 663 tests pass; 9 terminal-only files could not load because the local package firewall denied the existing locked `@openclaw/libterminal` tarball.
- Full repository oxlint passes.
- Full 360-file oxfmt check passes.
- 20 vendored RoyalVNCKit protocol tests pass.
- 32 macOS app tests pass.
- Real local-tailnet RoyalVNCKit server/client smoke passes.
- Strict Swift format lint passes.
- Release bundle builds and passes `codesign --verify --deep --strict`.
- `git diff --check` passes.