### PR TITLE
fix: surface stalled provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Classify stalled or errored workspace provisioning as attention, exclude it from the Starting count, and surface the redacted reconciliation reason in Fleet.
 - Add private per-user desktop-host registration so native macOS shares appear in Fleet with direct same-tailnet VNC endpoints.
 - Add app-owned macOS desktop hosting with ScreenCaptureKit, bounded Tight/JPEG RFB streaming, Accessibility-authorized input, an exact active-tailnet bind, and same-user Tailscale peer admission without Apple Screen Sharing or a public relay.
 - Add atomically claimed recurring card intervals with constant-time catch-up, crash-recoverable leases, scheduler/API proof, and coalescing for active or capacity-blocked runs, thanks @Jhacarreiro.

--- a/docs/spec-v2.md
+++ b/docs/spec-v2.md
@@ -70,6 +70,7 @@ Fleet state shape:
     "active": 2,
     "ready": 2,
     "provisioning": 0,
+    "attention": 1,
     "failed": 1,
     "stopped": 1,
     "attachable": 2,
@@ -101,6 +102,8 @@ Per-session summary:
 - `owner`
 - `status`
 - `active`
+- `attention`
+- `attentionReason`
 - `attachable`
 - `vnc`
 - `archived`
@@ -120,6 +123,10 @@ Per-session summary:
 - `policy.openAIBaseUrlHost`
 
 `attachable` is true only for terminal-capable `ready`, `attached`, or `detached` sessions with current control and a resolvable Sandbox or valid WSS/literal-loopback WS provider URL.
+
+`totals.provisioning` counts only healthy `provisioning` sessions. `totals.attention` counts failed or stopping sessions, sessions waiting for an adapter, and provisioning sessions with an expired lease, an actionable reconciliation error, or no progress for 15 minutes. `totals.byStatus` preserves the raw lifecycle counts, so a provisioning session needing attention remains present under `byStatus.provisioning` while being excluded from `totals.provisioning`.
+
+Per-session `attention` exposes the same operational classification. `attentionReason` is a bounded, redacted diagnostic for controllers and a generic operator-attention message when provider details are concealed by authorization policy.
 
 ## Security
 

