### PR TITLE
fix: preserve native approval origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve the real same-origin `Origin` header on browser-approved native Mac authorization forms so Chromium can complete the device link without weakening CSRF validation.
 - Connect desktop-capable Crabbox Fleet leases directly in the macOS app through the installed CLI's foreground, loopback-only native VNC handoff, with helper teardown tied to viewer lifecycle.
 - Classify stalled or errored workspace provisioning as attention, exclude it from the Starting count, and surface the redacted reconciliation reason in Fleet.
 - Add private per-user desktop-host registration so native macOS shares appear in Fleet with direct same-tailnet VNC endpoints.

--- a/src/worker/native-link.ts
+++ b/src/worker/native-link.ts
@@ -22,6 +22,8 @@ const nativeLinkHtmlHeaders = {
   "cache-control": "no-store",
   "content-security-policy":
     "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+  // A no-referrer policy serializes same-origin form POSTs as Origin: null in Chromium.
+  "referrer-policy": "same-origin",
   "x-frame-options": "DENY",
 };
 

--- a/tests/native-link.test.ts
+++ b/tests/native-link.test.ts
@@ -121,6 +121,7 @@ test("trusted-proxy native approval uses asserted identity and exact Origin with
   assert.equal(get.status, 200);
   assert.equal(get.headers.has("set-cookie"), false);
   assert.match(get.headers.get("content-security-policy") ?? "", /frame-ancestors 'none'/);
+  assert.equal(get.headers.get("referrer-policy"), "same-origin");
   assert.equal(get.headers.get("x-frame-options"), "DENY");
   const csrf = (await get.text()).match(/name="csrf" value="([^"]+)"/)?.[1];
   assert.ok(csrf);


### PR DESCRIPTION
## Summary

- override the global no-referrer policy on the native approval page with `same-origin`
- retain the exact-Origin CSRF gate and link-bound double-submit token
- add a response-header regression test and changelog entry

## Live reproduction

Chromium submitted the production same-origin approval form with `Origin: null` under the global `Referrer-Policy: no-referrer`, and the Worker correctly rejected it. The narrower page policy makes Chromium send the deployment origin while preserving the existing exact-origin validation.

## Tests

- `pnpm check`
- `pnpm test` (727 passed)
- `node --test --experimental-strip-types tests/native-link.test.ts` (5 passed)
