### PR TITLE
ci: pin Crabbox hydrate actions

### DIFF
--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -39,15 +39,15 @@ jobs:
     runs-on: [self-hosted, crabbox, openclaw, "${{ inputs.crabbox_runner_label }}"]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm


### PR DESCRIPTION
## Summary

- pin the Crabbox hydrate workflow's checkout, pnpm setup, and Node setup actions to immutable commit SHAs
- preserve the action versions currently selected by the existing tags
- align the last mutable workflow references with the repository's pinned-action policy

## Proof

- `actionlint .github/workflows/crabbox-hydrate.yml`
- `pnpm check`
- `pnpm test` (733/733)
- `git diff --check`
- structured Codex autoreview: clean, no accepted/actionable findings (0.94 confidence)

The manual hydrate workflow requires a live dynamic Crabbox runner/lease, so no standalone dispatch was appropriate for this metadata-only change.

## Risk

Low. One workflow file, +3/-3; the pinned SHAs resolve to the same checkout v6.0.3, pnpm/action-setup v6.0.8, and setup-node v6.4.0 releases selected before this change. No product behavior, changelog, version, tag, release, or publish mutation.
