### PR TITLE
[codex] add macOS auto-connect launch mode

### DIFF
--- a/macos/CrabfleetMac/README.md
+++ b/macos/CrabfleetMac/README.md
@@ -43,6 +43,15 @@ and then starts the same tailnet-only RFB listener used by the in-app control:
 /Applications/Crabfleet.app/Contents/MacOS/CrabfleetMac --share-this-mac
 ```
 
+To open a no-password VNC endpoint immediately, use `--connect` or set
+`CRABFLEET_AUTO_CONNECT`. The address is saved as a favorite and focused when
+the app opens. Embedded passwords are rejected:
+
+```sh
+/Applications/Crabfleet.app/Contents/MacOS/CrabfleetMac \
+  --connect vnc://100.64.0.8:5901
+```
+
 ## Build
 
 ```sh

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/CrabfleetMacApp.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/CrabfleetMacApp.swift
@@ -14,6 +14,26 @@ enum PrivateMacShareLaunchMode {
   }
 }
 
+enum VNCConnectionLaunchMode {
+  static let argument = "--connect"
+  static let environmentKey = "CRABFLEET_AUTO_CONNECT"
+
+  static func address(
+    arguments: [String] = ProcessInfo.processInfo.arguments,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) throws -> VNCAddress? {
+    let rawValue: String?
+    if let argumentIndex = arguments.dropFirst().firstIndex(of: argument) {
+      let valueIndex = arguments.index(after: argumentIndex)
+      rawValue = valueIndex < arguments.endIndex ? arguments[valueIndex] : ""
+    } else {
+      rawValue = environment[environmentKey]
+    }
+    guard let rawValue else { return nil }
+    return try VNCAddress.parse(rawValue)
+  }
+}
+
 @MainActor
 final class CrabfleetApplicationDelegate: NSObject, NSApplicationDelegate {
   private var shareController: PrivateMacShareController?
@@ -79,13 +99,15 @@ struct CrabfleetMacApp: App {
   @StateObject private var fleetStore = FleetStore()
   @StateObject private var connectionLibrary = ConnectionLibrary()
   @StateObject private var sessionPool = VNCSessionPool()
+  private let launchConnection = try? VNCConnectionLaunchMode.address()
 
   var body: some Scene {
     Window("Crabfleet", id: "main") {
       CrabfleetAppRoot(
         fleetStore: fleetStore,
         connectionLibrary: connectionLibrary,
-        sessionPool: sessionPool
+        sessionPool: sessionPool,
+        launchConnection: launchConnection
       )
     }
     .defaultSize(width: 1_360, height: 860)
@@ -107,6 +129,7 @@ private struct CrabfleetAppRoot: View {
   @ObservedObject var fleetStore: FleetStore
   @ObservedObject var connectionLibrary: ConnectionLibrary
   @ObservedObject var sessionPool: VNCSessionPool
+  let launchConnection: VNCAddress?
 
   @Environment(\.scenePhase) private var scenePhase
 
@@ -114,7 +137,8 @@ private struct CrabfleetAppRoot: View {
     FleetRootView(
       store: fleetStore,
       connections: connectionLibrary,
-      sessions: sessionPool
+      sessions: sessionPool,
+      launchConnection: launchConnection
     )
     .frame(minWidth: 1_080, minHeight: 680)
     .preferredColorScheme(.dark)

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/FleetRootView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/FleetRootView.swift
@@ -5,6 +5,7 @@ struct FleetRootView: View {
   @ObservedObject var store: FleetStore
   @ObservedObject var connections: ConnectionLibrary
   @ObservedObject var sessions: VNCSessionPool
+  let launchConnection: VNCAddress?
   @StateObject private var privateShare = PrivateMacShareController()
 
   @Namespace private var desktopTransition
@@ -16,6 +17,7 @@ struct FleetRootView: View {
   @State private var connectionTarget: DesktopTarget?
   @State private var showingQuickConnect = false
   @State private var showingPrivateShare = false
+  @State private var didHandleLaunchConnection = false
 
   private var allTargets: [DesktopTarget] {
     let saved = connections.profiles.map(DesktopTarget.init(profile:))
@@ -118,6 +120,7 @@ struct FleetRootView: View {
     .sheet(isPresented: $showingPrivateShare) {
       PrivateMacShareSheet(controller: privateShare)
     }
+    .onAppear(perform: connectLaunchConnectionIfNeeded)
     .onExitCommand(perform: closeFocus)
     .onChange(of: allTargets.map(\.id)) { _, targetIDs in
       sessions.reconcile(validTargetIDs: Set(targetIDs))
@@ -172,6 +175,29 @@ struct FleetRootView: View {
     } else {
       connectionTarget = target
     }
+  }
+
+  private func connectLaunchConnectionIfNeeded() {
+    guard !didHandleLaunchConnection, let launchConnection else { return }
+    didHandleLaunchConnection = true
+    let profile = connections.save(
+      name: launchConnection.displayValue,
+      address: launchConnection,
+      favorite: true
+    )
+    let target = DesktopTarget(profile: profile)
+    focus(target.id)
+    sessions.connect(
+      targetID: target.id,
+      request: .init(
+        host: launchConnection.host,
+        port: launchConnection.port,
+        username: launchConnection.username,
+        password: "",
+        clipboardEnabled: false
+      )
+    )
+    connections.markConnected(profileID: profile.id)
   }
 
   private func closeFocus() {

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
@@ -20,6 +20,42 @@ struct PrivateMacShareTests {
   }
 
   @Test
+  func parsesExplicitVNCConnectionLaunchMode() throws {
+    let explicitAddress = try VNCConnectionLaunchMode.address(
+      arguments: ["CrabfleetMac", "--connect", "vnc://100.64.0.8:5901"],
+      environment: ["CRABFLEET_AUTO_CONNECT": "vnc://ignored.example:5900"]
+    )
+    let explicit = try #require(explicitAddress)
+    #expect(explicit.host == "100.64.0.8")
+    #expect(explicit.port == 5_901)
+
+    let environmentAddress = try VNCConnectionLaunchMode.address(
+      arguments: ["CrabfleetMac"],
+      environment: ["CRABFLEET_AUTO_CONNECT": "viewer.example:5999"]
+    )
+    let environment = try #require(environmentAddress)
+    #expect(environment.host == "viewer.example")
+    #expect(environment.port == 5_999)
+    #expect(
+      try VNCConnectionLaunchMode.address(
+        arguments: ["CrabfleetMac"], environment: [:]) == nil)
+  }
+
+  @Test
+  func rejectsMissingOrCredentialedVNCConnectionLaunchAddress() {
+    #expect(throws: VNCAddressError.missingHost) {
+      try VNCConnectionLaunchMode.address(
+        arguments: ["CrabfleetMac", "--connect"], environment: [:])
+    }
+    #expect(throws: VNCAddressError.embeddedPassword) {
+      try VNCConnectionLaunchMode.address(
+        arguments: ["CrabfleetMac", "--connect", "vnc://user:secret@example.test"],
+        environment: [:]
+      )
+    }
+  }
+
+  @Test
   func acceptsOnlineUserOnActiveTailnet() throws {
     let identity = try TailnetIdentityPolicy.identity(from: statusDocument())
 


### PR DESCRIPTION
## What changed

- add generic `--connect vnc://host:port` and `CRABFLEET_AUTO_CONNECT` launch inputs
- save the launch endpoint as a favorite, focus it, and initiate the no-password VNC session when the app appears
- reject embedded credentials and document the unattended client mode

## Why

Remote deployment could install and launch Crabfleet, but still required someone at the receiving Mac to operate the Quick Connect sheet. The explicit launch mode makes managed, Taildrop, and SSH-based client startup deterministic without baking any deployment-specific endpoint into the open-source app.

## Validation

- `pnpm macos:test` (20 RoyalVNCKit tests and 35 Crabfleet tests)
- `xcrun swift-format lint --strict` on the changed Swift files
- release app bundle built and passed deep/strict code-sign verification
- live launch attempted the supplied tailnet endpoint automatically, without Quick Connect UI interaction
