### PR TITLE
[security] fix(openclaw): require owner proof to resume action work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Require every GitHub Actions session resume to prove the existing stable owner before rotating its agent credential, preventing ownerless `workKey` reuse from taking over another action session, thanks @Hinotoi-agent.
 - Fit the native Mac VNC desktop flush to the available window, continuously synchronize its remote resolution to the viewport and current display pixel density when supported, compact the surrounding controls, and use an available stable signing identity for local app bundles so Keychain access survives rebuilds.
 - Preserve the real same-origin `Origin` header on browser-approved native Mac authorization forms so Chromium can complete the device link without weakening CSRF validation.
 - Connect desktop-capable Crabbox Fleet sessions directly in the macOS app through session-scoped, one-time Crabbox grants and a coordinator-backed VNC relay, without publishing provider lease IDs in Fleet or exposing coordinator SSH keys; grants reach the CLI only on stdin and helper teardown remains tied to viewer lifecycle.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Content-Type: application/json
 {"workKey":"openclaw/crabfleet:pr:42","workKind":"pr_repair","repo":"openclaw/crabfleet","branch":"fix/pr-42","owner":"operator@example.test","sourceUrl":"https://github.com/openclaw/crabfleet/pull/42","runUrl":"https://github.com/openclaw/crabfleet/actions/runs/123","purpose":"repair PR 42","summary":"starting repair"}
 ```
 
-The response contains `{session, agentToken, runnerPtyUrl, browserUrl}`. New work keys require `owner` to resolve to one active Crabfleet user; the stable subject owns browser visibility while the OpenClaw service retains lifecycle authority for its session. `runnerPtyUrl` includes the rotated session-scoped query credential and works directly with Node's global `WebSocket`:
+The response contains `{session, agentToken, runnerPtyUrl, browserUrl}`. New registrations and resumes require `owner` to resolve to one active Crabfleet user; resumes must prove the same stable owner subject already recorded on the `workKey`. The stable subject owns browser visibility while the OpenClaw service retains lifecycle authority for its session. `runnerPtyUrl` includes the rotated session-scoped query credential and works directly with Node's global `WebSocket`:
 
 ```js
 const terminal = new WebSocket(runnerPtyUrl);

--- a/docs/api.md
+++ b/docs/api.md
@@ -596,7 +596,7 @@ Response:
 }
 ```
 
-Every new work key requires `owner`; it must resolve to exactly one active Crabfleet user by login, email, or stable subject. Existing owned work keys can resume without repeating it, and a work key cannot transfer to a different stable owner. `runnerPtyUrl` is directly usable with Node's global `WebSocket`; no custom headers are required. The query credential is session-scoped, rotates on registration, is stored only as a hash, and is not exposed through viewer/session APIs.
+Every new registration and every resume requires `owner`; it must resolve to exactly one active Crabfleet user by login, email, or stable subject. Existing work keys resume only when the supplied owner resolves to the same stable owner subject already stored on the work key. Ownerless resumes fail closed before token rotation, and a work key cannot transfer to a different stable owner. `runnerPtyUrl` is directly usable with Node's global `WebSocket`; no custom headers are required. The query credential is session-scoped, rotates on registration, is stored only as a hash, and is not exposed through viewer/session APIs.
 
 ### GET /api/agent/interactive-sessions/:id/runner-pty
 

--- a/docs/github-actions-sessions.md
+++ b/docs/github-actions-sessions.md
@@ -108,18 +108,18 @@ Example:
 }
 ```
 
-Required fields:
+Required fields for both new registrations and resumes:
 
 - `workKey`
 - `workKind`
 - `repo`
+- `owner`, resolved to exactly one active Crabfleet user by login, email, or stable subject
 
-New work keys also require `owner`, resolved to exactly one active Crabfleet user by login, email, or stable subject. Existing owned work keys can resume without repeating it.
+When a request reuses an existing `workKey`, Crabfleet treats it as a resume only after the supplied `owner` resolves to the same stable owner subject already recorded on that work key. Ownerless resumes fail closed with `owner is required for GitHub Actions work` and do not rotate the agent token.
 
 Optional fields:
 
 - `branch`, default `main`
-- `owner` when resuming an existing owned work key
 - `sourceUrl`
 - `runUrl`
 - `purpose`

