### PR TITLE
fix: request native VNC by Fleet session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Preserve the real same-origin `Origin` header on browser-approved native Mac authorization forms so Chromium can complete the device link without weakening CSRF validation.
-- Connect desktop-capable Crabbox Fleet leases directly in the macOS app through the installed CLI's foreground, loopback-only native VNC handoff, with helper teardown tied to viewer lifecycle.
+- Connect desktop-capable Crabbox Fleet sessions directly in the macOS app through session-scoped, one-time Crabbox grants and a coordinator-backed VNC relay, without publishing provider lease IDs in Fleet or exposing coordinator SSH keys; grants reach the CLI only on stdin and helper teardown remains tied to viewer lifecycle.
 - Classify stalled or errored workspace provisioning as attention, exclude it from the Starting count, and surface the redacted reconciliation reason in Fleet.
 - Add private per-user desktop-host registration so native macOS shares appear in Fleet with direct same-tailnet VNC endpoints.
 - Let the macOS app use saved and ad-hoc VNC connections without requiring a deployment session.

--- a/docs/api.md
+++ b/docs/api.md
@@ -158,6 +158,16 @@ Requires the native bearer and returns the same tenant-filtered, redacted
 `{ "fleet": ... }` envelope as `GET /api/fleet`. It does not return an attach
 credential, native RFB endpoint, or mutation authority.
 
+### POST /api/native/v1/sessions/:id/native-vnc
+
+Requires the native bearer, a current controllable Crabbox runtime-adapter
+session, and `capabilities.nativeVnc=true`. Crabfleet asks the session's
+registered adapter for a one-minute, single-use grant and returns it with
+`Cache-Control: no-store`. Fleet exposes the Crabfleet session ID for this
+request instead of the provider lease ID. The macOS app sends the grant ticket
+to the installed Crabbox CLI on stdin; the ticket is never placed in argv or a
+URL.
+
 ### DELETE /api/native/v1/auth/token
 
 Requires the native bearer, revokes that token without depending on an external
@@ -187,6 +197,7 @@ method/path set:
 - `DELETE /api/native/v1/auth/token`
 - `GET /api/native/v1/session`
 - `GET /api/native/v1/fleet`
+- `POST /api/native/v1/sessions/IS-<number>/native-vnc`
 
 They must pass those requests directly to Crabfleet and must not add a competing
 asserted identity to bearer requests. Every `/native/link/*` browser route
@@ -201,6 +212,7 @@ scope, plus these two exact authenticated reads:
 
 - `GET /mcp/crabfleet/native/v1/session`
 - `GET /mcp/crabfleet/native/v1/fleet`
+- `POST /mcp/crabfleet/native/v1/sessions/IS-<number>/native-vnc`
 
 Both challenges must resolve to the same authorization server. RFC 9728
 metadata identifies each exact challenged route, and the client requests both
