### PR TITLE
[security] fix(terminal): validate browser websocket origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reject cross-origin browser terminal WebSocket handshakes before ambient session cookies can reach the terminal hub, while preserving authenticated service clients and originless non-browser clients, thanks @Hinotoi-agent.
 - Require every GitHub Actions session resume to prove the existing stable owner before rotating its agent credential, preventing ownerless `workKey` reuse from taking over another action session, thanks @Hinotoi-agent.
 - Fit the native Mac VNC desktop flush to the available window, continuously synchronize its remote resolution to the viewport and current display pixel density when supported, compact the surrounding controls, and use an available stable signing identity for local app bundles so Keychain access survives rebuilds.
 - Preserve the real same-origin `Origin` header on browser-approved native Mac authorization forms so Chromium can complete the device link without weakening CSRF validation.

--- a/docs/api.md
+++ b/docs/api.md
@@ -523,6 +523,8 @@ An adapter-reported `failed` workspace is not locally terminal until Crabfleet c
 
 Visible session owner, user with a current named viewer/controller grant, current delegated controller, SSH gateway linked-key identity, scoped session agent, or a public shared-link token for read-only sessions. In shared tenancy mode, legacy maintainer/owner visibility also applies. Multiplex WebSocket endpoint used by the Ghostty WASM session grid, Go CLI, and SSH gateway. One socket can subscribe to multiple interactive sessions, receive PTY output frames, resize terminals, and send input only when the current user has control.
 