--- a/src/worker/github-actions-session-registration.ts
+++ b/src/worker/github-actions-session-registration.ts
@@ -101,8 +101,8 @@ export class GitHubActionsSessionRegistrationService {
     const agentTokenHash = await this.store.hashToken(agentToken);
     const now = this.store.now();
     let existing = await this.store.readByWorkKey(workKey);
-    if (!existing && !resolvedOwner) {
-      throw badRequest("owner is required for new GitHub Actions work");
+    if (!resolvedOwner) {
+      throw badRequest("owner is required for GitHub Actions work");
     }
     const purpose =
       boundedValue(input.purpose, 500) ||
@@ -120,8 +120,8 @@ export class GitHubActionsSessionRegistrationService {
         runUrl,
         purpose,
         summary,
-        owner: resolvedOwner!.actor,
-        ownerSubject: resolvedOwner!.subject,
+        owner: resolvedOwner.actor,
+        ownerSubject: resolvedOwner.subject,
         agentTokenHash,
         now,
       });

--- a/tests/github-actions-session-registration.test.ts
+++ b/tests/github-actions-session-registration.test.ts
@@ -179,7 +179,7 @@ test("GitHub Actions registration requires and persists a stable owner", async (
       workKind: "issue",
       repo: "openclaw/crabfleet",
     }),
-    { message: "owner is required for new GitHub Actions work" },
+    { message: "owner is required for GitHub Actions work" },
   );
 
   const owned = registrationStore();
@@ -212,6 +212,54 @@ test("GitHub Actions work keys cannot transfer between tenant owners", async () 
     }),
     { message: "workKey is already registered to a different owner" },
   );
+});
+
+test("GitHub Actions work keys cannot be resumed without proving the owner", async () => {
+  const existing = sessionRow({
+    id: "IS-owned",
+    runtime: "github_actions",
+    work_key: "issue:owned",
+    owner: "operator@example.test",
+    owner_subject: "github:42",
+  });
+  const { store, state } = registrationStore([existing]);
+
+  await assert.rejects(
+    new GitHubActionsSessionRegistrationService(store).register({
+      workKey: "issue:owned",
+      workKind: "issue",
+      repo: "openclaw/crabfleet",
+    }),
+    { message: "owner is required for GitHub Actions work" },
+  );
+  assert.equal(state.updates.length, 0);
+  assert.deepEqual(state.operations, ["repo:openclaw/crabfleet"]);
+});
+
+test("GitHub Actions work keys can be resumed by the matching owner", async () => {
+  const existing = sessionRow({
+    id: "IS-owned",
+    runtime: "github_actions",
+    work_key: "issue:owned",
+    work_state: "completed",
+    status: "stopped",
+    owner: "operator",
+    owner_subject: "github:42",
+  });
+  const { store, state } = registrationStore([existing]);
+
+  const result = await new GitHubActionsSessionRegistrationService(store).register({
+    workKey: "issue:owned",
+    workKind: "issue",
+    repo: "openclaw/crabfleet",
+    owner: "operator@example.test",
+  });
+
+  assert.equal(result.resumed, true);
+  assert.equal(result.session.id, "IS-owned");
+  assert.equal(state.updates[0]?.values.owner, "operator");
+  assert.equal(state.updates[0]?.values.owner_subject, "github:42");
+  assert.equal(state.updates[0]?.values.agent_token_hash, "agent-token-hash");
 });
 
 test("GitHub Actions rejects work keys without a stable owner", async () => {
@@ -255,6 +303,7 @@ test("resumed work preserves omitted links and resets terminal state", async () 
     workKey: "pull:200",
     workKind: "pull_request",
     repo: "openclaw/crabfleet",
+    owner: "operator@example.test",
   });
 
   assert.equal(result.resumed, true);
@@ -321,6 +370,7 @@ test("registration rejects invalid input and work keys owned by another runtime"
         workKey: "issue:container",
         workKind: "issue",
         repo: "openclaw/crabfleet",
+        owner: "operator@example.test",
       }),
     { message: "workKey is already registered to a different runtime" },
   );


### PR DESCRIPTION
## Summary

Require every GitHub Actions action-session registration, including resumes of an existing `workKey`, to present an owner that resolves to the existing stable owner subject before rotating the session agent token.

## Security issue

`POST /api/openclaw/action-sessions` accepts a service-token-authenticated registration body and uses `workKey` to find an existing GitHub Actions session. Before this change, `owner` was required only for new work. If the `workKey` already existed, a caller could omit `owner`, bypass the owner-subject mismatch check, reset the existing session, rotate `agent_token_hash`, and receive a fresh plaintext `agentToken` for that session.

