### PR TITLE
feat(mac): add unattended private sharing

### DIFF
--- a/macos/CrabfleetMac/README.md
+++ b/macos/CrabfleetMac/README.md
@@ -34,6 +34,15 @@ macOS makes captured frames available. Ad-hoc development signatures can cause
 macOS to ask again after a rebuild; production signing is required for a stable
 permission identity.
 
+For an unattended host, launch the bundled app with `--share-this-mac`, or set
+`CRABFLEET_AUTO_SHARE=1`. Crabfleet requests any missing Screen Recording and
+Accessibility permissions, waits up to five minutes for them to be granted,
+and then starts the same tailnet-only RFB listener used by the in-app control:
+
+```sh
+/Applications/Crabfleet.app/Contents/MacOS/CrabfleetMac --share-this-mac
+```
+
 ## Build
 
 ```sh

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/CrabfleetMacApp.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/CrabfleetMacApp.swift
@@ -1,7 +1,81 @@
+import AppKit
+import Foundation
 import SwiftUI
+
+enum PrivateMacShareLaunchMode {
+  static let argument = "--share-this-mac"
+  static let environmentKey = "CRABFLEET_AUTO_SHARE"
+
+  static func isEnabled(
+    arguments: [String] = ProcessInfo.processInfo.arguments,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) -> Bool {
+    arguments.dropFirst().contains(argument) || environment[environmentKey] == "1"
+  }
+}
+
+@MainActor
+final class CrabfleetApplicationDelegate: NSObject, NSApplicationDelegate {
+  private var shareController: PrivateMacShareController?
+  private var autoShareTask: Task<Void, Never>?
+
+  func applicationDidFinishLaunching(_ notification: Notification) {
+    guard PrivateMacShareLaunchMode.isEnabled() else { return }
+    NSApp.activate(ignoringOtherApps: true)
+    let controller = PrivateMacShareController()
+    shareController = controller
+    autoShareTask = Task { [weak self] in
+      guard let self else { return }
+      try? await Task.sleep(for: .milliseconds(500))
+      await self.startPrivateShare(controller)
+    }
+  }
+
+  func applicationWillTerminate(_ notification: Notification) {
+    autoShareTask?.cancel()
+  }
+
+  private func startPrivateShare(_ controller: PrivateMacShareController) async {
+    await controller.refresh()
+    if !controller.screenRecordingGranted {
+      await controller.requestScreenRecordingPermission()
+    }
+    if !controller.accessibilityGranted {
+      controller.requestAccessibilityPermission()
+    }
+
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: .seconds(300))
+    while !Task.isCancelled, clock.now < deadline {
+      await controller.refresh()
+      if controller.canStart {
+        await controller.start()
+        for _ in 0..<50 where controller.phase == .starting {
+          try? await Task.sleep(for: .milliseconds(100))
+        }
+        let address = controller.connectionAddress.map { " at \($0)" } ?? ""
+        let notice = controller.notice.map { ": \($0)" } ?? ""
+        report("private share \(controller.phase.title.lowercased())\(address)\(notice)")
+        return
+      }
+      try? await Task.sleep(for: .seconds(2))
+    }
+
+    let missing = [
+      controller.screenRecordingGranted ? nil : "Screen Recording",
+      controller.accessibilityGranted ? nil : "Accessibility",
+    ].compactMap { $0 }
+    report("private share waiting for \(missing.joined(separator: " and ")) permission")
+  }
+
+  private func report(_ message: String) {
+    FileHandle.standardError.write(Data("Crabfleet: \(message)\n".utf8))
+  }
+}
 
 @main
 struct CrabfleetMacApp: App {
+  @NSApplicationDelegateAdaptor(CrabfleetApplicationDelegate.self) private var appDelegate
   @StateObject private var fleetStore = FleetStore()
   @StateObject private var connectionLibrary = ConnectionLibrary()
   @StateObject private var sessionPool = VNCSessionPool()

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
@@ -6,6 +6,20 @@ import Testing
 
 struct PrivateMacShareTests {
   @Test
+  func recognizesExplicitPrivateShareLaunchMode() {
+    #expect(
+      PrivateMacShareLaunchMode.isEnabled(
+        arguments: ["CrabfleetMac", "--share-this-mac"], environment: [:]))
+    #expect(
+      PrivateMacShareLaunchMode.isEnabled(
+        arguments: ["CrabfleetMac"], environment: ["CRABFLEET_AUTO_SHARE": "1"]))
+    #expect(
+      !PrivateMacShareLaunchMode.isEnabled(
+        arguments: ["CrabfleetMac"], environment: ["CRABFLEET_AUTO_SHARE": "true"]))
+    #expect(!PrivateMacShareLaunchMode.isEnabled(arguments: ["CrabfleetMac"], environment: [:]))
+  }
+
+  @Test
   func acceptsOnlineUserOnActiveTailnet() throws {
     let identity = try TailnetIdentityPolicy.identity(from: statusDocument())
 


### PR DESCRIPTION
## Summary

- add a generic `--share-this-mac` / `CRABFLEET_AUTO_SHARE=1` unattended launch mode
- foreground once for macOS privacy consent, poll the two required grants, and start the existing tailnet-only ScreenCaptureKit/RFB host
- document the mode and cover explicit opt-in detection

## Validation

- `pnpm macos:test` (20 RoyalVNCKit tests and 33 Crabfleet tests)
- `xcrun swift-format lint --strict` on the changed Swift files
- release bundle built and passed deep/strict code-sign verification
- live host bound only to `100.68.201.40:5901`; tailnet smoke connection returned `RFB 003.008`