+Cookie-authenticated browser handshakes must send an `Origin` that exactly matches the browser-visible request origin, including the configured trusted-proxy public origin when present. Cross-origin browser handshakes fail with `403` before the terminal hub accepts the socket. Authenticated SSH gateway and session-agent clients use their service credentials instead; originless handshakes remain available to non-browser clients.
+
 The wire format is a compact binary frame:
 
 ```text

--- a/src/worker/session-terminal-route.ts
+++ b/src/worker/session-terminal-route.ts
@@ -105,6 +105,7 @@ export function validateTerminalWebSocketOrigin(
   if (serviceAuthenticated) return;
 
   const origin = request.headers.get("origin");
+  // Browsers send Origin on WebSocket handshakes; originless clients are non-browser transports.
   if (!origin) return;
   if (origin !== browserRequestOrigin(request, env)) {
     throw forbidden("terminal websocket origin is invalid");

--- a/src/worker/session-terminal-route.ts
+++ b/src/worker/session-terminal-route.ts
@@ -5,8 +5,9 @@ import {
   runtimeAdapterTerminalOriginMatches,
   safeWebSocketUrl,
 } from "../runtime-adapter.ts";
+import { browserRequestOrigin } from "./deployment.ts";
 import type { RuntimeEnv } from "./env.ts";
-import { bearer } from "./http.ts";
+import { bearer, forbidden } from "./http.ts";
 import {
   requireRegisteredRuntimeAdapterControlPlane,
   runtimeAdapterToken,
@@ -94,4 +95,18 @@ export function interactiveTerminalHeaders(
   });
   if (authorization) headers.set("authorization", authorization);
   return headers;
+}
+
+export function validateTerminalWebSocketOrigin(
+  request: Request,
+  env: RuntimeEnv,
+  serviceAuthenticated: boolean,
+): void {
+  if (serviceAuthenticated) return;
+
+  const origin = request.headers.get("origin");
+  if (!origin) return;
+  if (origin !== browserRequestOrigin(request, env)) {
+    throw forbidden("terminal websocket origin is invalid");
+  }
 }

--- a/src/worker/worker-application.ts
+++ b/src/worker/worker-application.ts
@@ -48,7 +48,10 @@ import {
 import { readInteractiveSessionShareCredential } from "./session-repository.ts";
 import { ownsInteractiveSession } from "./session-access.ts";
 import { readSandboxFleetPolicies } from "./session-control-do.ts";
-import { interactiveTerminalRouteAvailable } from "./session-terminal-route.ts";
+import {
+  interactiveTerminalRouteAvailable,
+  validateTerminalWebSocketOrigin,
+} from "./session-terminal-route.ts";
 import { SharedSessionService, type SharedSessionServiceStore } from "./shared-session-service.ts";
 import { SshGateway } from "./ssh-gateway.ts";
 import { createWorkflowService, type WorkflowService } from "./workflow-service.ts";
@@ -147,8 +150,10 @@ export class WorkerApplication {
   sessionIngressRoutes(requestAuth: TrustedProxyAuthResult): SessionIngressRouteDependencies {
     return {
       readSharedSession: (sessionId, token) => this.sharedSessions().read(sessionId, token),
-      openTerminal: async (request) =>
-        this.terminal().open(request, await this.terminalHubUser(request, requestAuth)),
+      openTerminal: async (request) => {
+        validateTerminalWebSocketOrigin(request, this.env, this.isServiceTerminalRequest(request));
+        return this.terminal().open(request, await this.terminalHubUser(request, requestAuth));
+      },
     };
   }
 
@@ -379,6 +384,10 @@ export class WorkerApplication {
       return (await this.githubActions.authenticate(request)).user;
     }
     return optionalUser(request, this.env, requestAuth);
+  }
+
+  private isServiceTerminalRequest(request: Request): boolean {
+    return this.sshGateway().isRequest(request) || this.githubActions.isAgentRequest(request);
   }
 
   private async agentState(request: Request): Promise<Record<string, unknown>> {

--- a/tests/session-terminal-route.test.ts
+++ b/tests/session-terminal-route.test.ts
@@ -8,6 +8,7 @@ import {
   interactiveTerminalRouteAvailable,
   interactiveTerminalTarget,
   runtimeAdapterTerminalAuthorization,
+  validateTerminalWebSocketOrigin,
 } from "../src/worker/session-terminal-route.ts";
 import { interactiveSession } from "../src/worker/session-model.ts";
 import { sessionRow } from "./helpers/session-row.ts";
@@ -126,4 +127,86 @@ test("terminal headers carry canonical session context", () => {
   assert.equal(headers.get("x-crabbox-repo"), "openclaw/crabfleet");
   assert.equal(headers.get("x-crabbox-runtime"), "crabbox");
   assert.equal(headers.get("authorization"), "Bearer upstream");
+});
+
+test("browser terminal websocket origins must match the browser-visible request origin", () => {
+  const env = { CRABFLEET_CANONICAL_URL: "https://fleet.example" } as RuntimeEnv;
+
+  assert.doesNotThrow(() =>
+    validateTerminalWebSocketOrigin(
+      new Request("https://fleet.example/api/terminal/ws", {
+        headers: { origin: "https://fleet.example", upgrade: "websocket" },
+      }),
+      env,
+      false,
+    ),
+  );
+  assert.doesNotThrow(() =>
+    validateTerminalWebSocketOrigin(
+      new Request("https://tenant.localhost/api/terminal/ws", {
+        headers: { origin: "https://tenant.localhost", upgrade: "websocket" },
+      }),
+      env,
+      false,
+    ),
+  );
+  assert.doesNotThrow(() =>
+    validateTerminalWebSocketOrigin(
+      new Request("https://fleet.example/api/terminal/ws", {
+        headers: { upgrade: "websocket" },
+      }),
+      env,
+      false,
+    ),
+  );
+  assert.throws(
+    () =>
+      validateTerminalWebSocketOrigin(
+        new Request("https://fleet.example/api/terminal/ws", {
+          headers: { origin: "https://attacker.example", upgrade: "websocket" },
+        }),
+        env,
+        false,
+      ),
+    { message: "terminal websocket origin is invalid", status: 403 },
+  );
+  assert.doesNotThrow(() =>
+    validateTerminalWebSocketOrigin(
+      new Request("https://fleet.example/api/terminal/ws", {
+        headers: { origin: "https://attacker.example", upgrade: "websocket" },
+      }),
+      env,
+      true,
+    ),
+  );
+});
+
+test("trusted proxy public origin is the browser terminal websocket origin", () => {
+  const env = {
+    CRABFLEET_TRUSTED_PROXY_ORIGIN: "https://backend.example",
+    CRABFLEET_TRUSTED_PROXY_PUBLIC_ORIGIN: "https://fleet.example",
+    CRABFLEET_TRUSTED_PROXY_SECRET: "proxy-secret",
+    CRABFLEET_TRUSTED_PROXY_USER_HEADER: "x-user",
+  } as RuntimeEnv;
+
+  assert.doesNotThrow(() =>
+    validateTerminalWebSocketOrigin(
+      new Request("https://backend.example/api/terminal/ws", {
+        headers: { origin: "https://fleet.example", upgrade: "websocket" },
+      }),
+      env,
+      false,
+    ),
+  );
+  assert.throws(
+    () =>
+      validateTerminalWebSocketOrigin(
+        new Request("https://backend.example/api/terminal/ws", {
+          headers: { origin: "https://backend.example", upgrade: "websocket" },
+        }),
+        env,
+        false,
+      ),
+    { message: "terminal websocket origin is invalid", status: 403 },
+  );
 });


### PR DESCRIPTION
## Summary

This PR hardens the browser terminal WebSocket boundary so cross-site pages cannot reuse a signed-in user's ambient Crabfleet session cookie to open `/api/terminal/ws`.

- Adds an origin check before cookie/browser-authenticated terminal WebSocket upgrades are handed to the terminal hub.
- Compares `Origin` against the browser-visible request origin, using the trusted-proxy public origin when configured and the request URL origin otherwise.
- Preserves direct tenant/local browser origins and service-authenticated terminal paths for SSH gateway and GitHub Actions agent requests.
- Adds regression coverage for canonical same-origin, direct tenant/local same-origin, trusted-proxy public-origin, cross-origin rejection, non-browser clients without an `Origin`, and service-authenticated requests.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Missing Origin validation on browser terminal WebSocket | A malicious site loaded by an authenticated user could open the terminal WebSocket with the victim's ambient cookie, then interact with terminal sessions the victim is allowed to access. | High when terminal-control grants and session IDs are reachable in the deployment; otherwise Medium/High depending on exposure. |

## Before this PR

- `GET /api/terminal/ws` accepted browser WebSocket handshakes before enforcing a same-origin browser boundary.
- Browser-cookie authentication could flow through `optionalUser(...)` into `TerminalHub.open(...)` without comparing the handshake `Origin` to the browser-visible Crabfleet origin.
- Tests covered terminal routing and adapter-origin binding, but not the browser-origin boundary for the frontend terminal WebSocket.

## After this PR

- Non-service terminal WebSocket requests that include an `Origin` header must match `browserRequestOrigin(request, env)`.
- `browserRequestOrigin(...)` preserves trusted-proxy public-origin handling and otherwise uses the incoming request URL origin, so direct tenant/local browser terminals continue to work.
- Cross-origin browser handshakes are rejected with `403` before the terminal hub accepts the socket.
- SSH gateway and GitHub Actions agent terminal requests continue through the existing service-authenticated path.
- The new regression tests lock in the blocked cross-site case and the allowed same-origin, direct-origin, trusted-proxy, origin-less, and service-authenticated cases.

## Why this matters

WebSocket handshakes are not protected by ordinary same-origin reads: browsers can initiate cross-site WebSocket requests and include ambient cookies. For cookie-authenticated terminal access, the server must enforce the browser-visible origin before accepting the socket.

Without that check, a victim who is signed in to Crabfleet and visits an attacker-controlled page can be used as the authenticated principal for `/api/terminal/ws`. If the attacker knows or discovers a live session ID that the victim can view/control, the socket can expose terminal output and allow terminal input through the victim's grant.

## How this differs from related issue/PR

- PR #66 addressed a different agent-resource authorization issue: binding agent credentials to the path session for `/api/agent/interactive-sessions/:id/*` routes.
- This PR fixes the browser terminal WebSocket trust boundary: cross-site browser handshakes using ambient cookies on `/api/terminal/ws`.
- This revision also addresses the compatibility concern from review by using the repository's existing browser-visible origin helper rather than requiring `CRABFLEET_CANONICAL_URL` for every direct browser terminal connection.

## Attack flow

```text
Victim is signed in to Crabfleet and visits attacker.example
    -> attacker page opens wss://<crabfleet>/api/terminal/ws
        -> browser includes the victim's Crabfleet session cookie
            -> server accepts the socket without validating Origin
                -> attacker can subscribe to accessible terminal sessions and send input as the victim grant allows
```

## Affected code

| Issue | Files |
|-------|-------|
| Missing browser-origin check for terminal WebSocket | `src/worker/routes/session-ingress.ts`, `src/worker/worker-application.ts`, `src/worker/terminal-hub.ts`, `src/worker/session-terminal-route.ts` |

## Root cause

Missing Origin validation on browser terminal WebSocket:
- `/api/terminal/ws` entered the terminal hub through the session-ingress route and browser-cookie user resolution.
- The terminal hub validated the WebSocket upgrade and terminal authorization, but not the browser `Origin` that determines whether the handshake came from the Crabfleet app or an attacker-controlled page.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Missing Origin validation on browser terminal WebSocket | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N` |

Rationale:
- The attacker does not need Crabfleet credentials, but needs the victim to visit attacker-controlled content while signed in.
- Impact depends on the victim's terminal grants and session-ID discoverability, but the affected boundary can expose terminal output and permit terminal input under the victim's authorization.

## Safe reproduction steps

1. In a local test harness, construct a WebSocket upgrade request to `https://fleet.example/api/terminal/ws` with:
   - `Origin: https://attacker.example`
   - a placeholder authenticated browser session cookie
   - `Upgrade: websocket`
2. Route the request through the terminal ingress path with an authenticated browser user.
3. Observe pre-patch behavior: the terminal hub accepts the socket and sends the terminal welcome frame instead of rejecting the cross-origin browser handshake.
4. Apply this PR.
5. Observe patched behavior: `validateTerminalWebSocketOrigin(...)` rejects the cross-origin browser handshake with `403`, while same-origin, direct tenant/local-origin, trusted-proxy-public-origin, origin-less non-browser, and service-authenticated cases remain allowed.

## Expected vulnerable behavior

- A cross-site browser WebSocket handshake should never be able to use a victim's ambient Crabfleet session cookie unless the `Origin` matches the browser-visible request origin.
- Pre-patch, `/api/terminal/ws` could accept the socket before applying that browser-origin boundary.
- The safe proof signal is the explicit `403` rejection for `Origin: https://attacker.example` while representative allowed terminal paths still reach the accepted terminal welcome state.

## Runtime proof after fix

The proof harness drives the same terminal admission guard and `TerminalHub.open(...)` path with redacted cookies/tokens/host details. It proves the rejected exploit path plus representative allowed browser/direct/service terminal paths after the fix.

Executed locally:

```text
$ node --experimental-strip-types .huntpack/terminal-origin-runtime-proof.mjs
cross-origin browser terminal: REJECT status=403 message=terminal websocket origin is invalid origin=[REDACTED]
same-origin browser terminal: ACCEPT status=101 accepted=true welcome_type=2 origin=[REDACTED]
direct tenant browser terminal: ACCEPT status=101 accepted=true welcome_type=2 origin=[REDACTED]
service-authenticated terminal: ACCEPT status=101 accepted=true welcome_type=2 origin=[REDACTED]
```

Executed in Docker with Node 22:

```text
$ docker run --rm -v "$PWD":/repo:ro -w /repo node:22 node --experimental-strip-types .huntpack/terminal-origin-runtime-proof.mjs
cross-origin browser terminal: REJECT status=403 message=terminal websocket origin is invalid origin=[REDACTED]
same-origin browser terminal: ACCEPT status=101 accepted=true welcome_type=2 origin=[REDACTED]
direct tenant browser terminal: ACCEPT status=101 accepted=true welcome_type=2 origin=[REDACTED]
service-authenticated terminal: ACCEPT status=101 accepted=true welcome_type=2 origin=[REDACTED]
```

## Changes in this PR

- Adds `validateTerminalWebSocketOrigin(...)` beside the terminal route helpers.
- Checks browser-origin validity before dispatching `/api/terminal/ws` to `TerminalHub.open(...)`.
- Uses `browserRequestOrigin(request, env)` so trusted-proxy public origins and direct tenant/local origins are handled consistently with existing browser-visible URL behavior.
- Exempts SSH gateway and GitHub Actions agent terminal requests from the browser-origin check because they use service authentication rather than browser cookies.
- Adds regression tests covering same-origin browser requests, direct tenant/local-origin browser requests, trusted-proxy public-origin requests, cross-origin browser rejection, non-browser clients without an `Origin`, and service-authenticated requests.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Terminal origin guard | `src/worker/session-terminal-route.ts` | Adds the browser terminal WebSocket origin validator using `browserRequestOrigin(...)`. |
| Worker routing | `src/worker/worker-application.ts` | Calls the validator before opening the terminal hub and identifies service-authenticated terminal requests. |
| Tests | `tests/session-terminal-route.test.ts` | Adds regression coverage for terminal WebSocket origin handling, including direct tenant/local and trusted-proxy public-origin cases. |

## Maintainer impact

- The patch is intentionally narrow: it only changes `/api/terminal/ws` admission before the terminal hub accepts a socket.
- Browser users on the browser-visible Crabfleet origin continue to work.
- Direct tenant/local-origin browser terminal connections continue to work when the incoming request origin is the visible browser origin.
- Trusted-proxy deployments use the configured public origin.
- Non-browser clients without an `Origin` header continue to work.
- SSH gateway and GitHub Actions agent terminal paths remain on their existing service-authenticated behavior.
- No storage schema, frontend state, terminal protocol, or runtime-adapter routing changes are included.

## Fix rationale

- The terminal WebSocket boundary is the right place to enforce this because browser-origin validity must be decided before accepting the socket.
- `browserRequestOrigin(request, env)` matches existing deployment behavior: trusted-proxy public origin when configured, incoming request origin otherwise.
- Keeping the service-authenticated bypass explicit avoids breaking SSH/agent paths while closing the browser-cookie CSWSH case.
- The regression tests cover the security invariant and the compatibility cases highlighted in review.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused terminal/deployment route tests passed locally.
- [x] Focused terminal/deployment route tests passed in Docker with Node 22.
- [x] Redacted runtime proof shows cross-origin `403` and same-origin/direct-origin/service-authenticated terminal success locally and in Docker.
- [x] Repository check passed with generated `.huntpack/` audit artifacts temporarily moved out of the worktree.
- [x] Full test suite passed with generated `.huntpack/` audit artifacts temporarily moved out of the worktree.
- [x] `git diff --check` passed.

Executed with:
- `pnpm exec node --test --experimental-strip-types tests/session-terminal-route.test.ts tests/deployment.test.ts tests/terminal-hub.test.ts`
- `docker run --rm -v "$PWD":/repo:ro -w /repo node:22 node --test --experimental-strip-types tests/session-terminal-route.test.ts tests/deployment.test.ts tests/terminal-hub.test.ts`
- `node --experimental-strip-types .huntpack/terminal-origin-runtime-proof.mjs`
- `docker run --rm -v "$PWD":/repo:ro -w /repo node:22 node --experimental-strip-types .huntpack/terminal-origin-runtime-proof.mjs`
- `tmp=$(mktemp -d) && mv .huntpack "$tmp/huntpack" && trap 'mv "$tmp/huntpack" .huntpack; rmdir "$tmp"' EXIT && pnpm run check && pnpm test`
- `git diff --check`

Relevant pass summaries:

```text
# focused local
1..17
# tests 17
# pass 17
# fail 0

# focused Docker
1..17
# tests 17
# pass 17
# fail 0

# full suite
1..731
# tests 731
# pass 731
# fail 0
```

## Disclosure notes

- No production systems were tested.
- No real cookies, tokens, terminal contents, IPs, or private endpoints are included in this PR.
- The attack requires user interaction: the victim must load attacker-controlled content while signed in to Crabfleet.
- No unrelated files were changed.