That token authenticates as the session agent. In deployments where the OpenClaw automation token is shared across automation contexts/rooms/tenants or less-trusted service components, a known or guessed `workKey` could be used to hijack another action session.

## Root cause

The registration flow only rejected missing owner proof when no existing row was found:

```ts
let existing = await this.store.readByWorkKey(workKey);
if (!existing && !resolvedOwner) {
  throw badRequest("owner is required for new GitHub Actions work");
}
```

Later, the existing-owner mismatch guard only ran when an owner was supplied:

```ts
if (resolvedOwner && existing.owner_subject && existing.owner_subject !== resolvedOwner.subject) {
  throw badRequest("workKey is already registered to a different owner");
}
```

As a result, omitted-owner resumes skipped the stable-owner proof but still reached the token rotation/update path.

## Fix

- Require a resolved owner for all action-session registrations, not only new work.
- Keep the existing stable-owner mismatch check for resumes.
- Preserve successful resume behavior when the supplied owner matches the existing `owner_subject`.
- Update `README.md`, `docs/api.md`, and `docs/github-actions-sessions.md` so the public contract says `owner` is required for both new registrations and resumes, and ownerless resumes fail closed before token rotation.
- Add regressions for:
  - omitted-owner resume rejects without updating the session;
  - matching-owner resume succeeds and rotates only after owner proof;
  - wrong-owner resume still rejects;
  - existing registration behavior continues to require/persist stable owners.

## Runtime proof after fix

Local Worker proof against `wrangler dev --local` with local D1 state. Secrets, returned credentials, non-local endpoints, proof work keys, stable subjects, and token hashes are redacted. The local proof user was explicitly allowlisted in local D1 so the real Worker owner-resolution path succeeded.

Setup used local-only `.dev.vars` bindings for `CRABBOX_OPENCLAW_TOKEN` and `CRABBOX_TOKEN_ENCRYPTION_KEY`; those values are not committed.

```sh
pnpm exec wrangler d1 migrations apply DB --local --config wrangler.jsonc
pnpm exec wrangler d1 execute DB --local --config wrangler.jsonc --command '[seed local proof user and allow_entries]'
pnpm exec wrangler dev --local --ip 127.0.0.1 --port 8787 --config wrangler.jsonc
python3 .huntpack/capture-action-runtime-proof.py
```

Sanitized real endpoint output:

```text
Runtime proof against local wrangler Worker endpoint (sanitized):
workKey=proof:rankup-[REDACTED]
new registration with owner: status=201 session.id=IS-[REDACTED] agentToken=[REDACTED] owner=proof-operator ownerSubject=[REDACTED]
omitted-owner resume: status=400 error="owner is required for GitHub Actions work" token_rotated=False
matching-owner resume: status=201 session.id=IS-[SAME-REDACTED] agentToken=[REDACTED] token_rotated=True
DB proof: ownerless_reject_preserved_hash=True
```

This demonstrates the changed service behavior through the real Worker endpoint: ownerless resume rejects before agent-token hash rotation, while a matching-owner resume still succeeds and rotates the session-scoped agent token after owner proof.

## Validation

Focused local regression:

```sh
pnpm exec node --test --experimental-strip-types tests/github-actions-session-registration.test.ts
```

```text
1..12
# tests 12
# pass 12
# fail 0
```

Focused Docker regression:

```sh
docker run --rm \
  -v "$PWD":/repo:ro \
  -w /repo \
  node:22 \
  node --test --experimental-strip-types tests/github-actions-session-registration.test.ts
```

```text
1..12
# tests 12
# pass 12
# fail 0
```

Full local validation, with generated `.huntpack/` audit artifacts temporarily moved out of the worktree so repository formatting checks only covered project files:

```sh
pnpm run check && pnpm test
```

```text
Found 0 warnings and 0 errors.
All matched files use the correct format.
1..731
# tests 731
# pass 731
# fail 0
```

Diff hygiene:

```sh
git diff --check
```

passed with no output.

## Duplicate check

Searched open and closed PRs/issues for:

- `action-session owner`
- `action-sessions owner`
- `workKey agent token`
- `GitHub Actions workKey owner`
- `resume owner GitHub Actions session`
- `action session hijack`

No exact duplicate for omitted-owner `workKey` resume/token rotation was found. Adjacent historical PRs around room scoping, lifecycle cleanup, and terminal/embed access do not appear to enforce owner proof on this resume path.