--- a/src/app/fleet.jsx
+++ b/src/app/fleet.jsx
@@ -6,6 +6,7 @@ import {
   fleetCoversInteractiveSessions,
   humanStatus,
   interactiveSessionStatus,
+  isFleetSessionAttention,
   isFleetSessionAttachable,
   isTerminalReadyInteractiveSession,
   runCapabilities,
@@ -21,17 +22,25 @@ export function FleetPage(props) {
   const preferredRepo = deployment.preferredRepo || "openclaw/crabfleet";
   const sessions = props.state.interactiveSessions || [];
   const fleet = props.state.fleet;
-  const totals = fleetCoversInteractiveSessions(fleet, sessions) ? fleet.totals : {};
   const fleetSessionsById = new Map(
     (fleet?.sessions || []).map((session) => [session.id, session]),
   );
+  const fleetSessions = sessions.map((session) => ({
+    ...session,
+    fleet: fleetSessionsById.get(session.id),
+  }));
+  const totals = fleetCoversInteractiveSessions(fleet, sessions) ? fleet.totals : {};
   const groups = groupedFleetSessions(sessions);
   const ownerCount = groups.length;
   const sessionCount = totals.sessions ?? sessions.length;
   const readyCount = totals.ready ?? countStatuses(sessions, ["ready", "attached", "detached"]);
   const provisioningCount =
-    totals.provisioning ?? countStatuses(sessions, ["provisioning", "pending_adapter"]);
-  const failedCount = totals.failed ?? countStatuses(sessions, ["failed"]);
+    totals.provisioning ??
+    fleetSessions.filter(
+      (session) => session.status === "provisioning" && !isFleetSessionAttention(session),
+    ).length;
+  const attentionCount =
+    totals.attention ?? fleetSessions.filter((session) => isFleetSessionAttention(session)).length;
   const stoppedCount =
     totals.stopped ?? countStatuses(sessions, ["stopped", "expired", "unavailable"]);
 
@@ -60,7 +69,7 @@ export function FleetPage(props) {
         <div class="fleet-signal-grid" aria-label="Fleet status summary">
           <Signal label="Live" value={readyCount} tone="live" />
           <Signal label="Starting" value={provisioningCount} tone="provisioning" />
-          <Signal label="Attention" value={failedCount} tone="failed" />
+          <Signal label="Attention" value={attentionCount} tone="failed" />
           <Signal label="People" value={ownerCount} />
           <Signal label="Total" value={sessionCount} />
         </div>
@@ -73,7 +82,7 @@ export function FleetPage(props) {
           sessionCount={sessionCount}
           ready={readyCount}
           provisioning={provisioningCount}
-          failed={failedCount}
+          attention={attentionCount}
           stopped={stoppedCount}
           board={{
             active: props.active,
@@ -160,7 +169,7 @@ function ReadinessPanel({
   sessionCount,
   ready,
   provisioning,
-  failed,
+  attention,
   stopped,
   board,
   cli,
@@ -170,7 +179,7 @@ function ReadinessPanel({
   const statuses = [
     { label: "Ready", value: ready, tone: "live" },
     { label: "Provisioning", value: provisioning, tone: "provisioning" },
-    { label: "Failed", value: failed, tone: "failed" },
+    { label: "Attention", value: attention, tone: "failed" },
     { label: "Stopped", value: stopped, tone: "stopped" },
   ];
   return (
@@ -311,7 +320,12 @@ function FleetBox({ session, openSessionGrid, deleteInteractiveSession, canManag
         {archiveCount ? <span>{archiveCount} logs</span> : null}
         {fleetPolicy?.present ? <span>{fleetPolicy.allowedHostCount} egress</span> : null}
       </div>
-      <p class="fleet-box-event">{session.summary || session.lastEvent || "Waiting for session"}</p>
+      <p class="fleet-box-event">
+        {session.fleet?.attentionReason ||
+          session.summary ||
+          session.lastEvent ||
+          "Waiting for session"}
+      </p>
       {attachable ? (
         <div class="fleet-box-command">
           <code>

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -3,6 +3,7 @@ import {
   githubActionsRuntime,
   githubActionsRuntimeLabel,
 } from "../github-actions-runtime.ts";
+import { fleetSessionAttentionReason } from "../fleet-attention.ts";
 
 export const lanes = ["Todo", "Running", "Human Review", "Done"];
 export const preferredRepo = "openclaw/crabfleet";
@@ -195,6 +196,9 @@ export function interactiveSessionStatus(session) {
   if (session.status === "stopped" || session.status === "expired") {
     return { label: "Stopped", tone: "stopped" };
   }
+  if (isFleetSessionAttention(session) && provisioningInteractiveStatuses.has(session.status)) {
+    return { label: "Attention", tone: "failed" };
+  }
   if (provisioningInteractiveStatuses.has(session.status)) {
     return { label: "Provisioning", tone: "provisioning" };
   }
@@ -206,6 +210,11 @@ export function interactiveSessionStatus(session) {
     return { label: "Live", tone: "live" };
   }
   return { label: humanStatus(session.status), tone: "" };
+}
+
+export function isFleetSessionAttention(session, now = Date.now()) {
+  if (typeof session?.fleet?.attention === "boolean") return session.fleet.attention;
+  return fleetSessionAttentionReason(session || {}, now) !== null;
 }
 
 export function sessionLogsUrl(id) {

--- a/src/fleet-attention.ts
+++ b/src/fleet-attention.ts
@@ -1,0 +1,49 @@
+export type FleetAttentionSession = {
+  status?: string;
+  expiresAt?: number | null;
+  reconcileError?: string | null;
+  reconciliationNeedsAttention?: boolean;
+  lastEvent?: string | null;
+  createdAt?: number | null;
+  updatedAt?: number | null;
+};
+
+const fleetProvisioningStaleMs = 15 * 60_000;
+const expectedProvisioningEvidence = new Set(["runtime adapter create pending"]);
+
+export function hasActionableReconciliationError(value: string | null | undefined): boolean {
+  const evidence = value?.trim();
+  return Boolean(evidence && !expectedProvisioningEvidence.has(evidence));
+}
+
+export function fleetSessionAttentionReason(
+  session: FleetAttentionSession,
+  generatedAt: number,
+): string | null {
+  const reconcileError = session.reconcileError?.trim() || null;
+  const lastEvent = session.lastEvent?.trim() || null;
+  if (session.status === "failed") {
+    return reconcileError ?? lastEvent ?? "Interactive workspace failed";
+  }
+  if (session.status === "stopping") {
+    return reconcileError ?? "Workspace release in progress";
+  }
+  if (session.status === "pending_adapter") {
+    return reconcileError ?? lastEvent ?? "Interactive runtime unavailable";
+  }
+  if (session.status !== "provisioning") return null;
+  if (
+    session.expiresAt !== null &&
+    session.expiresAt !== undefined &&
+    session.expiresAt <= generatedAt
+  ) {
+    return "Provisioning lease expired";
+  }
+  if (hasActionableReconciliationError(reconcileError)) return reconcileError;
+  if (session.reconciliationNeedsAttention) return "Provisioning needs operator attention";
+  const lastProgressAt = Math.max(session.createdAt ?? 0, session.updatedAt ?? 0);
+  if (lastProgressAt > 0 && generatedAt - lastProgressAt >= fleetProvisioningStaleMs) {
+    return "Provisioning has not made progress for 15 minutes";
+  }
+  return null;
+}

--- a/src/fleet-state.ts
+++ b/src/fleet-state.ts
@@ -1,4 +1,5 @@
 import { normalizedSecureWebSocketUrl } from "./url-security.ts";
+import { fleetSessionAttentionReason } from "./fleet-attention.ts";
 
 export type FleetStatus =
   | "provisioning"
@@ -42,6 +43,9 @@ export type FleetSessionInput = {
   capabilities?: { vnc?: boolean; desktop?: boolean; terminal?: boolean };
   canControl?: boolean;
   ptyAvailable?: boolean;
+  expiresAt?: number | null;
+  reconcileError?: string | null;
+  reconciliationNeedsAttention?: boolean;
   lastEvent: string;
   createdAt: number;
   updatedAt: number;
@@ -108,6 +112,8 @@ export type FleetSessionSummary = {
   completionReason: string | null;
   status: FleetStatus;
   active: boolean;
+  attention: boolean;
+  attentionReason: string | null;
   attachable: boolean;
   vnc: boolean;
   archived: boolean;
@@ -146,6 +152,7 @@ export type FleetState = {
     attachable: number;
     byRuntime: Record<FleetRuntime, number>;
     byStatus: Record<FleetStatus, number>;
+    attention: number;
     failed: number;
     provisioning: number;
     ready: number;
@@ -233,8 +240,11 @@ export function buildFleetState(
       attachable: sessionSummaries.filter((session) => session.attachable).length,
       byRuntime,
       byStatus,
+      attention: sessionSummaries.filter((session) => session.attention).length,
       failed: byStatus.failed,
-      provisioning: byStatus.provisioning + byStatus.pending_adapter,
+      provisioning: sessionSummaries.filter(
+        (session) => session.status === "provisioning" && !session.attention,
+      ).length,
       ready: byStatus.ready + byStatus.attached + byStatus.detached,
       sessions: sessionSummaries.length,
       stopped: byStatus.stopped + byStatus.expired,
@@ -247,10 +257,11 @@ export function buildFleetState(
 export function fleetSessionSummary(
   session: FleetSessionInput,
   policy: FleetSandboxPolicySummary | null,
-  options: Pick<FleetStateOptions, "sandboxAvailable"> = {},
+  options: Pick<FleetStateOptions, "generatedAt" | "sandboxAvailable">,
 ): FleetSessionSummary {
   const sandboxId = sandboxIdFromLeaseId(session.leaseId);
   const archived = Boolean(session.logArchive?.eventCount);
+  const attentionReason = fleetSessionAttentionReason(session, options.generatedAt);
   const terminalCapable =
     session.capabilities?.terminal === true ||
     (session.adapter !== "runtime-v1" && session.capabilities?.terminal !== false);
@@ -277,6 +288,8 @@ export function fleetSessionSummary(
     completionReason: session.completionReason ?? null,
     status: session.status,
     active: !inactiveStatuses.has(session.status),
+    attention: attentionReason !== null,
+    attentionReason,
     attachable:
       terminalCapable &&
       (session.ptyAvailable === true ||

--- a/src/worker/session-model.ts
+++ b/src/worker/session-model.ts
@@ -4,6 +4,7 @@ import {
   parseGitHubActionsWorkState,
   type GitHubActionsWorkState,
 } from "../github-actions-runtime.ts";
+import { hasActionableReconciliationError } from "../fleet-attention.ts";
 import type { ResolvedRuntimeProfileCodexSsh } from "../runtime-profiles.ts";
 import type { InteractiveSessionLogArchiveTable, InteractiveSessionRow } from "./database.ts";
 import type { InteractiveRuntime, InteractiveSessionStatus } from "./models.ts";
@@ -63,6 +64,7 @@ export type InteractiveSession = {
   expiresAt: number | null;
   lastReconciledAt: number | null;
   reconcileError: string | null;
+  reconciliationNeedsAttention?: boolean;
   command: string;
   prompt: string;
   purpose: string;
@@ -156,6 +158,7 @@ export function interactiveSession(
     expiresAt: row.expires_at,
     lastReconciledAt: row.last_reconciled_at,
     reconcileError: row.reconcile_error,
+    reconciliationNeedsAttention: hasActionableReconciliationError(row.reconcile_error),
     command: row.command,
     prompt: row.prompt,
     purpose: row.purpose,

--- a/tests/app-utils.test.ts
+++ b/tests/app-utils.test.ts
@@ -8,6 +8,7 @@ import {
   isFleetSessionAttachable,
   isTerminalReadyInteractiveSession,
   interactiveSessionStatus,
+  isFleetSessionAttention,
   interactiveCommand,
   linkedInteractiveSessionPlaceholder,
   optimisticInteractiveSession,
@@ -176,6 +177,7 @@ test("interactive lifecycle helpers keep UI and terminal state aligned", () => {
     canControl: false,
     sharedReadOnly: true,
   };
+  const starting = { kind: "interactive", status: "provisioning" };
   const provisioning = { kind: "interactive", status: "pending_adapter" };
   const stopping = { kind: "interactive", status: "stopping" };
   const deleting = { ...stopping, adapter: "runtime-v1" };
@@ -209,10 +211,42 @@ test("interactive lifecycle helpers keep UI and terminal state aligned", () => {
     false,
   );
   assert.deepEqual(interactiveSessionStatus(live), { label: "Live", tone: "live" });
-  assert.deepEqual(interactiveSessionStatus(provisioning), {
+  assert.deepEqual(interactiveSessionStatus(starting), {
     label: "Provisioning",
     tone: "provisioning",
   });
+  assert.deepEqual(interactiveSessionStatus(provisioning), {
+    label: "Attention",
+    tone: "failed",
+  });
+  assert.deepEqual(interactiveSessionStatus({ ...provisioning, fleet: { attention: true } }), {
+    label: "Attention",
+    tone: "failed",
+  });
+  assert.equal(
+    isFleetSessionAttention({ ...provisioning, reconciliationNeedsAttention: true }),
+    true,
+  );
+  assert.equal(
+    isFleetSessionAttention(
+      {
+        ...starting,
+        reconcileError: "runtime adapter create pending",
+        createdAt: 90_000,
+        updatedAt: 95_000,
+      },
+      100_000,
+    ),
+    false,
+  );
+  assert.equal(
+    isFleetSessionAttention({ ...starting, reconcileError: "provider unavailable" }, 100_000),
+    true,
+  );
+  assert.equal(
+    isFleetSessionAttention({ ...starting, createdAt: 1, updatedAt: 2 }, 20 * 60_000),
+    true,
+  );
   assert.equal(isActiveRun(stopping), false);
   assert.deepEqual(interactiveSessionStatus(stopping), {
     label: "Stopping",

--- a/tests/fleet-state.test.ts
+++ b/tests/fleet-state.test.ts
@@ -91,6 +91,7 @@ test("fleet state aggregates sessions and redacted sandbox policies", () => {
   assert.equal(fleet.totals.sessions, 2);
   assert.equal(fleet.totals.active, 1);
   assert.equal(fleet.totals.failed, 1);
+  assert.equal(fleet.totals.attention, 1);
   assert.equal(fleet.totals.ready, 1);
   assert.equal(fleet.totals.archived, 1);
   assert.equal(fleet.totals.attachable, 1);
@@ -121,6 +122,78 @@ test("fleet state aggregates sessions and redacted sandbox policies", () => {
       updatedAt: 50,
     },
   ]);
+});
+
+test("fleet state separates healthy provisioning from sessions needing attention", () => {
+  const generatedAt = 20 * 60_000;
+  const sessions = [
+    {
+      ...baseSession,
+      id: "healthy",
+      status: "provisioning" as const,
+      createdAt: generatedAt - 10_000,
+      updatedAt: generatedAt - 5_000,
+      reconcileError: "runtime adapter create pending",
+    },
+    {
+      ...baseSession,
+      id: "error",
+      status: "provisioning" as const,
+      reconcileError: "runtime adapter control plane differs from workspace registration",
+    },
+    {
+      ...baseSession,
+      id: "stale",
+      status: "provisioning" as const,
+      createdAt: 0,
+      updatedAt: 1,
+    },
+    {
+      ...baseSession,
+      id: "expired",
+      status: "provisioning" as const,
+      expiresAt: generatedAt,
+    },
+    {
+      ...baseSession,
+      id: "pending",
+      status: "pending_adapter" as const,
+    },
+    {
+      ...baseSession,
+      id: "stopping",
+      status: "stopping" as const,
+    },
+    {
+      ...baseSession,
+      id: "redacted-error",
+      status: "provisioning" as const,
+      reconcileError: null,
+      reconciliationNeedsAttention: true,
+    },
+  ];
+  const fleet = buildFleetState(sessions, [], {
+    canonicalUrl: "https://fleet.example",
+    defaultEgressHosts: [],
+    generatedAt,
+    productUrl: "https://product.example",
+  });
+  const byId = new Map(fleet.sessions.map((session) => [session.id, session]));
+
+  assert.equal(fleet.totals.provisioning, 1);
+  assert.equal(fleet.totals.attention, 6);
+  assert.equal(fleet.totals.byStatus.provisioning, 5);
+  assert.equal(fleet.totals.byStatus.pending_adapter, 1);
+  assert.equal(byId.get("healthy")?.attention, false);
+  assert.equal(byId.get("error")?.attentionReason, sessions[1]?.reconcileError);
+  assert.match(byId.get("stale")?.attentionReason ?? "", /15 minutes/);
+  assert.equal(byId.get("expired")?.attentionReason, "Provisioning lease expired");
+  assert.equal(byId.get("pending")?.attention, true);
+  assert.equal(byId.get("stopping")?.attention, true);
+  assert.equal(
+    byId.get("redacted-error")?.attentionReason,
+    "Provisioning needs operator attention",
+  );
 });
 
 test("GitHub Actions sessions are attachable through the Worker relay", () => {

--- a/tests/session-model.test.ts
+++ b/tests/session-model.test.ts
@@ -45,6 +45,7 @@ test("interactive session mapping centralizes row names, defaults, and hidden id
   const session = interactiveSession(
     sessionRow({
       capabilities_json: '{"terminal":false}',
+      reconcile_error: "provider unavailable",
       work_state: "running",
     }),
     ["ready"],
@@ -55,6 +56,7 @@ test("interactive session mapping centralizes row names, defaults, and hidden id
   assert.equal(session.attachUrl, null);
   assert.equal(session.multiplayerMode, true);
   assert.equal(session.workState, "running");
+  assert.equal(session.reconciliationNeedsAttention, true);
   assert.deepEqual(session.logs, ["ready"]);
   assert.equal(session.logArchive, archive);
   assert.equal(session[interactiveSessionAdapterControlPlane], "https://adapter.example");

--- a/tests/session-presentation.test.ts
+++ b/tests/session-presentation.test.ts
@@ -99,7 +99,7 @@ test("session presentation hides provider authority from viewers without control
       provider_resource_id: "box-1",
       last_reconciled_at: 90,
       reconcile_error: "private provider state",
-      status: "ready",
+      status: "provisioning",
     }),
     [],
   );
@@ -112,6 +112,7 @@ test("session presentation hides provider authority from viewers without control
   assert.equal(presented.providerResourceId, null);
   assert.equal(presented.lastReconciledAt, null);
   assert.equal(presented.reconcileError, null);
+  assert.equal(presented.reconciliationNeedsAttention, true);
   assert.equal(presented.attachUrl, null);
   assert.equal(presented.vncUrl, null);
   assert.equal(presented.codexSsh, null);


### PR DESCRIPTION
## Summary

- classify stalled, errored, expired, or adapter-blocked provisioning as operational attention without mutating provider lifecycle state
- preserve a non-sensitive attention signal when provider diagnostics are authorization-redacted
- keep partial Fleet-state fallbacks consistent and document the updated API contract

## Testing

- `pnpm test` (691 passing)
- `pnpm check`
- structured autoreview: clean
