### PR TITLE
[security] fix(agent): bind resource auth to path session

### DIFF
--- a/src/worker/routes/service-sessions.ts
+++ b/src/worker/routes/service-sessions.ts
@@ -15,7 +15,7 @@ export type ServiceSessionRouteDependencies = {
   updateAgentWorkState(request: Request, sessionId: string): Promise<unknown>;
   openAgentRunnerPty(request: Request, sessionId: string): Promise<Response>;
   requireSshViewer(request: Request): Promise<User>;
-  requireAgentUser(request: Request): Promise<User>;
+  requireAgentUser(request: Request, sessionId: string): Promise<User>;
   readFreshSession(user: User, sessionId: string): Promise<InteractiveSession | null>;
   presentSession(session: InteractiveSession, user: User): Promise<InteractiveSession | null>;
   mutateSession(request: Request, user: User, sessionId: string, action: string): Promise<unknown>;
@@ -70,7 +70,9 @@ export async function handleServiceSessionRoute(
   return handleInteractiveSessionResourceRoute(request, url, {
     basePath: `/api/${principal}/interactive-sessions`,
     requireUser:
-      principal === "ssh" ? dependencies.requireSshViewer : dependencies.requireAgentUser,
+      principal === "ssh"
+        ? dependencies.requireSshViewer
+        : (request) => dependencies.requireAgentUser(request, sessionId),
     readFreshSession: dependencies.readFreshSession,
     presentSession: dependencies.presentSession,
     readLogs: dependencies.readLogs,

--- a/src/worker/worker-application.ts
+++ b/src/worker/worker-application.ts
@@ -277,7 +277,8 @@ export class WorkerApplication {
         requireRole(user, "viewer");
         return user;
       },
-      requireAgentUser: async (request) => (await this.githubActions.authenticate(request)).user,
+      requireAgentUser: async (request, sessionId) =>
+        (await this.githubActions.authenticate(request, sessionId)).user,
       readFreshSession: (user, sessionId) => this.sessions.readFreshForUser(user, sessionId),
       presentSession: (session, user) => this.sessions.presentVisibleForUser(session, user),
       mutateSession: (request, user, sessionId, action) =>

--- a/tests/service-session-routes.test.ts
+++ b/tests/service-session-routes.test.ts
@@ -64,8 +64,8 @@ function dependencies(calls: string[]): ServiceSessionRouteDependencies {
       calls.push("auth:ssh");
       return sshUser;
     },
-    async requireAgentUser() {
-      calls.push("auth:agent");
+    async requireAgentUser(_request: Request, sessionId: string) {
+      calls.push(`auth:agent:${sessionId}`);
       return agentUser;
     },
     async readFreshSession(user: User, sessionId: string) {
@@ -157,7 +157,7 @@ test("service-session routes share read, log, transcript, and summary behavior b
     ],
     [
       request("GET", "/api/agent/interactive-sessions/IS%2F2"),
-      ["auth:agent", "read:agent-user:IS/2", "present:IS/2:agent-user"],
+      ["auth:agent:IS/2", "read:agent-user:IS/2", "present:IS/2:agent-user"],
     ],
     [
       request("GET", "/api/ssh/interactive-sessions/IS%2F2/logs"),
@@ -165,7 +165,7 @@ test("service-session routes share read, log, transcript, and summary behavior b
     ],
     [
       request("GET", "/api/agent/interactive-sessions/IS%2F2/logs"),
-      ["auth:agent", "logs:agent-user:IS/2"],
+      ["auth:agent:IS/2", "logs:agent-user:IS/2"],
     ],
     [
       request("POST", "/api/ssh/interactive-sessions/IS%2F2/summary", {}),
@@ -173,7 +173,7 @@ test("service-session routes share read, log, transcript, and summary behavior b
     ],
     [
       request("POST", "/api/agent/interactive-sessions/IS%2F2/summary", {}),
-      ["auth:agent", "summary:agent-user:IS/2"],
+      ["auth:agent:IS/2", "summary:agent-user:IS/2"],
     ],
   ];
 
@@ -191,7 +191,7 @@ test("service-session routes share read, log, transcript, and summary behavior b
     );
     assert.equal(result?.headers.get("x-handler"), "transcript");
     assert.deepEqual(calls, [
-      `auth:${principal}`,
+      principal === "ssh" ? "auth:ssh" : "auth:agent:IS/2",
       `transcript:${principal === "ssh" ? "ssh-user" : "agent-user"}:IS/2`,
     ]);
   }


### PR DESCRIPTION
## Summary

This PR hardens agent-scoped interactive-session resource routes so an agent credential is authenticated against the same session id named in the URL path.

- Fixes a path-binding gap where `/api/agent/interactive-sessions/:id/*` routes authenticated an agent token without passing the URL session id into the credential check.
- Prevents an agent token for one session from being reused against another session's generic resource routes such as logs and transcript.
- Keeps the existing SSH viewer path unchanged and preserves same-session agent access.
- Adds regression coverage that service-session routes pass the decoded path session id into agent authentication before reading session resources.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Agent session credential not bound to path-scoped resource id | A token for session A could authenticate as the agent user for A while requesting resource data for session B on shared-tenancy deployments. | Medium |

## Before this PR

- Generic agent resource routes delegated to `handleInteractiveSessionResourceRoute` with `requireAgentUser(request)` only.
- `AgentSessionAuthenticator.require()` can bind to an `expectedId`, but these URL-scoped routes did not provide one.
- In shared tenancy, the resulting synthetic agent viewer could pass visibility checks for unrelated sessions and reach resource readers such as logs/transcript.
- The service-session route tests asserted only that agent authentication happened, not that it was bound to the decoded path session id.

## After this PR

- Agent resource routes wrap `requireAgentUser` with the decoded URL `sessionId`.
- Worker wiring passes that expected id into `githubActions.authenticate(request, sessionId)`.
- Existing authenticator behavior now rejects requests where the presented agent session id/header does not match the URL-scoped resource id.
- Route regression tests now verify that agent auth receives `IS/2` before read/log/transcript/summary resource handling.

## Why this matters

Agent credentials are intended to represent one active interactive session. When a route is explicitly scoped as `/api/agent/interactive-sessions/:id/...`, the credential check needs to prove that the credential belongs to the same `:id`, not merely to any active agent session. Without that binding, a credential for one session can become a bearer credential for viewing unrelated session resources in deployments where shared tenancy makes sessions broadly visible.

## How this differs from related issue/PR

Related prior work in #35 added room-scoped Crabbox supervision and included checks to prevent room-service credentials from attaching children to unrelated session trees.

This PR covers a different boundary:

- **Different route family:** generic `/api/agent/interactive-sessions/:id/*` resource routes.
- **Different failure mode:** read-oriented resources authenticated an agent credential without passing the URL path id as the expected credential id.
- **Different impact:** cross-session access to existing resource readers such as logs/transcript, rather than attaching new child sessions to an unrelated room tree.

Both boundaries are useful: room lineage checks protect service-created session trees, while this patch ensures path-scoped agent resource reads remain credential-bound to the exact session in the URL.

## Attack flow

```text
attacker has an agent token for session IS-101
    -> sends request to /api/agent/interactive-sessions/IS-102/logs
        -> route authenticates the token without expectedId = IS-102
            -> shared-tenancy visibility admits the synthetic agent viewer
                -> logs/transcript for IS-102 can be returned
```

## Affected code

| Issue | Files |
|-------|-------|
| Agent session credential not bound to path-scoped resource id | `src/worker/routes/service-sessions.ts`, `src/worker/worker-application.ts`, `tests/service-session-routes.test.ts` |

## Root cause

Agent session credential not bound to path-scoped resource id:

- The route parsed and decoded `sessionId` from `/api/{ssh,agent}/interactive-sessions/:id`, but the generic agent resource path passed `dependencies.requireAgentUser` directly into the shared resource handler.
- Worker wiring then called `this.githubActions.authenticate(request)` without an expected id.
- The authenticator correctly supports expected-id binding, but this route path was not using it.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Agent session credential not bound to path-scoped resource id | 6.5 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` |

Rationale:

- The attacker needs a valid low-privilege agent/session credential, so this is not unauthenticated.
- The vulnerable behavior can be triggered over the network without user interaction.
- The direct impact is confidentiality of another session's logs/transcript data; this PR does not claim an integrity or availability impact for this route.

## Safe reproduction steps

1. On vulnerable code, create or simulate an agent credential for session `IS-101`.
2. Send a request to a different path-scoped resource, for example `/api/agent/interactive-sessions/IS-102/logs`, while presenting the `IS-101` credential/session id.
3. Observe that the route authenticates the `IS-101` agent user without requiring the credential to match `IS-102`, then proceeds to the `IS-102` resource reader when visibility allows it.
4. After this PR, the same mismatch is rejected by the existing `AgentSessionAuthenticator.require(request, expectedId)` check because the presented id and expected URL id differ.

## Expected vulnerable behavior

- A path-scoped agent resource route should never let an agent token for one session authenticate access to another session's resource path.
- Pre-patch, the generic agent resource route performed agent authentication without the URL path id, so the existing expected-id mismatch protection was bypassed for these resources.
- The safe proof signal is that the route-level regression now records agent auth as `auth:agent:IS/2` before log/transcript/summary/resource handling, proving the decoded path id is passed into authentication.

## Changes in this PR

- Changes `ServiceSessionRouteDependencies.requireAgentUser` to accept the decoded path `sessionId`.
- Wraps agent resource-route authentication so `handleInteractiveSessionResourceRoute` calls `requireAgentUser(request, sessionId)`.
- Updates `WorkerApplication.serviceSessionRoutes()` to call `githubActions.authenticate(request, sessionId)`.
- Updates service-session route tests to assert path-bound agent authentication for read, logs, transcript, and summary resource routes.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Route authorization | `src/worker/routes/service-sessions.ts` | Passes the decoded URL session id into agent authentication for generic resource routes. |
| Worker wiring | `src/worker/worker-application.ts` | Binds agent authentication to the expected session id. |
| Regression tests | `tests/service-session-routes.test.ts` | Verifies agent auth receives the decoded path id before resource access. |

## Maintainer impact

- Same-session agent resource requests continue to work.
- SSH viewer routes are unchanged.
- Agent-specialized routes that already passed the path id, such as work-state and runner PTY, keep their existing behavior.
- The patch is intentionally narrow and uses the existing authenticator mismatch check instead of adding a second authorization model.

## Fix rationale

The correct trust boundary is the session id encoded in the resource path. The existing authenticator already has the durable rule: if an expected id is supplied, any presented agent session id must match it, and the token hash must validate for that same credential. Passing the path id into that existing check keeps authorization centralized and avoids relying on later visibility checks to compensate for a credential/session mismatch.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused route/auth regression tests passed.
- [x] Full local test suite passed with generated hunt artifacts temporarily moved out of the worktree so repository formatting checks only evaluated project files.
- [x] Repository check script passed with generated hunt artifacts temporarily moved out of the worktree.
- [x] Docker/container focused regression test passed.
- [x] Whitespace diff check passed.

Executed with:

- `pnpm exec node --test --experimental-strip-types tests/session-agent-auth.test.ts tests/service-session-routes.test.ts`
- `pnpm test`
- `pnpm run check`
- `docker run --rm -v "$PWD":/repo:ro -w /repo node:22 node --test --experimental-strip-types tests/session-agent-auth.test.ts tests/service-session-routes.test.ts`
- `git diff --check`

## Disclosure notes

- This PR is bounded to path/session binding for generic agent resource routes.
- It does not claim unauthenticated access; the attacker condition is possession of a valid agent credential for a different session.
- No production credentials, tokens, or deployment-specific endpoints were used in validation.
- No unrelated source files are intentionally changed.