@@ -495,6 +507,7 @@ Crabfleet authenticates every adapter request with `Authorization: Bearer CRABBO
 - `GET /v1/workspaces/:id`: inspect current status, capabilities, terminal URL, expiry, and provider resource identity. Status-only responses preserve previously stored capabilities and expiry; explicit `null` clears those fields. Active external sessions are reconciled in bounded batches; state responses wait only for a short foreground budget while remaining work continues in the Worker background.
 - `DELETE /v1/workspaces/:id`: stop/release. Crabfleet enters `stopping` before calling the adapter and marks the session stopped only after `204`, `404`, or a valid exact-ID terminal response confirms release; malformed successful bodies remain `stopping`. Plain-text and malformed-JSON responses are read once and sanitized before their evidence is retained. An explicit stop whose ownership claim loses returns success only when the exact workspace is already stopping or terminal; otherwise it returns a lifecycle conflict.
 - `POST /v1/workspaces/:id/connections/desktop`: mint a current transient desktop URL. The request has no body. `expiresAt` is optional; when present it must be in the future and no more than 15 minutes away. Accepted HTTPS URLs are treated as opaque signed connection material and redirected byte-for-byte without URL normalization. After minting, Crabfleet re-reads the exact current session status, control grant, capabilities, and registered adapter identity before redirecting; a concurrent stop, revocation, capability withdrawal, or lifecycle replacement discards the URL and denies access.
+- `POST /v1/workspaces/:id/connections/native-vnc`: mint a short-lived, single-use native VNC grant. The response must use the `crabbox/native-vnc-grant/v1` schema, an HTTPS broker URL (literal loopback HTTP is allowed for development), the exact opaque lease ID, a 32-byte-hex `native_vnc_` ticket, and an expiry no more than two minutes away. Crabfleet never exposes the provider lease ID in Fleet state and requests this grant only after revalidating current session control and the persisted adapter identity.
 
 `CRABBOX_RUNTIME_ADAPTER_NAMESPACE` is required and must remain stable for the deployment. It prevents workspace and idempotency collisions when an adapter serves more than one Crabfleet tenant. The adapter workspace `id` is an immutable lifecycle route key and remains separate from an opaque `providerResourceId`; the provider identity is never interpreted as a Sandbox lease ID. Create, inspect, and stop responses must echo the byte-exact requested DNS-safe `id`; whitespace normalization is not accepted. Responses use `status`, `id`, optional `providerResourceId`, `attachUrl`, `capabilities`, `expiresAt`, and `message`. The optional `capabilities.nativeVnc` flag advertises a native-client handoff without asserting that the browser desktop endpoint exists; `vnc` and `desktop` remain the browser endpoint capability. Only a literal `null` clears a previously stored expiry; a malformed non-null timestamp invalidates the response. A terminal URL implies terminal capability only when the response omits a terminal capability; an explicit `terminal: false` wins. Supported status values include `provisioning`, `ready`, `stopping`, `stopped`, `expired`, and `failed`. Every session-bound provider DELETE is gated on the persisted create ambiguity marker being clear.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -158,13 +158,14 @@ Requires the native bearer and returns the same tenant-filtered, redacted
 `{ "fleet": ... }` envelope as `GET /api/fleet`. It does not return an attach
 credential, native RFB endpoint, or mutation authority.
 
-### POST /api/native/v1/sessions/:id/native-vnc
+### POST /api/native/v1/native-vnc
 
 Requires the native bearer, a current controllable Crabbox runtime-adapter
 session, and `capabilities.nativeVnc=true`. Crabfleet asks the session's
 registered adapter for a one-minute, single-use grant and returns it with
 `Cache-Control: no-store`. Fleet exposes the Crabfleet session ID for this
-request instead of the provider lease ID. The macOS app sends the grant ticket
+request instead of the provider lease ID; the JSON body is `{ "sessionId": "IS-<number>" }`.
+The macOS app sends the grant ticket
 to the installed Crabbox CLI on stdin; the ticket is never placed in argv or a
 URL.
 
@@ -197,7 +198,7 @@ method/path set:
 - `DELETE /api/native/v1/auth/token`
 - `GET /api/native/v1/session`
 - `GET /api/native/v1/fleet`
-- `POST /api/native/v1/sessions/IS-<number>/native-vnc`
+- `POST /api/native/v1/native-vnc`
 
 They must pass those requests directly to Crabfleet and must not add a competing
 asserted identity to bearer requests. Every `/native/link/*` browser route
@@ -208,14 +209,14 @@ If a gateway cannot bypass browser SSO for exact routes but supports OAuth 2.0
 dynamic client registration and authorization-code PKCE, it may instead return
 a Bearer challenge whose same-origin `resource_metadata` describes the protected
 resource and authorization server and whose `scope` names the required read-only
-scope, plus these two exact authenticated reads:
+scope, plus these exact authenticated operations:
 
 - `GET /mcp/crabfleet/native/v1/session`
 - `GET /mcp/crabfleet/native/v1/fleet`
-- `POST /mcp/crabfleet/native/v1/sessions/IS-<number>/native-vnc`
+- `POST /mcp/crabfleet/native/v1/native-vnc`
 
-Both challenges must resolve to the same authorization server. RFC 9728
-metadata identifies each exact challenged route, and the client requests both
+All three challenges must resolve to the same authorization server. RFC 9728
+metadata identifies each exact challenged route, and the client requests all
 resource identifiers. A compatibility profile may return authorization-server
 metadata directly only when it omits a `resource` field and its explicit
 `api://` scope can be matched to the issued JWT's `aud` claim before the bearer
@@ -226,7 +227,8 @@ explicit user trust for that provider origin.
 
 The gateway must consume and strip its OAuth bearer, assert the authenticated
 browser identity through the deployment's trusted-proxy boundary, and map the
-two reads to `/api/session` and `/api/fleet`. It must reject queries, mutations,
+two reads plus the native VNC grant POST to their exact `/api/native/v1/*`
+counterparts. It must reject queries, other mutations,
 unknown suffixes, and WebSocket upgrades under that prefix. This alternative
 does not expose Crabfleet's device-code or token endpoints through the gateway.
 

--- a/docs/macos-native-client.md
+++ b/docs/macos-native-client.md
@@ -164,9 +164,10 @@ public client, use authorization-code PKCE, and receive the callback on the
 exact loopback redirect URI returned by registration. The resulting gateway
 bearer and optional refresh grant are
 stored under the same deployment-scoped Keychain policy and are sent only to
-`/mcp/crabfleet/native/v1/session` and `/mcp/crabfleet/native/v1/fleet`.
+`/mcp/crabfleet/native/v1/session`, `/mcp/crabfleet/native/v1/fleet`, and
+`/mcp/crabfleet/native/v1/native-vnc`.
 The client requires each RFC 9728 route challenge to identify its exact
-protected resource and requests both identifiers. For gateways that return
+protected resource and requests all identifiers. For gateways that return
 authorization-server metadata directly, a `resource` field is rejected and an
 explicit `api://` scope must match the issued JWT's `aud` claim before use.
 The app asks for explicit trust before contacting any OAuth provider origin
@@ -176,8 +177,8 @@ An unauthorized read rotates an available refresh grant in Keychain before one
 retry; a rejected refresh grant expires the saved connection.
 Those gateway routes must authenticate the user, strip the gateway bearer
 before proxying, and map only those exact read methods to Crabfleet's
-authenticated `/api/session` and `/api/fleet` routes. Unknown paths, queries,
-mutations, and WebSocket upgrades remain closed.
+authenticated native session, Fleet, and VNC-grant routes. Unknown paths,
+queries, other mutations, and WebSocket upgrades remain closed.
 
 Saved and ad-hoc VNC profiles are also available through an explicit local-only
 mode. That mode does not contact a deployment, synthesize Fleet data, or create

--- a/macos/CrabfleetMac/README.md
+++ b/macos/CrabfleetMac/README.md
@@ -102,10 +102,11 @@ browser-authenticated approval page. A proxy-only deployment must also configure
 Alternatively, a gateway that supports OAuth 2.0 dynamic client registration
 and PKCE may advertise a same-origin `resource_metadata` URL in its Bearer
 challenge with an explicit read-only scope and expose exact authenticated GET
-routes at `/mcp/crabfleet/native/v1/session` and
-`/mcp/crabfleet/native/v1/fleet`. The gateway must remove its OAuth bearer
+routes at `/mcp/crabfleet/native/v1/session`,
+`/mcp/crabfleet/native/v1/fleet`, and `/mcp/crabfleet/native/v1/native-vnc`.
+The gateway must remove its OAuth bearer
 before mapping those routes to Crabfleet's trusted authenticated
-`/api/session` and `/api/fleet` reads. The app uses only the registration-
+the exact native session, Fleet, and VNC-grant routes. The app uses only the registration-
 provided literal-loopback callback, asks for explicit trust before contacting
 provider origins outside the deployment, stores the resulting bearer and
 refresh grant in Keychain, rotates refresh grants before retrying unauthorized

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/CrabboxVNCBridge.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/CrabboxVNCBridge.swift
@@ -57,13 +57,13 @@ final class CrabboxVNCBridge: @unchecked Sendable {
   }
 
   static func start(
-    leaseID: String,
+    grant: NativeVNCGrant,
     executableURL: URL? = nil,
     timeout: TimeInterval = 20
   ) async throws -> CrabboxVNCBridge {
     let worker = Task.detached(priority: .userInitiated) {
       try startSynchronously(
-        leaseID: leaseID,
+        grant: grant,
         executableURL: executableURL,
         timeout: timeout
       )
@@ -106,11 +106,12 @@ final class CrabboxVNCBridge: @unchecked Sendable {
   }
 
   private static func startSynchronously(
-    leaseID: String,
+    grant: NativeVNCGrant,
     executableURL: URL?,
     timeout: TimeInterval
   ) throws -> CrabboxVNCBridge {
-    guard validLeaseID(leaseID) else { throw CrabboxVNCBridgeError.invalidLeaseID }
+    guard validLeaseID(grant.leaseID) else { throw CrabboxVNCBridgeError.invalidLeaseID }
+    guard validGrant(grant) else { throw CrabboxVNCBridgeError.invalidHandoff }
     guard let executable = executableURL ?? resolveExecutable() else {
       throw CrabboxVNCBridgeError.executableNotFound
     }
@@ -118,15 +119,24 @@ final class CrabboxVNCBridge: @unchecked Sendable {
     let process = Process()
     let stdout = Pipe()
     let stderr = Pipe()
+    let stdin = Pipe()
     process.executableURL = executable
-    process.arguments = ["vnc", "--id", leaseID, "--native-handoff"]
-    process.standardInput = FileHandle.nullDevice
+    process.arguments = [
+      "vnc", "--id", grant.leaseID, "--native-handoff",
+      "--native-grant-url", grant.brokerURL.absoluteString,
+      "--native-grant-stdin",
+    ]
+    process.standardInput = stdin
     process.standardOutput = stdout
     process.standardError = stderr
 
     do {
       try process.run()
+      try stdin.fileHandleForWriting.write(contentsOf: Data((grant.ticket + "\n").utf8))
+      try stdin.fileHandleForWriting.close()
     } catch {
+      try? stdin.fileHandleForWriting.close()
+      terminate(process)
       throw CrabboxVNCBridgeError.launchFailed(error.localizedDescription)
     }
 
@@ -241,6 +251,25 @@ final class CrabboxVNCBridge: @unchecked Sendable {
       value.utf8.count <= 200 &&
       value.trimmingCharacters(in: .whitespacesAndNewlines) == value &&
       value.unicodeScalars.allSatisfy { !CharacterSet.controlCharacters.contains($0) }
+  }
+
+  private static func validGrant(_ grant: NativeVNCGrant) -> Bool {
+    let ticketPrefix = "native_vnc_"
+    let ticketSuffix = grant.ticket.dropFirst(ticketPrefix.count)
+    let secureBroker = grant.brokerURL.scheme == "https"
+      || (grant.brokerURL.scheme == "http"
+        && ["localhost", "127.0.0.1", "::1"].contains(grant.brokerURL.host ?? ""))
+    return secureBroker
+      && grant.brokerURL.user == nil
+      && grant.brokerURL.password == nil
+      && grant.brokerURL.query == nil
+      && grant.brokerURL.fragment == nil
+      && grant.ticket.hasPrefix(ticketPrefix)
+      && ticketSuffix.utf8.count == 32
+      && ticketSuffix.utf8.allSatisfy {
+        ($0 >= 0x30 && $0 <= 0x39) || ($0 >= 0x61 && $0 <= 0x66)
+      }
+      && grant.expiresAt > Date()
   }
 
   private static func terminate(_ process: Process) {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/DesktopModels.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/DesktopModels.swift
@@ -146,7 +146,7 @@ struct DesktopTarget: Identifiable, Hashable {
   let endpoint: VNCAddress?
   let desktopAvailable: Bool
   let profileID: String?
-  let nativeVncLeaseID: String?
+  let nativeVncSessionID: String?
 
   init(lease: CrabboxLease) {
     id = "fleet:\(lease.id)"
@@ -162,7 +162,7 @@ struct DesktopTarget: Identifiable, Hashable {
     endpoint = nil
     desktopAvailable = lease.desktopAvailable
     profileID = nil
-    nativeVncLeaseID = lease.nativeVncLeaseID
+    nativeVncSessionID = lease.nativeVncSessionID
   }
 
   init(profile: VNCConnectionProfile) {
@@ -179,7 +179,7 @@ struct DesktopTarget: Identifiable, Hashable {
     endpoint = profile.address
     desktopAvailable = true
     profileID = profile.id
-    nativeVncLeaseID = nil
+    nativeVncSessionID = nil
   }
 
   init(host: RegisteredDesktopHost) {
@@ -196,7 +196,7 @@ struct DesktopTarget: Identifiable, Hashable {
     endpoint = .init(host: host.address, port: host.port, username: "")
     desktopAvailable = true
     profileID = nil
-    nativeVncLeaseID = nil
+    nativeVncSessionID = nil
   }
 
   func matches(_ query: String) -> Bool {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/FleetModels.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/FleetModels.swift
@@ -26,7 +26,7 @@ enum LeaseStatus: String, Codable, CaseIterable {
 struct CrabboxLease: Identifiable, Hashable {
   let id: String
   let leaseID: String?
-  let nativeVncLeaseID: String?
+  let nativeVncSessionID: String?
   let owner: String
   let repository: String
   let branch: String
@@ -118,7 +118,7 @@ struct FleetAPISession: Decodable {
   let attachable: Bool
   let vnc: Bool
   let leaseId: String?
-  let nativeVncLeaseId: String?
+  let nativeVncSessionId: String?
   let lastEvent: String
   let updatedAt: Double
 
@@ -126,7 +126,7 @@ struct FleetAPISession: Decodable {
     .init(
       id: id,
       leaseID: leaseId,
-      nativeVncLeaseID: nativeVncLeaseId,
+      nativeVncSessionID: nativeVncSessionId,
       owner: owner,
       repository: repo,
       branch: branch,
@@ -136,7 +136,7 @@ struct FleetAPISession: Decodable {
       summary: summary,
       lastEvent: lastEvent,
       updatedAt: Date(timeIntervalSince1970: updatedAt / 1_000),
-      desktopAvailable: vnc || nativeVncLeaseId != nil,
+      desktopAvailable: vnc || nativeVncSessionId != nil,
       terminalAvailable: attachable
     )
   }

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/FleetRootView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/FleetRootView.swift
@@ -55,7 +55,7 @@ struct FleetRootView: View {
 
   private var targetConnectionStates: [DesktopTargetConnectionState] {
     allTargets.map {
-      DesktopTargetConnectionState(id: $0.id, nativeVncLeaseID: $0.nativeVncLeaseID)
+      DesktopTargetConnectionState(id: $0.id, nativeVncSessionID: $0.nativeVncSessionID)
     }
   }
 
@@ -138,12 +138,12 @@ struct FleetRootView: View {
     .onExitCommand(perform: closeFocus)
     .onChange(of: targetConnectionStates) { _, targetStates in
       let targetIDs = Set(targetStates.map(\.id))
-      let nativeLeaseIDs = Dictionary(
+      let nativeSessionIDs = Dictionary(
         uniqueKeysWithValues: targetStates.compactMap { state in
-          state.nativeVncLeaseID.map { (state.id, $0) }
+          state.nativeVncSessionID.map { (state.id, $0) }
         }
       )
-      sessions.reconcile(validTargetIDs: targetIDs, nativeLeaseIDs: nativeLeaseIDs)
+      sessions.reconcile(validTargetIDs: targetIDs, nativeSessionIDs: nativeSessionIDs)
       if let focusedTargetID, !targetIDs.contains(focusedTargetID) {
         self.focusedTargetID = nil
         sessions.focus(targetID: nil)
@@ -166,7 +166,7 @@ struct FleetRootView: View {
     sessions.focus(targetID: targetID)
     if let target = allTargets.first(where: { $0.id == targetID }),
       target.source == .crabfleet,
-      (target.endpoint != nil || target.nativeVncLeaseID != nil),
+      (target.endpoint != nil || target.nativeVncSessionID != nil),
       !sessions.session(for: targetID).phase.isConnectedOrConnecting
     {
       connect(target)
@@ -181,8 +181,10 @@ struct FleetRootView: View {
   }
 
   private func connect(_ target: DesktopTarget) {
-    if target.source == .crabfleet, let leaseID = target.nativeVncLeaseID {
-      sessions.connectCrabbox(targetID: target.id, leaseID: leaseID)
+    if target.source == .crabfleet, let sessionID = target.nativeVncSessionID {
+      sessions.connectCrabbox(targetID: target.id, sessionID: sessionID) {
+        try await store.nativeVNCGrant(sessionID: sessionID)
+      }
     } else if target.source == .crabfleet, let endpoint = target.endpoint {
       sessions.connect(
         targetID: target.id,
@@ -237,7 +239,7 @@ struct FleetRootView: View {
 
 private struct DesktopTargetConnectionState: Equatable {
   let id: String
-  let nativeVncLeaseID: String?
+  let nativeVncSessionID: String?
 }
 
 private struct DesktopSourceRail: View {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/FleetStore.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/FleetStore.swift
@@ -284,6 +284,34 @@ final class FleetStore: ObservableObject {
     await refresh(expectedGeneration: connectionGeneration)
   }
 
+  func nativeVNCGrant(sessionID: String) async throws -> NativeVNCGrant {
+    let generation = connectionGeneration
+    guard let client, let connectedOrigin, let credential,
+      credential.origin == connectedOrigin,
+      client.origin == connectedOrigin,
+      connectionPhase == .connected
+    else {
+      throw NativeAPIError.unauthorized
+    }
+    do {
+      return try await authenticatedRead(
+        api: client,
+        token: credential.token,
+        origin: connectedOrigin,
+        generation: generation,
+        operation: { token in
+          try await client.nativeVNCGrant(sessionID: sessionID, accessToken: token)
+        }
+      ).value
+    } catch NativeAPIError.unauthorized {
+      await expireCredential(
+        message: NativeAPIError.unauthorized.localizedDescription,
+        expectedGeneration: generation
+      )
+      throw NativeAPIError.unauthorized
+    }
+  }
+
   private func refresh(expectedGeneration: UInt64) async {
     guard isCurrent(expectedGeneration), !isRefreshing, let client, let connectedOrigin,
       let credential, credential.origin == connectedOrigin, client.origin == connectedOrigin,

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/NativeAPIClient.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/NativeAPIClient.swift
@@ -35,6 +35,13 @@ struct NativeAPIFleet: Equatable, Sendable {
   let desktopHosts: [RegisteredDesktopHost]
 }
 
+struct NativeVNCGrant: Equatable, Sendable {
+  let brokerURL: URL
+  let leaseID: String
+  let ticket: String
+  let expiresAt: Date
+}
+
 struct NativeDeviceAuthorization: Equatable, Sendable {
   let deviceCode: String
   let verificationURL: URL
@@ -65,6 +72,7 @@ protocol NativeAPIClientProtocol: AnyObject {
   func exchangeDeviceCode(_ deviceCode: String) async throws -> NativeTokenExchange
   func session(accessToken: String) async throws -> NativeAPISession
   func fleet(accessToken: String) async throws -> NativeAPIFleet
+  func nativeVNCGrant(sessionID: String, accessToken: String) async throws -> NativeVNCGrant
   func refreshCredential(accessToken: String) async throws -> String?
   func revoke(accessToken: String) async throws
   @MainActor
@@ -461,6 +469,38 @@ final class NativeAPIClient: NativeAPIClientProtocol {
     )
   }
 
+  func nativeVNCGrant(sessionID: String, accessToken: String) async throws -> NativeVNCGrant {
+    guard validNativeVNCSessionID(sessionID) else {
+      throw NativeAPIError.invalidResponse
+    }
+    let credential = NativeStoredCredential(accessToken)
+    let prefix = credential.kind == .oauth ? "/mcp/crabfleet/native/v1" : "/api/native/v1"
+    let response = try await request(
+      path: "\(prefix)/sessions/\(sessionID)/native-vnc",
+      method: "POST",
+      accessToken: credential.value
+    )
+    guard response.statusCode == 200 else { throw error(for: response) }
+    let payload = try decode(NativeVNCGrantEnvelope.self, from: response.data).grant
+    guard
+      let brokerURL = URL(string: payload.brokerUrl),
+      validNativeVNCBrokerURL(brokerURL),
+      validOpaqueNativeVNCValue(payload.leaseId, maximumBytes: 200),
+      validNativeVNCTicket(payload.ticket),
+      let expiresAt = ISO8601DateFormatter().date(from: payload.expiresAt),
+      expiresAt > Date(),
+      expiresAt <= Date().addingTimeInterval(120)
+    else {
+      throw NativeAPIError.invalidResponse
+    }
+    return .init(
+      brokerURL: brokerURL,
+      leaseID: payload.leaseId,
+      ticket: payload.ticket,
+      expiresAt: expiresAt
+    )
+  }
+
   func refreshCredential(accessToken: String) async throws -> String? {
     let credential = NativeStoredCredential(accessToken)
     guard credential.kind == .oauth, let token = credential.oauthToken,
@@ -600,6 +640,34 @@ final class NativeAPIClient: NativeAPIClientProtocol {
       && url.fragment == nil
       && url.path.hasPrefix("/native/link/")
   }
+
+  private func validNativeVNCBrokerURL(_ url: URL) -> Bool {
+    guard url.user == nil, url.password == nil, url.query == nil, url.fragment == nil else {
+      return false
+    }
+    if url.scheme == "https" { return true }
+    return url.scheme == "http" && ["localhost", "127.0.0.1", "::1"].contains(url.host ?? "")
+  }
+
+  private func validOpaqueNativeVNCValue(_ value: String, maximumBytes: Int) -> Bool {
+    !value.isEmpty && value.utf8.count <= maximumBytes
+      && value.unicodeScalars.allSatisfy { !CharacterSet.controlCharacters.contains($0) }
+      && value.trimmingCharacters(in: .whitespacesAndNewlines) == value
+  }
+
+  private func validNativeVNCSessionID(_ value: String) -> Bool {
+    guard value.hasPrefix("IS-"), value.count > 3 else { return false }
+    let digits = value.dropFirst(3).utf8
+    return digits.first != 0x30 && digits.allSatisfy { $0 >= 0x30 && $0 <= 0x39 }
+  }
+
+  private func validNativeVNCTicket(_ value: String) -> Bool {
+    let prefix = "native_vnc_"
+    guard value.hasPrefix(prefix), value.utf8.count == prefix.utf8.count + 32 else { return false }
+    return value.dropFirst(prefix.count).utf8.allSatisfy {
+      ($0 >= 0x30 && $0 <= 0x39) || ($0 >= 0x61 && $0 <= 0x66)
+    }
+  }
 }
 
 enum NativeAPIError: LocalizedError, Equatable {
@@ -659,6 +727,17 @@ private struct SessionResponse: Decodable {
 
 private struct OAuthSessionResponse: Decodable {
   let user: NativeAPIUser
+}
+
+private struct NativeVNCGrantEnvelope: Decodable {
+  let grant: NativeVNCGrantResponse
+}
+
+private struct NativeVNCGrantResponse: Decodable {
+  let brokerUrl: String
+  let leaseId: String
+  let ticket: String
+  let expiresAt: String
 }
 
 private struct NativeStoredCredential {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/NativeAPIClient.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/NativeAPIClient.swift
@@ -474,11 +474,13 @@ final class NativeAPIClient: NativeAPIClientProtocol {
       throw NativeAPIError.invalidResponse
     }
     let credential = NativeStoredCredential(accessToken)
-    let prefix = credential.kind == .oauth ? "/mcp/crabfleet/native/v1" : "/api/native/v1"
     let response = try await request(
-      path: "\(prefix)/sessions/\(sessionID)/native-vnc",
+      path: credential.kind == .oauth
+        ? "/mcp/crabfleet/native/v1/native-vnc"
+        : "/api/native/v1/native-vnc",
       method: "POST",
-      accessToken: credential.value
+      accessToken: credential.value,
+      body: NativeVNCGrantRequest(sessionId: sessionID)
     )
     guard response.statusCode == 200 else { throw error(for: response) }
     let payload = try decode(NativeVNCGrantEnvelope.self, from: response.data).grant
@@ -733,6 +735,10 @@ private struct NativeVNCGrantEnvelope: Decodable {
   let grant: NativeVNCGrantResponse
 }
 
+private struct NativeVNCGrantRequest: Encodable {
+  let sessionId: String
+}
+
 private struct NativeVNCGrantResponse: Decodable {
   let brokerUrl: String
   let leaseId: String
@@ -846,7 +852,7 @@ private struct NativeStoredCredential {
       payload.refreshToken.map({ !$0.isEmpty && $0.utf8.count <= 16 * 1_024 }) != false,
       validScope(payload.scope),
       secureURL(payload.tokenEndpoint) != nil,
-      payload.resources.count <= 2,
+      payload.resources.count <= 3,
       payload.resources.allSatisfy({ protectedResourceURL($0) != nil }),
       payload.expectedAudiences.count <= 4,
       payload.expectedAudiences.allSatisfy({ !$0.isEmpty && $0.utf8.count <= 1_024 })

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/NativeAPIClient.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/NativeAPIClient.swift
@@ -489,7 +489,7 @@ final class NativeAPIClient: NativeAPIClientProtocol {
       validNativeVNCBrokerURL(brokerURL),
       validOpaqueNativeVNCValue(payload.leaseId, maximumBytes: 200),
       validNativeVNCTicket(payload.ticket),
-      let expiresAt = ISO8601DateFormatter().date(from: payload.expiresAt),
+      let expiresAt = nativeVNCExpiryDate(payload.expiresAt),
       expiresAt > Date(),
       expiresAt <= Date().addingTimeInterval(120)
     else {
@@ -670,6 +670,12 @@ final class NativeAPIClient: NativeAPIClientProtocol {
       ($0 >= 0x30 && $0 <= 0x39) || ($0 >= 0x61 && $0 <= 0x66)
     }
   }
+}
+
+private func nativeVNCExpiryDate(_ value: String) -> Date? {
+  let fractional = ISO8601DateFormatter()
+  fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+  return fractional.date(from: value) ?? ISO8601DateFormatter().date(from: value)
 }
 
 enum NativeAPIError: LocalizedError, Equatable {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/OAuthGatewayAuthorizer.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/OAuthGatewayAuthorizer.swift
@@ -122,6 +122,7 @@ final class OAuthGatewayAuthorizer: OAuthGatewayAuthorizing {
     for path in [
       "/mcp/crabfleet/native/v1/session",
       "/mcp/crabfleet/native/v1/fleet",
+      "/mcp/crabfleet/native/v1/native-vnc",
     ] {
       let challenge = try await discoverResourceChallenge(
         origin: origin,

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/OAuthGatewayAuthorizer.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/OAuthGatewayAuthorizer.swift
@@ -119,14 +119,15 @@ final class OAuthGatewayAuthorizer: OAuthGatewayAuthorizing {
     transport: HTTPDataTransport
   ) async throws -> OAuthGatewayAccessToken {
     var discoveries: [OAuthDiscoveryResult] = []
-    for path in [
-      "/mcp/crabfleet/native/v1/session",
-      "/mcp/crabfleet/native/v1/fleet",
-      "/mcp/crabfleet/native/v1/native-vnc",
+    for (path, method) in [
+      ("/mcp/crabfleet/native/v1/session", "GET"),
+      ("/mcp/crabfleet/native/v1/fleet", "GET"),
+      ("/mcp/crabfleet/native/v1/native-vnc", "POST"),
     ] {
       let challenge = try await discoverResourceChallenge(
         origin: origin,
         path: path,
+        method: method,
         transport: transport
       )
       let discoveryData = try await dataRequest(
@@ -319,11 +320,12 @@ final class OAuthGatewayAuthorizer: OAuthGatewayAuthorizing {
   private func discoverResourceChallenge(
     origin: DeploymentOrigin,
     path: String,
+    method: String,
     transport: HTTPDataTransport
   ) async throws -> OAuthResourceChallenge {
     let resourceURL = try origin.endpoint(path)
     var request = URLRequest(url: resourceURL)
-    request.httpMethod = "GET"
+    request.httpMethod = method
     request.timeoutInterval = 20
     request.setValue("application/json", forHTTPHeaderField: "Accept")
     let (_, response) = try await transport.data(for: request)

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/VNCSessionPool.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/VNCSessionPool.swift
@@ -12,7 +12,7 @@ final class VNCSessionPool: ObservableObject {
   private var crabboxBridges: [String: CrabboxVNCBridge] = [:]
   private var crabboxBridgeTasks: [String: Task<Void, Never>] = [:]
   private var crabboxBridgeGenerations: [String: UUID] = [:]
-  private var crabboxBridgeLeaseIDs: [String: String] = [:]
+  private var crabboxBridgeSessionIDs: [String: String] = [:]
   private var phaseObservers: [String: AnyCancellable] = [:]
   private var lastUsedAt: [String: Date] = [:]
   private var isApplicationActive = true
@@ -48,17 +48,22 @@ final class VNCSessionPool: ObservableObject {
     connectDirect(targetID: targetID, request: request)
   }
 
-  func connectCrabbox(targetID: String, leaseID: String, executableURL: URL? = nil) {
+  func connectCrabbox(
+    targetID: String,
+    sessionID: String,
+    executableURL: URL? = nil,
+    grant: @escaping @MainActor () async throws -> NativeVNCGrant
+  ) {
     stopCrabboxBridge(targetID: targetID)
     enforceLiveSessionBudget(excluding: targetID)
     let generation = UUID()
     crabboxBridgeGenerations[targetID] = generation
-    crabboxBridgeLeaseIDs[targetID] = leaseID
+    crabboxBridgeSessionIDs[targetID] = sessionID
     session(for: targetID).beginConnecting(endpoint: "Crabbox secure tunnel")
     let task = Task { [weak self] in
       do {
         let bridge = try await CrabboxVNCBridge.start(
-          leaseID: leaseID,
+          grant: try await grant(),
           executableURL: executableURL
         )
         guard
@@ -147,10 +152,10 @@ final class VNCSessionPool: ObservableObject {
     }
   }
 
-  func reconcile(validTargetIDs: Set<String>, nativeLeaseIDs: [String: String]) {
+  func reconcile(validTargetIDs: Set<String>, nativeSessionIDs: [String: String]) {
     let crabboxTargetIDs = Set(crabboxBridges.keys).union(crabboxBridgeTasks.keys)
     for targetID in crabboxTargetIDs
-    where nativeLeaseIDs[targetID] != crabboxBridgeLeaseIDs[targetID] {
+    where nativeSessionIDs[targetID] != crabboxBridgeSessionIDs[targetID] {
       disconnect(targetID: targetID)
     }
 
@@ -190,7 +195,7 @@ final class VNCSessionPool: ObservableObject {
 
   private func stopCrabboxBridge(targetID: String) {
     crabboxBridgeGenerations[targetID] = nil
-    crabboxBridgeLeaseIDs[targetID] = nil
+    crabboxBridgeSessionIDs[targetID] = nil
     crabboxBridgeTasks[targetID]?.cancel()
     crabboxBridgeTasks[targetID] = nil
     crabboxBridges[targetID]?.stop()

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/FleetModelsTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/FleetModelsTests.swift
@@ -4,6 +4,17 @@ import Testing
 
 @testable import CrabfleetMac
 
+private let nativeVNCTicket = "native_vnc_0123456789abcdef0123456789abcdef"
+
+private func nativeVNCGrant(leaseID: String = "cbx_native123") -> NativeVNCGrant {
+  .init(
+    brokerURL: URL(string: "https://crabbox.example.test")!,
+    leaseID: leaseID,
+    ticket: nativeVNCTicket,
+    expiresAt: Date().addingTimeInterval(60)
+  )
+}
+
 struct FleetModelsTests {
   @Test
   func startsAndStopsBoundedCrabboxNativeHandoff() async throws {
@@ -14,10 +25,15 @@ struct FleetModelsTests {
     let executable = directory.appendingPathComponent("crabbox")
     let pidFile = directory.appendingPathComponent("helper.pid")
     let drainFile = directory.appendingPathComponent("stderr-drained")
+    let ticketFile = directory.appendingPathComponent("ticket")
+    let argumentsFile = directory.appendingPathComponent("arguments")
     try Data(
       """
       #!/bin/sh
       trap '' TERM
+      IFS= read -r ticket
+      printf '%s' "$ticket" > '\(ticketFile.path)'
+      printf '%s\n' "$@" > '\(argumentsFile.path)'
       printf '%s' "$$" > '\(pidFile.path)'
       printf '%s\\n' '{"schema":"crabbox/vnc-handoff/v1","host":"127.0.0.1","port":15901,"username":"dev","password":"secret"}'
       dd if=/dev/zero bs=131072 count=1 2>/dev/null | cat >&2
@@ -28,7 +44,7 @@ struct FleetModelsTests {
     try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
 
     var bridge: CrabboxVNCBridge? = try await CrabboxVNCBridge.start(
-      leaseID: "cloud/project/box-42",
+      grant: nativeVNCGrant(leaseID: "cloud/project/box-42"),
       executableURL: executable,
       timeout: 2
     )
@@ -36,6 +52,11 @@ struct FleetModelsTests {
     #expect(bridge?.request.port == 15901)
     #expect(bridge?.request.username == "dev")
     #expect(bridge?.request.password == "secret")
+    #expect(try String(contentsOf: ticketFile, encoding: .utf8) == nativeVNCTicket)
+    let arguments = try String(contentsOf: argumentsFile, encoding: .utf8)
+    #expect(arguments.contains("--native-grant-url"))
+    #expect(arguments.contains("--native-grant-stdin"))
+    #expect(!arguments.contains(nativeVNCTicket))
     #expect(
       await waitUntil(timeout: .seconds(2)) {
         FileManager.default.fileExists(atPath: drainFile.path)
@@ -68,6 +89,7 @@ struct FleetModelsTests {
       """
       #!/bin/sh
       trap '' TERM
+      IFS= read -r ticket
       printf '%s' "$$" > '\(pidFile.path)'
       while :; do sleep 1; done
       """.utf8
@@ -77,8 +99,9 @@ struct FleetModelsTests {
     let pool = VNCSessionPool()
     pool.connectCrabbox(
       targetID: "fleet-native",
-      leaseID: "cbx_native123",
-      executableURL: executable
+      sessionID: "IS-257",
+      executableURL: executable,
+      grant: { nativeVNCGrant() }
     )
     let launched = await waitUntil(timeout: .seconds(2)) {
       FileManager.default.fileExists(atPath: pidFile.path)
@@ -87,7 +110,7 @@ struct FleetModelsTests {
       launched ? Int(String(contentsOf: pidFile, encoding: .utf8)) : nil
     )
 
-    pool.reconcile(validTargetIDs: ["fleet-native"], nativeLeaseIDs: [:])
+    pool.reconcile(validTargetIDs: ["fleet-native"], nativeSessionIDs: [:])
     let stopped = await waitUntil(timeout: .seconds(3)) {
       Darwin.kill(Int32(pid), 0) != 0
     }
@@ -112,7 +135,7 @@ struct FleetModelsTests {
 
     await #expect(throws: CrabboxVNCBridgeError.invalidHandoff) {
       _ = try await CrabboxVNCBridge.start(
-        leaseID: "cbx_native123",
+        grant: nativeVNCGrant(),
         executableURL: executable,
         timeout: 2
       )
@@ -178,7 +201,7 @@ struct FleetModelsTests {
     let lease = CrabboxLease(
       id: "IS-248",
       leaseID: "blue-lobster",
-      nativeVncLeaseID: nil,
+      nativeVncSessionID: nil,
       owner: "operator",
       repository: "openclaw/crabfleet",
       branch: "codex/native-fleet",
@@ -228,7 +251,7 @@ struct FleetModelsTests {
             "attachable": true,
             "vnc": false,
             "leaseId": "blue-lobster",
-            "nativeVncLeaseId": "cbx_native123",
+            "nativeVncSessionId": "IS-257",
             "lastEvent": "ready",
             "updatedAt": 1770000000000
           }]
@@ -255,7 +278,7 @@ struct FleetModelsTests {
     #expect(target.desktopAvailable)
 
     let fleetTarget = DesktopTarget(lease: lease)
-    #expect(fleetTarget.nativeVncLeaseID == "cbx_native123")
+    #expect(fleetTarget.nativeVncSessionID == "IS-257")
   }
 
   @Test @MainActor

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/NativeConnectionTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/NativeConnectionTests.swift
@@ -93,9 +93,14 @@ struct NativeConnectionTests {
     let expiresAt = Date().addingTimeInterval(60)
     let transport = RecordingHTTPTransport { request in
       #expect(request.httpMethod == "POST")
-      #expect(request.url?.path == "/api/native/v1/sessions/IS-257/native-vnc")
+      #expect(request.url?.path == "/api/native/v1/native-vnc")
       #expect(request.url?.query == nil)
       #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer access-token")
+      let requestBody = try #require(request.httpBody)
+      let requestJSON = try #require(
+        JSONSerialization.jsonObject(with: requestBody) as? [String: String]
+      )
+      #expect(requestJSON == ["sessionId": "IS-257"])
       let body = Data(
         """
         {
@@ -286,6 +291,7 @@ struct NativeConnectionTests {
       switch url.path {
       case "/mcp/crabfleet/native/v1/session": scope = firstScope
       case "/mcp/crabfleet/native/v1/fleet": scope = secondScope
+      case "/mcp/crabfleet/native/v1/native-vnc": scope = secondScope
       case metadataURL.path:
         return (
           Data(
@@ -330,6 +336,8 @@ struct NativeConnectionTests {
       metadataURL.path,
       "/mcp/crabfleet/native/v1/fleet",
       metadataURL.path,
+      "/mcp/crabfleet/native/v1/native-vnc",
+      metadataURL.path,
     ])
     #expect(trust.endpoints.isEmpty)
   }
@@ -339,14 +347,18 @@ struct NativeConnectionTests {
     let origin = try DeploymentOrigin("https://fleet.example.test")
     let sessionURL = try origin.endpoint("/mcp/crabfleet/native/v1/session")
     let fleetURL = try origin.endpoint("/mcp/crabfleet/native/v1/fleet")
+    let nativeVNCURL = try origin.endpoint("/mcp/crabfleet/native/v1/native-vnc")
     let sessionMetadataURL = try origin.endpoint("/oauth/session-metadata")
     let fleetMetadataURL = try origin.endpoint("/oauth/fleet-metadata")
+    let nativeVNCMetadataURL = try origin.endpoint("/oauth/native-vnc-metadata")
     var requests: [URL] = []
     let transport = RecordingHTTPTransport { request in
       let url = try #require(request.url)
       requests.append(url)
-      if url == sessionURL || url == fleetURL {
-        let metadataURL = url == sessionURL ? sessionMetadataURL : fleetMetadataURL
+      if url == sessionURL || url == fleetURL || url == nativeVNCURL {
+        let metadataURL =
+          url == sessionURL
+          ? sessionMetadataURL : (url == fleetURL ? fleetMetadataURL : nativeVNCMetadataURL)
         return (
           Data(),
           httpResponse(
@@ -359,8 +371,10 @@ struct NativeConnectionTests {
           )
         )
       }
-      if url == sessionMetadataURL || url == fleetMetadataURL {
-        let resource = url == sessionMetadataURL ? sessionURL : fleetURL
+      if url == sessionMetadataURL || url == fleetMetadataURL || url == nativeVNCMetadataURL {
+        let resource =
+          url == sessionMetadataURL
+          ? sessionURL : (url == fleetMetadataURL ? fleetURL : nativeVNCURL)
         return (
           Data(
             """
@@ -404,6 +418,7 @@ struct NativeConnectionTests {
     #expect(requests.last?.path == "/register")
     #expect(requests.contains(sessionMetadataURL))
     #expect(requests.contains(fleetMetadataURL))
+    #expect(requests.contains(nativeVNCMetadataURL))
   }
 
   @Test
@@ -516,6 +531,8 @@ struct NativeConnectionTests {
       "/mcp/crabfleet/native/v1/session",
       metadataURL.path,
       "/mcp/crabfleet/native/v1/fleet",
+      metadataURL.path,
+      "/mcp/crabfleet/native/v1/native-vnc",
       metadataURL.path,
     ])
   }

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/NativeConnectionTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/NativeConnectionTests.swift
@@ -91,6 +91,8 @@ struct NativeConnectionTests {
   func nativeAPIRequestsShortLivedVNCGrantWithoutLeakingItIntoURL() async throws {
     let origin = try DeploymentOrigin("https://fleet.example.test")
     let expiresAt = Date().addingTimeInterval(60)
+    let expiryFormatter = ISO8601DateFormatter()
+    expiryFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     let transport = RecordingHTTPTransport { request in
       #expect(request.httpMethod == "POST")
       #expect(request.url?.path == "/api/native/v1/native-vnc")
@@ -108,7 +110,7 @@ struct NativeConnectionTests {
             "brokerUrl": "https://crabbox.example.test",
             "leaseId": "cbx_native123",
             "ticket": "native_vnc_0123456789abcdef0123456789abcdef",
-            "expiresAt": "\(ISO8601DateFormatter().string(from: expiresAt))"
+            "expiresAt": "\(expiryFormatter.string(from: expiresAt))"
           }
         }
         """.utf8
@@ -356,6 +358,7 @@ struct NativeConnectionTests {
       let url = try #require(request.url)
       requests.append(url)
       if url == sessionURL || url == fleetURL || url == nativeVNCURL {
+        #expect(request.httpMethod == (url == nativeVNCURL ? "POST" : "GET"))
         let metadataURL =
           url == sessionURL
           ? sessionMetadataURL : (url == fleetURL ? fleetMetadataURL : nativeVNCMetadataURL)

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/NativeConnectionTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/NativeConnectionTests.swift
@@ -88,6 +88,41 @@ struct NativeConnectionTests {
   }
 
   @Test
+  func nativeAPIRequestsShortLivedVNCGrantWithoutLeakingItIntoURL() async throws {
+    let origin = try DeploymentOrigin("https://fleet.example.test")
+    let expiresAt = Date().addingTimeInterval(60)
+    let transport = RecordingHTTPTransport { request in
+      #expect(request.httpMethod == "POST")
+      #expect(request.url?.path == "/api/native/v1/sessions/IS-257/native-vnc")
+      #expect(request.url?.query == nil)
+      #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer access-token")
+      let body = Data(
+        """
+        {
+          "grant": {
+            "brokerUrl": "https://crabbox.example.test",
+            "leaseId": "cbx_native123",
+            "ticket": "native_vnc_0123456789abcdef0123456789abcdef",
+            "expiresAt": "\(ISO8601DateFormatter().string(from: expiresAt))"
+          }
+        }
+        """.utf8
+      )
+      return (body, httpResponse(url: request.url!, status: 200))
+    }
+    let grant = try await NativeAPIClient(origin: origin, transport: transport)
+      .nativeVNCGrant(sessionID: "IS-257", accessToken: "access-token")
+    #expect(grant.brokerURL.absoluteString == "https://crabbox.example.test")
+    #expect(grant.leaseID == "cbx_native123")
+    #expect(grant.ticket == "native_vnc_0123456789abcdef0123456789abcdef")
+
+    await #expect(throws: NativeAPIError.invalidResponse) {
+      try await NativeAPIClient(origin: origin, transport: transport)
+        .nativeVNCGrant(sessionID: "IS-0", accessToken: "access-token")
+    }
+  }
+
+  @Test
   func nativeAPIFallsBackToOAuthGatewayAndUsesItsReadIngress() async throws {
     let origin = try DeploymentOrigin("https://fleet.example.test")
     var requests: [URLRequest] = []
@@ -1668,6 +1703,8 @@ private final class StubNativeAPIClient: NativeAPIClientProtocol {
   var sessionResults: [Result<NativeAPISession, Error>] = []
   var sessionHandler: ((String) async throws -> NativeAPISession)?
   var fleetResult: Result<NativeAPIFleet, Error> = .failure(NativeAPIError.invalidResponse)
+  var nativeVNCGrantResult: Result<NativeVNCGrant, Error> = .failure(
+    NativeAPIError.invalidResponse)
   var fleetHandler: (() async throws -> NativeAPIFleet)?
   var sessionTokens: [String] = []
   var fleetTokens: [String] = []
@@ -1713,6 +1750,10 @@ private final class StubNativeAPIClient: NativeAPIClientProtocol {
     fleetTokens.append(accessToken)
     if let fleetHandler { return try await fleetHandler() }
     return try fleetResult.get()
+  }
+
+  func nativeVNCGrant(sessionID: String, accessToken: String) async throws -> NativeVNCGrant {
+    try nativeVNCGrantResult.get()
   }
 
   func refreshCredential(accessToken: String) async throws -> String? {
@@ -1833,7 +1874,7 @@ private func testLease(id: String = "IS-live") -> CrabboxLease {
   .init(
     id: id,
     leaseID: "live-crab",
-    nativeVncLeaseID: nil,
+    nativeVncSessionID: nil,
     owner: "operator",
     repository: "openclaw/crabfleet",
     branch: "main",

--- a/src/fleet-state.ts
+++ b/src/fleet-state.ts
@@ -125,7 +125,7 @@ export type FleetSessionSummary = {
   archived: boolean;
   logEvents: number;
   leaseId: string | null;
-  nativeVncLeaseId: string | null;
+  nativeVncSessionId: string | null;
   sandboxId: string | null;
   lastEvent: string;
   createdAt: number;
@@ -316,13 +316,13 @@ export function fleetSessionSummary(
     archived,
     logEvents: session.logArchive?.eventCount ?? session.logs?.length ?? 0,
     leaseId: session.leaseId,
-    nativeVncLeaseId:
+    nativeVncSessionId:
       session.adapter === "runtime-v1" &&
       session.runtime === "crabbox" &&
       session.canControl === true &&
       ptyReadyStatuses.has(session.status) &&
       session.capabilities?.nativeVnc === true
-        ? (session.providerResourceId ?? null)
+        ? session.id
         : null,
     sandboxId,
     lastEvent: session.lastEvent,

--- a/src/runtime-adapter.ts
+++ b/src/runtime-adapter.ts
@@ -59,6 +59,13 @@ export type AdapterDesktopConnection = {
   expiresAtPresent: boolean;
 };
 
+export type AdapterNativeVNCGrant = {
+  brokerUrl: string;
+  leaseId: string;
+  ticket: string;
+  expiresAt: number;
+};
+
 export type AdapterCreateInput = {
   namespace: string;
   id: string;
@@ -216,6 +223,10 @@ export function runtimeAdapterWorkspaceUrl(base: string, adapterWorkspaceId: str
 
 export function runtimeAdapterDesktopUrl(base: string, adapterWorkspaceId: string): string {
   return `${runtimeAdapterWorkspaceUrl(base, adapterWorkspaceId)}/connections/desktop`;
+}
+
+export function runtimeAdapterNativeVNCUrl(base: string, adapterWorkspaceId: string): string {
+  return `${runtimeAdapterWorkspaceUrl(base, adapterWorkspaceId)}/connections/native-vnc`;
 }
 
 export function runtimeAdapterBrowserVncUrl(canonicalUrl: string, sessionId: string): string {
@@ -640,6 +651,32 @@ export function currentAdapterDesktopConnection(
   return connection;
 }
 
+export function parseAdapterNativeVNCGrant(
+  value: unknown,
+  now = Date.now(),
+): AdapterNativeVNCGrant | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const input = value as Record<string, unknown>;
+  const brokerUrl = exactSecureHttpUrl(input.brokerUrl);
+  const leaseId = opaqueNativeVNCValue(input.leaseId, 200);
+  const ticket = typeof input.ticket === "string" ? input.ticket : "";
+  const expiresAt = typeof input.expiresAt === "string" ? Date.parse(input.expiresAt) : NaN;
+  if (
+    input.schema !== "crabbox/native-vnc-grant/v1" ||
+    !brokerUrl ||
+    !leaseId ||
+    !/^native_vnc_[a-f0-9]{32}$/u.test(ticket) ||
+    !Number.isFinite(expiresAt) ||
+    expiresAt <= now ||
+    expiresAt > now + 2 * 60_000
+  ) {
+    return null;
+  }
+  const broker = new URL(brokerUrl);
+  if (broker.search || broker.hash) return null;
+  return { brokerUrl, leaseId, ticket, expiresAt };
+}
+
 export function safeDesktopUrl(value: unknown): string | null {
   return exactSecureHttpUrl(value);
 }
@@ -651,6 +688,15 @@ export function safeWebSocketUrl(value: unknown): string | null {
 function adapterStatus(value: unknown): AdapterSessionStatus | null {
   const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
   return statusMap[normalized] ?? null;
+}
+
+function opaqueNativeVNCValue(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string" || value.length < 1 || value.length > maxLength) return null;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x20 || (code >= 0x7f && code <= 0x9f)) return null;
+  }
+  return value;
 }
 
 function adapterCapabilities(value: unknown): AdapterCapabilities | null {

--- a/src/worker/ingress.ts
+++ b/src/worker/ingress.ts
@@ -54,6 +54,8 @@ function usesNativeServiceAuth(method: string, pathname: string): boolean {
     (method === "POST" &&
       (pathname === "/api/native/v1/auth/device" || pathname === "/api/native/v1/auth/token")) ||
     (method === "DELETE" && pathname === "/api/native/v1/auth/token") ||
+    (method === "POST" &&
+      /^\/api\/native\/v1\/sessions\/IS-[1-9][0-9]*\/native-vnc$/u.test(pathname)) ||
     (method === "GET" &&
       (pathname === "/api/native/v1/session" || pathname === "/api/native/v1/fleet"))
   );

--- a/src/worker/ingress.ts
+++ b/src/worker/ingress.ts
@@ -54,8 +54,7 @@ function usesNativeServiceAuth(method: string, pathname: string): boolean {
     (method === "POST" &&
       (pathname === "/api/native/v1/auth/device" || pathname === "/api/native/v1/auth/token")) ||
     (method === "DELETE" && pathname === "/api/native/v1/auth/token") ||
-    (method === "POST" &&
-      /^\/api\/native\/v1\/sessions\/IS-[1-9][0-9]*\/native-vnc$/u.test(pathname)) ||
+    (method === "POST" && pathname === "/api/native/v1/native-vnc") ||
     (method === "GET" &&
       (pathname === "/api/native/v1/session" || pathname === "/api/native/v1/fleet"))
   );

--- a/src/worker/routes/native.ts
+++ b/src/worker/routes/native.ts
@@ -21,6 +21,7 @@ export type NativeRouteDependencies = {
   requireUser(request: Request): Promise<User>;
   revokeToken(request: Request): Promise<void>;
   readFleet(user: User): Promise<unknown>;
+  createNativeVNCGrant(user: User, sessionId: string): Promise<unknown>;
   deployment: PublicDeploymentConfig;
 };
 
@@ -78,6 +79,18 @@ export async function handleNativeRoute(
     const user = await dependencies.requireUser(request);
     requireRole(user, "viewer");
     return json({ fleet: await dependencies.readFleet(user) });
+  }
+  const nativeVNCMatch = /^\/api\/native\/v1\/sessions\/(IS-[1-9][0-9]*)\/native-vnc$/u.exec(
+    url.pathname,
+  );
+  if (request.method === "POST" && nativeVNCMatch) {
+    rejectAmbiguousProxyBearer(request, requestAuth);
+    const user = await dependencies.requireUser(request);
+    requireRole(user, "viewer");
+    return json(
+      { grant: await dependencies.createNativeVNCGrant(user, nativeVNCMatch[1]!) },
+      { headers: { "cache-control": "no-store" } },
+    );
   }
   return null;
 }

--- a/src/worker/routes/native.ts
+++ b/src/worker/routes/native.ts
@@ -21,7 +21,10 @@ export type NativeRouteDependencies = {
   requireUser(request: Request): Promise<User>;
   revokeToken(request: Request): Promise<void>;
   readFleet(user: User): Promise<unknown>;
-  createNativeVNCGrant(user: User, sessionId: string): Promise<unknown>;
+  createNativeVNCGrant(
+    user: User,
+    sessionId: string,
+  ): Promise<{ brokerUrl: string; leaseId: string; ticket: string; expiresAt: number }>;
   deployment: PublicDeploymentConfig;
 };
 
@@ -80,15 +83,17 @@ export async function handleNativeRoute(
     requireRole(user, "viewer");
     return json({ fleet: await dependencies.readFleet(user) });
   }
-  const nativeVNCMatch = /^\/api\/native\/v1\/sessions\/(IS-[1-9][0-9]*)\/native-vnc$/u.exec(
-    url.pathname,
-  );
-  if (request.method === "POST" && nativeVNCMatch) {
+  if (request.method === "POST" && url.pathname === "/api/native/v1/native-vnc") {
     rejectAmbiguousProxyBearer(request, requestAuth);
+    const body = await readNativeJson<{ sessionId?: unknown }>(request);
+    if (typeof body.sessionId !== "string" || !/^IS-[1-9][0-9]*$/u.test(body.sessionId)) {
+      throw badRequest("invalid session id");
+    }
     const user = await dependencies.requireUser(request);
     requireRole(user, "viewer");
+    const grant = await dependencies.createNativeVNCGrant(user, body.sessionId);
     return json(
-      { grant: await dependencies.createNativeVNCGrant(user, nativeVNCMatch[1]!) },
+      { grant: { ...grant, expiresAt: new Date(grant.expiresAt).toISOString() } },
       { headers: { "cache-control": "no-store" } },
     );
   }

--- a/src/worker/runtime-adapter-workspaces.ts
+++ b/src/worker/runtime-adapter-workspaces.ts
@@ -3,10 +3,12 @@ import { sql } from "kysely";
 import { githubActionsRuntime } from "../github-actions-runtime.ts";
 import {
   adapterWorkspaceIdMatches,
+  parseAdapterNativeVNCGrant,
   parseAdapterWorkspaceResult,
   redactedAdapterResponseMessage,
   runtimeAdapterCollectionUrl,
   runtimeAdapterName,
+  runtimeAdapterNativeVNCUrl,
   runtimeAdapterReplayRequest,
   runtimeAdapterStopOutcome,
   runtimeAdapterWorkspaceIdConflict,
@@ -14,6 +16,7 @@ import {
   shouldReplayRuntimeAdapterCreate,
   validatedRuntimeAdapterCreatePayloadJson,
   type AdapterProvisionRecord,
+  type AdapterNativeVNCGrant,
 } from "../runtime-adapter.ts";
 import { database, type InteractiveSessionRow } from "./database.ts";
 import type { RuntimeEnv } from "./env.ts";
@@ -69,6 +72,35 @@ export class RuntimeAdapterWorkspaceLifecycle {
   constructor(env: RuntimeEnv, dependencies: RuntimeAdapterWorkspaceLifecycleDependencies) {
     this.env = env;
     this.dependencies = dependencies;
+  }
+
+  async createNativeVNCGrant(
+    profile: string,
+    registeredControlPlane: string | null,
+    adapterWorkspaceId: string,
+  ): Promise<AdapterNativeVNCGrant> {
+    const controlPlane = requireRegisteredRuntimeAdapterControlPlane(
+      this.env,
+      profile,
+      registeredControlPlane,
+    );
+    const response = await this.dependencies.fetch(
+      runtimeAdapterNativeVNCUrl(controlPlane, adapterWorkspaceId),
+      { method: "POST" },
+    );
+    const responseBody = await this.dependencies.readResponseBody(response);
+    if (!response.ok) {
+      throw new Error(
+        redactedAdapterResponseMessage(
+          responseBody,
+          `runtime adapter native VNC HTTP ${response.status}`,
+          [adapterWorkspaceId],
+        ),
+      );
+    }
+    const grant = parseAdapterNativeVNCGrant(responseBody, this.dependencies.now());
+    if (!grant) throw new Error("runtime adapter returned an invalid native VNC grant");
+    return grant;
   }
 
   async inspect(

--- a/src/worker/worker-application.ts
+++ b/src/worker/worker-application.ts
@@ -18,7 +18,7 @@ import type { RuntimeEnv } from "./env.ts";
 import { githubHeaders } from "./github.ts";
 import { GitHubActionsApplication } from "./github-actions-application.ts";
 import { GitHubReferenceService } from "./github-reference-service.ts";
-import { readJson } from "./http.ts";
+import { conflict, forbidden, notFound, readJson } from "./http.ts";
 import { InteractiveSessionApplication } from "./interactive-session-application.ts";
 import { createInteractiveDesktopService } from "./interactive-desktop-service.ts";
 import { DesktopHostRepository } from "./desktop-host-repository.ts";
@@ -41,7 +41,10 @@ import { scheduleNativeAuthPruning, scheduleRecurringCardTick } from "./schedule
 import { createSandboxSessionResourceService } from "./sandbox-session-resources.ts";
 import { ServiceRegistry } from "./service-registry.ts";
 import type { InteractiveSession } from "./session-model.ts";
-import { interactiveSessionOwnerSubject } from "./session-model.ts";
+import {
+  interactiveSessionAdapterControlPlane,
+  interactiveSessionOwnerSubject,
+} from "./session-model.ts";
 import { readInteractiveSessionShareCredential } from "./session-repository.ts";
 import { ownsInteractiveSession } from "./session-access.ts";
 import { readSandboxFleetPolicies } from "./session-control-do.ts";
@@ -192,6 +195,24 @@ export class WorkerApplication {
       requireUser: (request) => auth.authenticate(request),
       revokeToken: (request) => auth.revoke(request),
       readFleet: (user) => this.readFleetState(user, undefined, context),
+      createNativeVNCGrant: async (user, sessionId) => {
+        const session = await this.sessions.readVisibleFresh(user, sessionId);
+        if (!session) throw notFound("session not found");
+        if (session.canControl !== true) throw forbidden("session control required");
+        const controlPlane = session[interactiveSessionAdapterControlPlane];
+        if (
+          session.runtime !== "crabbox" ||
+          session.adapter !== "runtime-v1" ||
+          session.capabilities.nativeVnc !== true ||
+          !session.adapterWorkspaceId ||
+          !controlPlane
+        ) {
+          throw conflict("native VNC is unavailable for this session");
+        }
+        return await this.runtime
+          .workspaceLifecycle()
+          .createNativeVNCGrant(session.profile, controlPlane, session.adapterWorkspaceId);
+      },
       deployment: publicDeploymentConfig(this.env),
     };
   }

--- a/tests/fleet-state.test.ts
+++ b/tests/fleet-state.test.ts
@@ -262,7 +262,7 @@ test("fleet exposes native VNC identity separately from browser VNC", () => {
 
   assert.equal(fleet.totals.vnc, 0);
   assert.equal(fleet.sessions[0]?.vnc, false);
-  assert.equal(fleet.sessions[0]?.nativeVncLeaseId, "cbx_native123");
+  assert.equal(fleet.sessions[0]?.nativeVncSessionId, "s1");
 });
 
 test("fleet omits native VNC identity for non-Crabbox runtimes", () => {
@@ -286,7 +286,7 @@ test("fleet omits native VNC identity for non-Crabbox runtimes", () => {
     },
   );
 
-  assert.equal(fleet.sessions[0]?.nativeVncLeaseId, null);
+  assert.equal(fleet.sessions[0]?.nativeVncSessionId, null);
 });
 
 test("fleet omits native VNC lease identity without control", () => {
@@ -312,7 +312,7 @@ test("fleet omits native VNC lease identity without control", () => {
     },
   );
 
-  assert.equal(fleet.sessions[0]?.nativeVncLeaseId, null);
+  assert.equal(fleet.sessions[0]?.nativeVncSessionId, null);
 });
 
 test("fleet omits stale native VNC lease identity after stop", () => {
@@ -337,7 +337,7 @@ test("fleet omits stale native VNC lease identity after stop", () => {
     },
   );
 
-  assert.equal(fleet.sessions[0]?.nativeVncLeaseId, null);
+  assert.equal(fleet.sessions[0]?.nativeVncSessionId, null);
 });
 
 test("stopping sessions are inactive and not attachable", () => {

--- a/tests/ingress.test.ts
+++ b/tests/ingress.test.ts
@@ -97,6 +97,15 @@ test("missing proxy assertions bypass enforcement only on independent service ro
     assert.equal(ingress.independentServiceAuth, true);
     assert.doesNotThrow(() => enforceWorkerIngressAuth(ingress));
   }
+  const nativeVNC = prepareWorkerIngress(
+    new Request("https://backend.example/api/native/v1/sessions/IS-257/native-vnc", {
+      method: "POST",
+      headers: { authorization: "Bearer native-token" },
+    }),
+    env,
+  );
+  assert.equal(nativeVNC.independentServiceAuth, true);
+  assert.doesNotThrow(() => enforceWorkerIngressAuth(nativeVNC));
 });
 
 test("terminal ingress requires authorization plus an SSH or agent identity", () => {

--- a/tests/ingress.test.ts
+++ b/tests/ingress.test.ts
@@ -98,7 +98,7 @@ test("missing proxy assertions bypass enforcement only on independent service ro
     assert.doesNotThrow(() => enforceWorkerIngressAuth(ingress));
   }
   const nativeVNC = prepareWorkerIngress(
-    new Request("https://backend.example/api/native/v1/sessions/IS-257/native-vnc", {
+    new Request("https://backend.example/api/native/v1/native-vnc", {
       method: "POST",
       headers: { authorization: "Bearer native-token" },
     }),

--- a/tests/native-routes.test.ts
+++ b/tests/native-routes.test.ts
@@ -115,7 +115,7 @@ test("native routes expose device, session, fleet, native VNC, and revoke contra
 
   const vncCalls: string[] = [];
   const vnc = await dispatch(
-    request("POST", "/api/native/v1/sessions/IS-257/native-vnc"),
+    request("POST", "/api/native/v1/native-vnc", { sessionId: "IS-257" }),
     vncCalls,
   );
   assert.equal(vnc?.status, 200);
@@ -125,7 +125,7 @@ test("native routes expose device, session, fleet, native VNC, and revoke contra
       brokerUrl: "https://crabbox.example.test",
       leaseId: "cbx_native123",
       ticket: "native_vnc_0123456789abcdef0123456789abcdef",
-      expiresAt: 660_000,
+      expiresAt: "1970-01-01T00:11:00.000Z",
     },
   });
   assert.deepEqual(vncCalls, ["authenticate", "native-vnc:github:1:IS-257"]);
@@ -183,7 +183,7 @@ test("native bearer routes reject simultaneous trusted-proxy identity", async ()
     ["POST", "/api/native/v1/auth/token"],
     ["GET", "/api/native/v1/session"],
     ["GET", "/api/native/v1/fleet"],
-    ["POST", "/api/native/v1/sessions/IS-257/native-vnc"],
+    ["POST", "/api/native/v1/native-vnc"],
     ["DELETE", "/api/native/v1/auth/token"],
   ]) {
     await assert.rejects(dispatch(request(method, path), [], {}, authenticated), (error) => {
@@ -199,8 +199,8 @@ test("native routes fall through on inexact methods and paths", async () => {
     request("GET", "/api/native/v1/auth/token"),
     request("POST", "/api/native/v1/fleet", {}),
     request("GET", "/api/native/v2/fleet"),
-    request("POST", "/api/native/v1/sessions/IS-0/native-vnc"),
-    request("POST", "/api/native/v1/sessions/IS-257/native-vnc/extra"),
+    request("POST", "/api/native/v1/sessions/IS-257/native-vnc", { sessionId: "IS-257" }),
+    request("POST", "/api/native/v1/native-vnc/extra", { sessionId: "IS-257" }),
   ]) {
     assert.equal(await dispatch(value, []), null);
   }

--- a/tests/native-routes.test.ts
+++ b/tests/native-routes.test.ts
@@ -42,6 +42,15 @@ function dependencies(calls: string[]): NativeRouteDependencies {
       calls.push(`fleet:${user.subject}`);
       return { sessions: [] };
     },
+    async createNativeVNCGrant(user, sessionId) {
+      calls.push(`native-vnc:${user.subject}:${sessionId}`);
+      return {
+        brokerUrl: "https://crabbox.example.test",
+        leaseId: "cbx_native123",
+        ticket: "native_vnc_0123456789abcdef0123456789abcdef",
+        expiresAt: 660_000,
+      };
+    },
     deployment: {
       label: "Fleet",
       canonicalUrl: "https://fleet.example",
@@ -75,7 +84,7 @@ async function dispatch(
   });
 }
 
-test("native routes expose the device, session, fleet, and revoke contracts", async () => {
+test("native routes expose device, session, fleet, native VNC, and revoke contracts", async () => {
   const startCalls: string[] = [];
   const start = await dispatch(
     request("POST", "/api/native/v1/auth/device", { clientName: "Peter's Mac" }),
@@ -103,6 +112,23 @@ test("native routes expose the device, session, fleet, and revoke contracts", as
   const fleet = await dispatch(request("GET", "/api/native/v1/fleet"), fleetCalls);
   assert.deepEqual(await fleet?.json(), { fleet: { sessions: [] } });
   assert.deepEqual(fleetCalls, ["authenticate", "fleet:github:1"]);
+
+  const vncCalls: string[] = [];
+  const vnc = await dispatch(
+    request("POST", "/api/native/v1/sessions/IS-257/native-vnc"),
+    vncCalls,
+  );
+  assert.equal(vnc?.status, 200);
+  assert.equal(vnc?.headers.get("cache-control"), "no-store");
+  assert.deepEqual(await vnc?.json(), {
+    grant: {
+      brokerUrl: "https://crabbox.example.test",
+      leaseId: "cbx_native123",
+      ticket: "native_vnc_0123456789abcdef0123456789abcdef",
+      expiresAt: 660_000,
+    },
+  });
+  assert.deepEqual(vncCalls, ["authenticate", "native-vnc:github:1:IS-257"]);
 
   const revokeCalls: string[] = [];
   const revoke = await dispatch(request("DELETE", "/api/native/v1/auth/token"), revokeCalls);
@@ -157,6 +183,7 @@ test("native bearer routes reject simultaneous trusted-proxy identity", async ()
     ["POST", "/api/native/v1/auth/token"],
     ["GET", "/api/native/v1/session"],
     ["GET", "/api/native/v1/fleet"],
+    ["POST", "/api/native/v1/sessions/IS-257/native-vnc"],
     ["DELETE", "/api/native/v1/auth/token"],
   ]) {
     await assert.rejects(dispatch(request(method, path), [], {}, authenticated), (error) => {
@@ -172,6 +199,8 @@ test("native routes fall through on inexact methods and paths", async () => {
     request("GET", "/api/native/v1/auth/token"),
     request("POST", "/api/native/v1/fleet", {}),
     request("GET", "/api/native/v2/fleet"),
+    request("POST", "/api/native/v1/sessions/IS-0/native-vnc"),
+    request("POST", "/api/native/v1/sessions/IS-257/native-vnc/extra"),
   ]) {
     assert.equal(await dispatch(value, []), null);
   }

--- a/tests/runtime-adapter-workspaces.test.ts
+++ b/tests/runtime-adapter-workspaces.test.ts
@@ -118,6 +118,50 @@ function runtimeAdapterSession(
   });
 }
 
+test("native VNC grants use the registered adapter and reject malformed credentials", async () => {
+  const calls: Array<{ input: string; init: RequestInit }> = [];
+  const service = new RuntimeAdapterWorkspaceLifecycle(
+    runtimeEnv(),
+    dependencies({
+      now: () => 1_000,
+      async fetch(input, init) {
+        calls.push({ input, init });
+        return Response.json({
+          schema: "crabbox/native-vnc-grant/v1",
+          brokerUrl: "https://crabbox.example.test",
+          leaseId: "cbx_native123",
+          ticket: "native_vnc_0123456789abcdef0123456789abcdef",
+          expiresAt: new Date(61_000).toISOString(),
+        });
+      },
+    }),
+  );
+
+  await assert.doesNotReject(
+    service.createNativeVNCGrant("default", "https://adapter.example.test/", "workspace-1"),
+  );
+  assert.deepEqual(calls, [
+    {
+      input: "https://adapter.example.test/v1/workspaces/workspace-1/connections/native-vnc",
+      init: { method: "POST" },
+    },
+  ]);
+
+  const malformed = new RuntimeAdapterWorkspaceLifecycle(
+    runtimeEnv(),
+    dependencies({
+      now: () => 1_000,
+      async fetch() {
+        return Response.json({ ticket: "secret" });
+      },
+    }),
+  );
+  await assert.rejects(
+    malformed.createNativeVNCGrant("default", "https://adapter.example.test/", "workspace-1"),
+    /invalid native VNC grant/u,
+  );
+});
+
 test("workspace inspection uses the registered control plane and bounded response parser", async () => {
   const requests: Array<{ url: string; method: string | undefined }> = [];
   let parsedResponses = 0;

--- a/tests/runtime-adapter.test.ts
+++ b/tests/runtime-adapter.test.ts
@@ -13,6 +13,7 @@ import {
   normalizeAdapterNamespace,
   normalizeAdapterWorkspaceId,
   parseAdapterDesktopConnection,
+  parseAdapterNativeVNCGrant,
   parseAdapterWorkspaceResult,
   redactedAdapterMessage,
   redactedAdapterResponseMessage,
@@ -21,6 +22,7 @@ import {
   runtimeAdapterCreatePayload,
   runtimeAdapterBrowserVncUrl,
   runtimeAdapterDesktopUrl,
+  runtimeAdapterNativeVNCUrl,
   runtimeAdapterReplayRequest,
   retainedRuntimeAdapterFailureMessage,
   runtimeAdapterStopOutcome,
@@ -1354,8 +1356,38 @@ test("adapter workspace paths use the controller id and encode it", () => {
     "https://controller.example/base/v1/workspaces/is-101/connections/desktop",
   );
   assert.equal(
+    runtimeAdapterNativeVNCUrl("https://controller.example/base", "is-101"),
+    "https://controller.example/base/v1/workspaces/is-101/connections/native-vnc",
+  );
+  assert.equal(
     runtimeAdapterBrowserVncUrl("https://fleet.example", "IS/101"),
     "https://fleet.example/api/interactive-sessions/IS%2F101/vnc",
+  );
+});
+
+test("native VNC grants are short-lived, secure, and strictly typed", () => {
+  const now = Date.parse("2026-06-26T00:00:00.000Z");
+  const value = {
+    schema: "crabbox/native-vnc-grant/v1",
+    brokerUrl: "https://crabbox.example.test",
+    leaseId: "cbx_native123",
+    ticket: "native_vnc_0123456789abcdef0123456789abcdef",
+    expiresAt: "2026-06-26T00:01:00.000Z",
+  };
+  assert.deepEqual(parseAdapterNativeVNCGrant(value, now), {
+    brokerUrl: value.brokerUrl,
+    leaseId: value.leaseId,
+    ticket: value.ticket,
+    expiresAt: now + 60_000,
+  });
+  assert.equal(
+    parseAdapterNativeVNCGrant({ ...value, brokerUrl: "http://example.test" }, now),
+    null,
+  );
+  assert.equal(parseAdapterNativeVNCGrant({ ...value, ticket: "native_vnc_secret" }, now), null);
+  assert.equal(
+    parseAdapterNativeVNCGrant({ ...value, expiresAt: "2026-06-26T00:03:00.000Z" }, now),
+    null,
   );
 });
 


### PR DESCRIPTION
## Summary

- expose a native-only, session-scoped endpoint that requests a one-time Crabbox VNC grant after fresh visibility/control checks
- publish Fleet session IDs instead of provider lease IDs to the macOS app
- pass grants to the Crabbox CLI through stdin and keep bridge teardown tied to viewer lifecycle

## Test plan

- `pnpm check`
- `pnpm test` (729 tests)
- `swift test --package-path macos/CrabfleetMac` (76 tests)
