### PR TITLE
feat(macos): UTF-8 clipboard, host clipboard sync, display selection, remote resize, and launch-at-login for Share This Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Exchange full UTF-8 clipboard text between the native Mac viewer, Share This Mac hosts, and any Extended Clipboard-capable VNC server by completing the RoyalVNCKit fork's extension stub, keeping Latin-1 cut text as the fallback and dropping malformed extension bodies without tearing down the connection.
+- Add persisted send-only and receive-only clipboard directions to the native viewer's focus toolbar; automatic sync respects the direction while the explicit Send and Get actions keep working.
+- Sync the host Mac's clipboard with the connected peer in both directions during Share This Mac sessions, with a pre-share opt-out, echo suppression, and the shared 1 MiB text bound; previously client cut text was discarded and the host never sent its clipboard.
+- Let Share This Mac capture a chosen display instead of always the primary one.
+- Honor viewer desktop-size requests in Share This Mac by announcing ExtendedDesktopSize, aspect-fitting the request up to the display's native pixel resolution, and re-targeting the live capture, so the shared desktop follows the viewer window.
+- Add a "Start sharing when I log in" toggle that registers the bundled app as a login item and auto-starts the private share for unattended access.
+- Fix Share This Mac connections on current macOS by binding the listener port wide and requiring the exact Tailscale local address per accepted connection before any protocol bytes; the previous required-local-endpoint bind made every accepted connection fail with EADDRINUSE.
+
 ## 0.3.0 - 2026-07-02
 
 - Reject cross-origin browser terminal WebSocket handshakes before ambient session cookies can reach the terminal hub, while preserving authenticated service clients and originless non-browser clients, thanks @Hinotoi-agent.

--- a/docs/macos-native-client.md
+++ b/docs/macos-native-client.md
@@ -41,12 +41,16 @@ polls or writes `NSPasteboard.general` directly. One app-owned coordinator sends
 only stable local text changes to the focused desktop, baselines rather than
 sending the existing clipboard on focus/connect, suppresses server echoes, and
 quarantines clipboard text received from background desktops. The focus toolbar
-provides explicit Send Clipboard and Get Clipboard recovery actions. Clipboard
+provides explicit Send Clipboard and Get Clipboard recovery actions plus a
+persisted sync direction: bidirectional, send-only, or receive-only. Directional
+modes gate only the automatic flows; the explicit actions still work. Clipboard
 sync remains opt-in. A deliberate local copy supersedes a quarantined value for
 the focused desktop. Versioned pasteboard snapshots and bounded SHA-256 echo
 fingerprints prevent delayed server echoes from erasing a newer copy without
-retaining clipboard history. Inbound and outbound text is capped at 1 MiB;
-standard RFB clipboard text must encode losslessly as ISO-8859-1, and
+retaining clipboard history. Inbound and outbound text is capped at 1 MiB.
+The connection advertises the RFB Extended Clipboard extension and exchanges
+full UTF-8 text with servers that negotiate it; against servers without the
+extension, standard cut text must encode losslessly as ISO-8859-1 and
 unsupported text is rejected instead of silently becoming empty data.
 
 ## Share This Mac
@@ -57,9 +61,18 @@ relay, Cloudflare, or the Crabfleet Worker.
 
 1. Tailscale status must report `BackendState=Running`, a valid active tailnet,
    an online signed-in user, and a CGNAT address in `100.64.0.0/10`.
-2. The app captures the main display at a bounded even resolution no larger
-   than 1600×1000 and encodes at most 15 Tight/JPEG frames per second.
-3. An RFB listener binds only to that exact Tailscale IPv4 address on port 5901.
+2. The app captures the selected display (default: main) at a bounded even
+   resolution no larger than 1600×1000 and encodes at most 15 Tight/JPEG frames
+   per second. When the connected viewer requests a desktop size, the host
+   re-targets the capture to aspect-fit that request up to the display's native
+   pixel resolution (bounded at 2560×1600), so the remote desktop follows the
+   viewer window.
+3. An RFB listener binds port 5901. Binding the Tailscale address directly is
+   not viable on current macOS — accepted Network-framework child connections
+   re-bind a required local endpoint and fail with `EADDRINUSE` — so instead
+   every accepted connection must prove it arrived on the exact Tailscale
+   address before the server emits a single protocol byte; connections on any
+   other interface are dropped immediately.
 4. Before sending the RFB banner or any framebuffer data, the app resolves the
    peer through `tailscale whois` and requires an authorized node with the same
    user ID and login as the host.
@@ -67,6 +80,15 @@ relay, Cloudflare, or the Crabfleet Worker.
    stable endpoint in the signed-in user's private Fleet registry. The receiving
    app discovers and directly connects that card with no VNC password. Quick
    Connect with the displayed `vnc://100.x.y.z:5901` address remains a fallback.
+6. Clipboard sync with the connected peer is on by default and can be disabled
+   before starting the share. Text copied on either Mac lands on the other
+   through Extended Clipboard UTF-8 when the viewer negotiates it, with
+   ISO-8859-1 cut text as the fallback; text that cannot be represented is
+   dropped rather than mangled.
+7. "Start sharing when I log in" registers the bundled app as a login item and
+   persists an auto-share preference, so the Mac comes back reachable after a
+   reboot without manual setup (the equivalent of `--share-this-mac` for
+   unattended hosts).
 
 After the first Screen Recording grant, restart the bundled app before starting
 the share. Ad-hoc development signatures do not provide a stable TCC identity,
@@ -107,16 +129,17 @@ from the build, or obtain written provenance approval.
 
 ## Current viewer limits
 
-- Text clipboard only; the current protocol path is ISO-8859-1, not complete
-  Unicode, image, or file clipboard support.
-- Clipboard mode is bidirectional or off, with explicit Send Clipboard and Get
-  Clipboard recovery. Directional send-only/receive-only modes remain future.
+- Text clipboard only. UTF-8 flows end to end when the server negotiates the
+  Extended Clipboard extension; image and file clipboard formats are not
+  implemented, and servers without the extension remain limited to ISO-8859-1.
 - The fleet deck uses paced framebuffer decoding plus cached previews, not six
   continuously rendering Metal surfaces. A production live mosaic should use
   one app-owned Metal compositor for zero-copy multi-tile rendering.
 - No input method editor integration.
-- Server-driven framebuffer resize works; client-requested remote resize does
-  not exist yet.
+- Client-requested remote resize works against servers that advertise
+  ExtendedDesktopSize, including Share This Mac hosts, which aspect-fit the
+  request instead of adopting arbitrary layouts; multi-screen layout requests
+  remain unsupported.
 - RoyalVNCKit provides raw TCP only. Generic production connections must remain
   bound to loopback behind an authenticated SSH tunnel; Share This Mac is the
   identity-gated tailnet exception.
@@ -125,10 +148,10 @@ from the build, or obtain written provenance approval.
   disabled until their parsers and cryptography are replaced or fully tested.
 - Password authentication uses a process-global DES key schedule. The fork
   serializes that path; replace it before concurrent password-auth sessions.
-- App-owned hosting is primary-display only, single-client, lossy Tight/JPEG,
-  and capped at 1600×1000 and 15 fps.
-- Host-to-client clipboard, audio, multi-display selection, display resize, and
-  unattended launch-at-login are not implemented.
+- App-owned hosting shares one selected display at a time to a single client,
+  as lossy Tight/JPEG at most 15 fps, capped at 1600×1000 until the viewer
+  requests a size (then up to native pixels, bounded at 2560×1600).
+- Audio is not implemented.
 - A connecting peer must be another device owned by the same Tailscale user.
   Team-wide or named-user sharing is intentionally unsupported.
 
@@ -136,8 +159,8 @@ from the build, or obtain written provenance approval.
 
 Keep further changes narrow and upstreamable:
 
-1. UTF-8 extended clipboard negotiation, advertised server limits, images,
-   files, and directional clipboard modes.
+1. Extended clipboard image and file formats on top of the existing UTF-8 text
+   negotiation.
 2. Public read-only framebuffer IOSurface plus update notifications so one
    Metal compositor can render all fleet previews without one drawable and
    command queue per card.

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/ClipboardCoordinator.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/ClipboardCoordinator.swift
@@ -32,12 +32,41 @@ final class ClipboardCoordinator: ObservableObject {
     }
   }
 
+  /// Which automatic flows are active; explicit Send/Get actions always work.
+  enum SyncDirection: String, CaseIterable, Identifiable {
+    case bidirectional
+    case sendOnly
+    case receiveOnly
+
+    var id: String { rawValue }
+
+    var title: String {
+      switch self {
+      case .bidirectional: "Send & Receive"
+      case .sendOnly: "Send Only"
+      case .receiveOnly: "Receive Only"
+      }
+    }
+  }
+
+  static let directionDefaultsKey = "org.openclaw.crabfleet.clipboard.direction"
+
   @Published private(set) var state: State = .off
   @Published private(set) var pendingRemoteTargetIDs: Set<String> = []
+
+  @Published var direction: SyncDirection {
+    didSet {
+      defaults.set(direction.rawValue, forKey: Self.directionDefaultsKey)
+      if direction == .receiveOnly {
+        candidate = nil
+      }
+    }
+  }
 
   private weak var focusedSession: (any ClipboardSessionEndpoint)?
   private var focusedTargetID: String?
   private let pasteboard: NSPasteboard
+  private let defaults: UserDefaults
   private let pollingInterval: TimeInterval
   private let originType = NSPasteboard.PasteboardType(
     "org.openclaw.crabfleet.clipboard-origin"
@@ -57,11 +86,16 @@ final class ClipboardCoordinator: ObservableObject {
 
   init(
     pasteboard: NSPasteboard = .general,
-    pollingInterval: TimeInterval = 0.15
+    pollingInterval: TimeInterval = 0.15,
+    defaults: UserDefaults = .standard
   ) {
     self.pasteboard = pasteboard
     self.pollingInterval = pollingInterval
+    self.defaults = defaults
     self.lastObservedChangeCount = pasteboard.changeCount
+    direction =
+      defaults.string(forKey: Self.directionDefaultsKey)
+      .flatMap(SyncDirection.init(rawValue:)) ?? .bidirectional
   }
 
   deinit {
@@ -127,6 +161,14 @@ final class ClipboardCoordinator: ObservableObject {
       focusedSession.isClipboardConnected
     else {
       pendingRemoteTargetIDs.insert(targetID)
+      return
+    }
+
+    // Send-only keeps remote text retrievable through Get Remote Clipboard
+    // without ever writing the Mac pasteboard automatically.
+    guard direction != .sendOnly else {
+      pendingRemoteTargetIDs.insert(targetID)
+      state = .remoteAvailable
       return
     }
 
@@ -221,6 +263,12 @@ final class ClipboardCoordinator: ObservableObject {
     }
     let text = snapshot.text
 
+    guard direction != .receiveOnly else {
+      lastObservedChangeCount = changeCount
+      candidate = nil
+      return
+    }
+
     if candidate?.changeCount == changeCount, candidate?.text == text {
       lastObservedChangeCount = changeCount
       candidate = nil
@@ -281,6 +329,11 @@ final class ClipboardCoordinator: ObservableObject {
       focusedSession.clipboardEnabled,
       focusedSession.isClipboardConnected
     else {
+      return
+    }
+
+    guard direction != .sendOnly else {
+      state = .synced
       return
     }
 

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/CrabfleetMacApp.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/CrabfleetMacApp.swift
@@ -12,6 +12,17 @@ enum PrivateMacShareLaunchMode {
   ) -> Bool {
     arguments.dropFirst().contains(argument) || environment[environmentKey] == "1"
   }
+
+  /// Explicit launch flags plus the persisted "start sharing when I log in"
+  /// preference set from the share sheet.
+  static func isRequested(
+    arguments: [String] = ProcessInfo.processInfo.arguments,
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    defaults: UserDefaults = .standard
+  ) -> Bool {
+    isEnabled(arguments: arguments, environment: environment)
+      || PrivateMacShareController.isAutoShareRequested(defaults: defaults)
+  }
 }
 
 enum VNCConnectionLaunchMode {
@@ -40,7 +51,7 @@ final class CrabfleetApplicationDelegate: NSObject, NSApplicationDelegate {
   private var autoShareTask: Task<Void, Never>?
 
   func applicationDidFinishLaunching(_ notification: Notification) {
-    guard PrivateMacShareLaunchMode.isEnabled() else { return }
+    guard PrivateMacShareLaunchMode.isRequested() else { return }
     NSApp.activate(ignoringOtherApps: true)
     let controller = PrivateMacShareController()
     shareController = controller

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/HostClipboard.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/HostClipboard.swift
@@ -1,0 +1,141 @@
+import AppKit
+import Foundation
+
+/// Synchronizes the host Mac's pasteboard with the connected RFB viewer while
+/// Share This Mac runs. The RFB session pulls snapshots and delivers client
+/// text from its background task; all pasteboard access happens on the main
+/// queue.
+protocol HostClipboardSyncing: AnyObject, Sendable {
+  /// Starts monitoring and forwards host pasteboard changes to `pusher`.
+  /// The current pasteboard content is baselined, not pushed.
+  func attach(pusher: @escaping @Sendable (String) -> Void)
+  func detach()
+
+  /// Applies clipboard text received from the connected viewer.
+  func receiveClientText(_ text: String)
+
+  /// Most recent host pasteboard text observed by the monitor.
+  func currentText() -> String?
+}
+
+final class HostClipboardBridge: HostClipboardSyncing, @unchecked Sendable {
+  private let pasteboard: NSPasteboard
+  private let pollingInterval: TimeInterval
+  private let lock = NSLock()
+  private var pusher: (@Sendable (String) -> Void)?
+  private var timer: Timer?
+  private var lastObservedChangeCount: Int?
+  private var suppressedChangeCount: Int?
+  private var lastKnownText: String?
+  private var lastAppliedClientText: String?
+
+  init(
+    pasteboard: NSPasteboard = .general,
+    pollingInterval: TimeInterval = 0.5
+  ) {
+    self.pasteboard = pasteboard
+    self.pollingInterval = pollingInterval
+  }
+
+  deinit {
+    timer?.invalidate()
+  }
+
+  func attach(pusher: @escaping @Sendable (String) -> Void) {
+    withLock {
+      self.pusher = pusher
+    }
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+      self.withLock {
+        self.lastObservedChangeCount = self.pasteboard.changeCount
+        self.suppressedChangeCount = nil
+        self.lastKnownText = self.pasteboard.string(forType: .string)
+      }
+      guard self.timer == nil else { return }
+      let timer = Timer.scheduledTimer(
+        withTimeInterval: self.pollingInterval,
+        repeats: true
+      ) { [weak self] _ in
+        self?.poll()
+      }
+      timer.tolerance = self.pollingInterval * 0.2
+      self.timer = timer
+    }
+  }
+
+  func detach() {
+    withLock {
+      pusher = nil
+      lastAppliedClientText = nil
+      suppressedChangeCount = nil
+    }
+    DispatchQueue.main.async { [weak self] in
+      self?.timer?.invalidate()
+      self?.timer = nil
+    }
+  }
+
+  func receiveClientText(_ text: String) {
+    guard text.utf8.count <= RFBWire.maximumClipboardBytes else { return }
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+      let alreadyCurrent = self.withLock { self.lastKnownText == text }
+      if alreadyCurrent {
+        self.withLock { self.lastAppliedClientText = text }
+        return
+      }
+      self.pasteboard.clearContents()
+      guard self.pasteboard.setString(text, forType: .string) else { return }
+      self.withLock {
+        self.suppressedChangeCount = self.pasteboard.changeCount
+        self.lastObservedChangeCount = self.pasteboard.changeCount
+        self.lastAppliedClientText = text
+        self.lastKnownText = text
+      }
+    }
+  }
+
+  func currentText() -> String? {
+    withLock { lastKnownText }
+  }
+
+  /// Runs one poll cycle; main-queue only. Internal for tests.
+  func poll() {
+    let changeCount = pasteboard.changeCount
+    let previous = withLock { lastObservedChangeCount }
+    guard changeCount != previous else { return }
+
+    let text = pasteboard.string(forType: .string)
+    guard pasteboard.changeCount == changeCount else { return }
+
+    var textToPush: String?
+    var pushHandler: (@Sendable (String) -> Void)?
+    withLock {
+      lastObservedChangeCount = changeCount
+      lastKnownText = text
+
+      if suppressedChangeCount == changeCount {
+        suppressedChangeCount = nil
+        return
+      }
+      guard let text, !text.isEmpty,
+        text != lastAppliedClientText,
+        text.utf8.count <= RFBWire.maximumClipboardBytes
+      else {
+        return
+      }
+      textToPush = text
+      pushHandler = pusher
+    }
+    if let textToPush, let pushHandler {
+      pushHandler(textToPush)
+    }
+  }
+
+  private func withLock<T>(_ body: () -> T) -> T {
+    lock.lock()
+    defer { lock.unlock() }
+    return body()
+  }
+}

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/MacRemoteInput.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/MacRemoteInput.swift
@@ -5,6 +5,11 @@ import Foundation
 protocol RemoteInputForwarding: Sendable {
   func keyEvent(down: Bool, keysym: UInt32)
   func pointerEvent(buttonMask: UInt8, x: UInt16, y: UInt16)
+  func updateFrameSize(width: Int, height: Int)
+}
+
+extension RemoteInputForwarding {
+  func updateFrameSize(width: Int, height: Int) {}
 }
 
 final class MacRemoteInputController: RemoteInputForwarding, @unchecked Sendable {
@@ -13,10 +18,24 @@ final class MacRemoteInputController: RemoteInputForwarding, @unchecked Sendable
     label: "org.openclaw.crabfleet.remote-input",
     qos: .userInteractive
   )
+  private let frameSizeLock = NSLock()
+  private var frameWidth: Int
+  private var frameHeight: Int
   private var previousButtonMask: UInt8 = 0
 
   init(descriptor: CapturedDisplayDescriptor) {
     self.descriptor = descriptor
+    frameWidth = descriptor.frameWidth
+    frameHeight = descriptor.frameHeight
+  }
+
+  /// Keeps pointer scaling aligned with the announced framebuffer size after
+  /// a client-requested desktop resize.
+  func updateFrameSize(width: Int, height: Int) {
+    frameSizeLock.lock()
+    frameWidth = width
+    frameHeight = height
+    frameSizeLock.unlock()
   }
 
   static var isAccessibilityGranted: Bool {
@@ -105,8 +124,12 @@ final class MacRemoteInputController: RemoteInputForwarding, @unchecked Sendable
   }
 
   private func mappedLocation(x: UInt16, y: UInt16) -> CGPoint {
-    let width = max(descriptor.frameWidth - 1, 1)
-    let height = max(descriptor.frameHeight - 1, 1)
+    frameSizeLock.lock()
+    let currentFrameWidth = frameWidth
+    let currentFrameHeight = frameHeight
+    frameSizeLock.unlock()
+    let width = max(currentFrameWidth - 1, 1)
+    let height = max(currentFrameHeight - 1, 1)
     let xRatio = min(max(CGFloat(x) / CGFloat(width), 0), 1)
     let yRatio = min(max(CGFloat(y) / CGFloat(height), 0), 1)
     return CGPoint(

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/MacScreenCapture.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/MacScreenCapture.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CoreImage
 import Foundation
 import ImageIO
@@ -33,6 +34,19 @@ struct CapturedDisplayDescriptor: Equatable, Sendable {
   let displayBounds: CGRect
   let frameWidth: Int
   let frameHeight: Int
+  let sourcePixelWidth: Int
+  let sourcePixelHeight: Int
+}
+
+struct ShareableDisplayOption: Identifiable, Equatable, Sendable {
+  let id: CGDirectDisplayID
+  let label: String
+  let width: Int
+  let height: Int
+
+  var detail: String {
+    "\(label) · \(width)×\(height)"
+  }
 }
 
 final class MacScreenCapture: NSObject, @unchecked Sendable {
@@ -49,18 +63,42 @@ final class MacScreenCapture: NSObject, @unchecked Sendable {
   private var sequence: UInt64 = 0
   private var consumerActive = false
   private var stream: SCStream?
+  private var configuration: SCStreamConfiguration?
 
-  func start() async throws -> CapturedDisplayDescriptor {
+  static func availableDisplays() async -> [ShareableDisplayOption] {
+    guard let shareableContent = try? await SCShareableContent.current else { return [] }
+    return shareableContent.displays.enumerated().map { index, display in
+      ShareableDisplayOption(
+        id: display.displayID,
+        label: Self.displayName(for: display.displayID) ?? "Display \(index + 1)",
+        width: display.width,
+        height: display.height
+      )
+    }
+  }
+
+  func start(displayID requestedDisplayID: CGDirectDisplayID? = nil) async throws
+    -> CapturedDisplayDescriptor
+  {
     guard CGPreflightScreenCaptureAccess() else {
       throw PrivateMacShareError.screenRecordingDenied
     }
 
-    let displayID = CGMainDisplayID()
     let shareableContent = try await SCShareableContent.current
-    guard let display = shareableContent.displays.first(where: { $0.displayID == displayID }) else {
+    // Fall back to the main display when a saved selection is disconnected.
+    let display =
+      shareableContent.displays.first(where: { $0.displayID == requestedDisplayID })
+      ?? shareableContent.displays.first(where: { $0.displayID == CGMainDisplayID() })
+    guard let display else {
       throw PrivateMacShareError.captureUnavailable
     }
+    let displayID = display.displayID
 
+    let sourcePixels = Self.sourcePixelDimensions(
+      displayID: displayID,
+      pointWidth: display.width,
+      pointHeight: display.height
+    )
     let dimensions = Self.captureDimensions(
       sourceWidth: display.width, sourceHeight: display.height)
     let configuration = SCStreamConfiguration()
@@ -78,18 +116,32 @@ final class MacScreenCapture: NSObject, @unchecked Sendable {
     try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: captureQueue)
     try await stream.startCapture()
     self.stream = stream
+    self.configuration = configuration
 
     return CapturedDisplayDescriptor(
       displayID: displayID,
       displayBounds: CGDisplayBounds(displayID),
       frameWidth: dimensions.width,
-      frameHeight: dimensions.height
+      frameHeight: dimensions.height,
+      sourcePixelWidth: sourcePixels.width,
+      sourcePixelHeight: sourcePixels.height
     )
+  }
+
+  /// Re-targets the running stream to a new output size for remote-resize.
+  func updateOutputSize(width: Int, height: Int) async throws {
+    guard let stream, let configuration else {
+      throw PrivateMacShareError.captureUnavailable
+    }
+    configuration.width = width
+    configuration.height = height
+    try await stream.updateConfiguration(configuration)
   }
 
   func stop() async {
     guard let stream else { return }
     self.stream = nil
+    self.configuration = nil
     try? await stream.stopCapture()
     await frameStore.clear()
   }
@@ -112,6 +164,50 @@ final class MacScreenCapture: NSObject, @unchecked Sendable {
     let scaledWidth = max(2, Int((width * scale).rounded(.down)) & ~1)
     let scaledHeight = max(2, Int((height * scale).rounded(.down)) & ~1)
     return (scaledWidth, scaledHeight)
+  }
+
+  /// Aspect-fits the captured display into a client-requested framebuffer
+  /// size, bounded by the display's native pixel resolution and a global cap.
+  static func resizedDimensions(
+    requestedWidth: Int,
+    requestedHeight: Int,
+    sourcePixelWidth: Int,
+    sourcePixelHeight: Int
+  ) -> (width: Int, height: Int) {
+    let maximumWidth = 2_560.0
+    let maximumHeight = 1_600.0
+    let requestWidth = min(max(Double(requestedWidth), 320), maximumWidth)
+    let requestHeight = min(max(Double(requestedHeight), 240), maximumHeight)
+    let sourceWidth = max(Double(sourcePixelWidth), 1)
+    let sourceHeight = max(Double(sourcePixelHeight), 1)
+    let scale = min(1, requestWidth / sourceWidth, requestHeight / sourceHeight)
+    let width = max(2, Int((sourceWidth * scale).rounded(.down)) & ~1)
+    let height = max(2, Int((sourceHeight * scale).rounded(.down)) & ~1)
+    return (width, height)
+  }
+
+  private static func sourcePixelDimensions(
+    displayID: CGDirectDisplayID,
+    pointWidth: Int,
+    pointHeight: Int
+  ) -> (width: Int, height: Int) {
+    guard let mode = CGDisplayCopyDisplayMode(displayID) else {
+      return (pointWidth, pointHeight)
+    }
+    return (mode.pixelWidth, mode.pixelHeight)
+  }
+
+  private static func displayName(for displayID: CGDirectDisplayID) -> String? {
+    for screen in NSScreen.screens {
+      let key = NSDeviceDescriptionKey("NSScreenNumber")
+      guard let number = screen.deviceDescription[key] as? NSNumber,
+        number.uint32Value == displayID
+      else {
+        continue
+      }
+      return screen.localizedName
+    }
+    return nil
   }
 
   private func nextSequence() -> UInt64 {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CoreGraphics
 import Foundation
+import ServiceManagement
 
 enum PrivateMacSharePermissionPolicy {
   static func canStart(
@@ -58,6 +59,9 @@ final class PrivateMacShareController: ObservableObject {
   }
 
   static let port: UInt16 = 5_901
+  nonisolated static let selectedDisplayDefaultsKey = "org.openclaw.crabfleet.share.display"
+  nonisolated static let clipboardSyncDefaultsKey = "org.openclaw.crabfleet.share.clipboard"
+  nonisolated static let autoShareDefaultsKey = "org.openclaw.crabfleet.share.auto-share"
 
   @Published private(set) var identity: TailnetIdentity?
   @Published private(set) var phase: Phase = .idle
@@ -68,21 +72,44 @@ final class PrivateMacShareController: ObservableObject {
   @Published private(set) var notice: String?
   @Published private(set) var isRefreshing = false
   @Published private(set) var registryPhase: RegistryPhase
+  @Published private(set) var availableDisplays: [ShareableDisplayOption] = []
+  @Published private(set) var launchAtLoginEnabled = false
+
+  @Published var selectedDisplayID: CGDirectDisplayID {
+    didSet {
+      defaults.set(Int(selectedDisplayID), forKey: Self.selectedDisplayDefaultsKey)
+    }
+  }
+
+  @Published var clipboardSyncEnabled: Bool {
+    didSet {
+      defaults.set(clipboardSyncEnabled, forKey: Self.clipboardSyncDefaultsKey)
+    }
+  }
 
   private let runner: (any TailscaleCommandRunning)?
   private let desktopRegistration: (any DesktopHostRegistering)?
   private let runnerInitializationError: Error?
+  private let defaults: UserDefaults
   private var capture: MacScreenCapture?
   private var server: TailnetRFBServer?
+  private var clipboardBridge: HostClipboardBridge?
   private var serverGeneration: UUID?
   private var registrationTask: Task<Void, Never>?
 
   init(
     runner: (any TailscaleCommandRunning)? = nil,
-    desktopRegistration: (any DesktopHostRegistering)? = CrabfleetDesktopRegistration()
+    desktopRegistration: (any DesktopHostRegistering)? = CrabfleetDesktopRegistration(),
+    defaults: UserDefaults = .standard
   ) {
     self.desktopRegistration = desktopRegistration
+    self.defaults = defaults
     registryPhase = desktopRegistration == nil ? .notConfigured : .registering
+    let savedDisplayID = defaults.object(forKey: Self.selectedDisplayDefaultsKey) as? Int
+    selectedDisplayID = savedDisplayID.map(CGDirectDisplayID.init) ?? CGMainDisplayID()
+    clipboardSyncEnabled =
+      defaults.object(forKey: Self.clipboardSyncDefaultsKey) as? Bool ?? true
+    launchAtLoginEnabled = SMAppService.mainApp.status == .enabled
     if let runner {
       self.runner = runner
       runnerInitializationError = nil
@@ -115,7 +142,40 @@ final class PrivateMacShareController: ObservableObject {
     notice = nil
     await loadIdentity()
     refreshPermissions()
+    await refreshDisplays()
+    launchAtLoginEnabled = SMAppService.mainApp.status == .enabled
     isRefreshing = false
+  }
+
+  /// Registers or removes the login item and remembers to auto-start the
+  /// share on launch, so this Mac stays reachable without manual setup.
+  func setLaunchAtLogin(_ enabled: Bool) {
+    do {
+      if enabled {
+        try SMAppService.mainApp.register()
+      } else {
+        try SMAppService.mainApp.unregister()
+      }
+      defaults.set(enabled, forKey: Self.autoShareDefaultsKey)
+      launchAtLoginEnabled = SMAppService.mainApp.status == .enabled
+    } catch {
+      launchAtLoginEnabled = SMAppService.mainApp.status == .enabled
+      notice =
+        "Could not update the login item: \(error.localizedDescription) "
+        + "(requires the bundled app, not a bare executable)"
+    }
+  }
+
+  nonisolated static func isAutoShareRequested(defaults: UserDefaults = .standard) -> Bool {
+    guard defaults.bool(forKey: autoShareDefaultsKey) else { return false }
+    guard SMAppService.mainApp.status == .enabled else {
+      // The login item was disabled outside the app (for example in System
+      // Settings); drop the stale request so a manual launch does not start
+      // sharing unexpectedly.
+      defaults.set(false, forKey: autoShareDefaultsKey)
+      return false
+    }
+    return true
   }
 
   func requestScreenRecordingPermission() async {
@@ -165,8 +225,9 @@ final class PrivateMacShareController: ObservableObject {
 
     let capture = MacScreenCapture()
     do {
-      let descriptor = try await capture.start()
+      let descriptor = try await capture.start(displayID: selectedDisplayID)
       let input = MacRemoteInputController(descriptor: descriptor)
+      let bridge = clipboardSyncEnabled ? HostClipboardBridge() : nil
       let generation = UUID()
       serverGeneration = generation
       let server = TailnetRFBServer(
@@ -175,6 +236,7 @@ final class PrivateMacShareController: ObservableObject {
         capture: capture,
         descriptor: descriptor,
         input: input,
+        clipboard: bridge,
         port: Self.port,
         eventHandler: { [weak self] event in
           Task { @MainActor in self?.handle(event, generation: generation) }
@@ -183,6 +245,7 @@ final class PrivateMacShareController: ObservableObject {
       try server.start()
       self.capture = capture
       self.server = server
+      self.clipboardBridge = bridge
     } catch {
       serverGeneration = nil
       await capture.stop()
@@ -200,6 +263,8 @@ final class PrivateMacShareController: ObservableObject {
     serverGeneration = nil
     server?.stop()
     server = nil
+    clipboardBridge?.detach()
+    clipboardBridge = nil
     let capture = capture
     self.capture = nil
     await capture?.stop()
@@ -253,6 +318,19 @@ final class PrivateMacShareController: ObservableObject {
     accessibilityGranted = MacRemoteInputController.isAccessibilityGranted
   }
 
+  private func refreshDisplays() async {
+    guard screenRecordingGranted else {
+      availableDisplays = []
+      return
+    }
+    let displays = await MacScreenCapture.availableDisplays()
+    availableDisplays = displays
+    if !displays.isEmpty, !displays.contains(where: { $0.id == selectedDisplayID }) {
+      selectedDisplayID =
+        displays.first(where: { $0.id == CGMainDisplayID() })?.id ?? displays[0].id
+    }
+  }
+
   private func handle(_ event: TailnetRFBServerEvent, generation: UUID) {
     guard serverGeneration == generation else { return }
     switch event {
@@ -281,6 +359,8 @@ final class PrivateMacShareController: ObservableObject {
       serverGeneration = nil
       server?.stop()
       server = nil
+      clipboardBridge?.detach()
+      clipboardBridge = nil
       let failedCapture = capture
       capture = nil
       Task { await failedCapture?.stop() }

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
@@ -64,6 +64,40 @@ struct PrivateMacShareSheet: View {
       }
       .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
 
+      VStack(alignment: .leading, spacing: 10) {
+        if controller.availableDisplays.count > 1 {
+          Picker("Shared display", selection: $controller.selectedDisplayID) {
+            ForEach(controller.availableDisplays) { display in
+              Text(display.detail).tag(display.id)
+            }
+          }
+          .disabled(controller.phase.isRunning)
+          .help(
+            controller.phase.isRunning
+              ? "Stop sharing to switch displays."
+              : "Which display the connected peer sees."
+          )
+        }
+
+        Toggle(
+          "Sync clipboard with the connected device",
+          isOn: $controller.clipboardSyncEnabled
+        )
+        .disabled(controller.phase.isRunning)
+        .help("Text copied on either Mac is available on the other while connected.")
+
+        Toggle(
+          "Start sharing when I log in",
+          isOn: Binding(
+            get: { controller.launchAtLoginEnabled },
+            set: { controller.setLaunchAtLogin($0) }
+          )
+        )
+        .help("Adds Crabfleet as a login item and starts this private share automatically.")
+      }
+      .toggleStyle(.switch)
+      .controlSize(.small)
+
       if controller.phase.isRunning, let address = controller.connectionAddress {
         VStack(alignment: .leading, spacing: 10) {
           Text("CONNECT FROM YOUR OTHER MAC")

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/RFBWire.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/RFBWire.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RoyalVNCKit
 
 enum RFBVersion: Comparable, Sendable {
   case v3Point3
@@ -100,7 +101,12 @@ struct RFBPixelFormat: Equatable, Sendable {
 
 enum RFBWire {
   static let tightEncoding: Int32 = 7
+  static let extendedDesktopSizeEncoding: Int32 = -308
+  static let extendedClipboardEncoding = Int32(bitPattern: 0xc0a1_e5ce)
   static let maximumClipboardBytes = 1 * 1_024 * 1_024
+
+  /// Flags word plus the codec's bounded compressed payload.
+  static let maximumExtendedClipboardBodyBytes = 4 + VNCExtendedClipboard.maximumBodyBytes
 
   static func serverInit(width: Int, height: Int, name: String) throws -> Data {
     guard
@@ -145,6 +151,59 @@ enum RFBWire {
     data.append(0x90)  // Tight JPEG subencoding
     data.append(tightCompactLength(frame.jpegData.count))
     data.append(frame.jpegData)
+    return data
+  }
+
+  /// FramebufferUpdate carrying a single ExtendedDesktopSize pseudo-rectangle.
+  /// `reason` and `status` use the RFB screen-layout codes; the single screen
+  /// uses a stable non-zero id so clients register a screen-layout change.
+  static func extendedDesktopSizeUpdate(
+    reason: UInt16,
+    status: UInt16,
+    width: Int,
+    height: Int
+  ) throws -> Data {
+    guard
+      (1...Int(UInt16.max)).contains(width),
+      (1...Int(UInt16.max)).contains(height)
+    else {
+      throw PrivateMacShareError.protocolError("invalid desktop size")
+    }
+
+    var data = Data(capacity: 36)
+    data.append(0)  // FramebufferUpdate
+    data.append(0)  // padding
+    data.appendBigEndian(UInt16(1))
+    data.appendBigEndian(reason)
+    data.appendBigEndian(status)
+    data.appendBigEndian(UInt16(width))
+    data.appendBigEndian(UInt16(height))
+    data.appendBigEndian(extendedDesktopSizeEncoding)
+    data.append(1)  // number of screens
+    data.append(contentsOf: [0, 0, 0])
+    data.appendBigEndian(UInt32(1))  // screen id
+    data.appendBigEndian(UInt16(0))
+    data.appendBigEndian(UInt16(0))
+    data.appendBigEndian(UInt16(width))
+    data.appendBigEndian(UInt16(height))
+    data.appendBigEndian(UInt32(0))  // flags
+    return data
+  }
+
+  /// Legacy Latin-1 ServerCutText. Returns nil when the text cannot be
+  /// represented losslessly or exceeds the clipboard limit.
+  static func legacyServerCutText(text: String) -> Data? {
+    guard let encoded = text.data(using: .isoLatin1),
+      encoded.count <= maximumClipboardBytes
+    else {
+      return nil
+    }
+
+    var data = Data(capacity: 8 + encoded.count)
+    data.append(3)  // ServerCutText
+    data.append(contentsOf: [0, 0, 0])
+    data.appendBigEndian(UInt32(encoded.count))
+    data.append(encoded)
     return data
   }
 

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/SessionWorkspaceView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/SessionWorkspaceView.swift
@@ -99,6 +99,13 @@ private struct FocusToolbar: View {
             }
             .disabled(!clipboard.hasRemoteClipboard(for: target.id))
             Divider()
+            Picker("Sync Direction", selection: $clipboard.direction) {
+              ForEach(ClipboardCoordinator.SyncDirection.allCases) { direction in
+                Text(direction.title).tag(direction)
+              }
+            }
+            .pickerStyle(.inline)
+            Divider()
             Text(clipboard.state.title)
           } label: {
             FocusControlPill(

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetIdentity.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetIdentity.swift
@@ -308,7 +308,11 @@ struct TailscaleWhoisDocument: Decodable, Sendable {
   }
 }
 
-struct TailnetPeerAuthorizer: Sendable {
+protocol TailnetPeerAuthorizing: Sendable {
+  func authorize(remoteAddress: String) async -> Bool
+}
+
+struct TailnetPeerAuthorizer: TailnetPeerAuthorizing, Sendable {
   let runner: any TailscaleCommandRunning
   let expectedIdentity: TailnetIdentity
 

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetRFBServer.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetRFBServer.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Network
+import RoyalVNCKit
 
 enum TailnetRFBServerEvent: Equatable, Sendable {
   case listening
@@ -18,6 +19,8 @@ final class TailnetRFBServer: @unchecked Sendable {
   private let capture: MacScreenCapture
   private let descriptor: CapturedDisplayDescriptor
   private let input: any RemoteInputForwarding
+  private let clipboard: (any HostClipboardSyncing)?
+  private let peerAuthorizer: (any TailnetPeerAuthorizing)?
   private let port: UInt16
   private let queue = DispatchQueue(label: "org.openclaw.crabfleet.rfb-listener")
   private let lock = NSLock()
@@ -31,6 +34,8 @@ final class TailnetRFBServer: @unchecked Sendable {
     capture: MacScreenCapture,
     descriptor: CapturedDisplayDescriptor,
     input: any RemoteInputForwarding,
+    clipboard: (any HostClipboardSyncing)? = nil,
+    peerAuthorizer: (any TailnetPeerAuthorizing)? = nil,
     port: UInt16,
     eventHandler: @escaping EventHandler
   ) {
@@ -39,20 +44,23 @@ final class TailnetRFBServer: @unchecked Sendable {
     self.capture = capture
     self.descriptor = descriptor
     self.input = input
+    self.clipboard = clipboard
+    self.peerAuthorizer = peerAuthorizer
     self.port = port
     self.eventHandler = eventHandler
   }
 
   func start() throws {
+    // A listener with `requiredLocalEndpoint` hands out child connections
+    // that re-bind that endpoint and fail with EADDRINUSE on current macOS,
+    // so the port binds wide and every accepted connection must instead prove
+    // it arrived on the expected local address before any protocol bytes.
     let parameters = NWParameters.tcp
+    parameters.allowLocalEndpointReuse = true
     guard let listenerPort = NWEndpoint.Port(rawValue: port) else {
       throw PrivateMacShareError.listenerFailed("invalid port")
     }
-    parameters.requiredLocalEndpoint = .hostPort(
-      host: NWEndpoint.Host(identity.ipv4Address),
-      port: listenerPort
-    )
-    let listener = try NWListener(using: parameters)
+    let listener = try NWListener(using: parameters, on: listenerPort)
     listener.stateUpdateHandler = { [weak self] state in
       guard let self else { return }
       switch state {
@@ -93,16 +101,20 @@ final class TailnetRFBServer: @unchecked Sendable {
       return
     }
 
-    let authorizer = TailnetPeerAuthorizer(
-      runner: runner,
-      expectedIdentity: identity
-    )
+    let authorizer =
+      peerAuthorizer
+      ?? TailnetPeerAuthorizer(
+        runner: runner,
+        expectedIdentity: identity
+      )
     let newSession = RFBHostSession(
       connection: connection,
       authorizer: authorizer,
-      frameStore: capture.frameStore,
+      capture: capture,
       descriptor: descriptor,
       input: input,
+      clipboard: clipboard,
+      requiredLocalAddress: identity.ipv4Address,
       desktopName: "Crabfleet — \(identity.hostName)",
       didAuthorize: { [weak capture] in capture?.setConsumerActive(true) },
       eventHandler: eventHandler,
@@ -132,10 +144,12 @@ final class TailnetRFBServer: @unchecked Sendable {
 
 private final class RFBHostSession: @unchecked Sendable {
   private let connection: NWConnection
-  private let authorizer: TailnetPeerAuthorizer
-  private let frameStore: CapturedDesktopFrameStore
+  private let authorizer: any TailnetPeerAuthorizing
+  private let capture: MacScreenCapture
   private let descriptor: CapturedDisplayDescriptor
   private let input: any RemoteInputForwarding
+  private let clipboard: (any HostClipboardSyncing)?
+  private let requiredLocalAddress: String
   private let desktopName: String
   private let didAuthorize: @Sendable () -> Void
   private let queue = DispatchQueue(label: "org.openclaw.crabfleet.rfb-session")
@@ -145,13 +159,26 @@ private final class RFBHostSession: @unchecked Sendable {
   private var started = false
   private var finished = false
   private var task: Task<Void, Never>?
+  private var pushIO: RFBConnectionIO?
+
+  // Negotiated per-connection state; only the protocol task mutates it.
+  private var supportsTightEncoding = false
+  private var supportsExtendedDesktopSize = false
+  private var supportsExtendedClipboard = false
+  private var sentServerClipboardCaps = false
+  private var needsDesktopSizeAnnounce = false
+  private var clientClipboardCaps: VNCExtendedClipboardCaps?
+  private var currentWidth: Int
+  private var currentHeight: Int
 
   init(
     connection: NWConnection,
-    authorizer: TailnetPeerAuthorizer,
-    frameStore: CapturedDesktopFrameStore,
+    authorizer: any TailnetPeerAuthorizing,
+    capture: MacScreenCapture,
     descriptor: CapturedDisplayDescriptor,
     input: any RemoteInputForwarding,
+    clipboard: (any HostClipboardSyncing)?,
+    requiredLocalAddress: String,
     desktopName: String,
     didAuthorize: @escaping @Sendable () -> Void,
     eventHandler: @escaping TailnetRFBServer.EventHandler,
@@ -159,13 +186,17 @@ private final class RFBHostSession: @unchecked Sendable {
   ) {
     self.connection = connection
     self.authorizer = authorizer
-    self.frameStore = frameStore
+    self.capture = capture
     self.descriptor = descriptor
     self.input = input
+    self.clipboard = clipboard
+    self.requiredLocalAddress = requiredLocalAddress
     self.desktopName = desktopName
     self.didAuthorize = didAuthorize
     self.eventHandler = eventHandler
     self.didFinish = didFinish
+    currentWidth = descriptor.frameWidth
+    currentHeight = descriptor.frameHeight
   }
 
   func start() {
@@ -214,9 +245,19 @@ private final class RFBHostSession: @unchecked Sendable {
   }
 
   private func runProtocol() async throws {
-    guard let remoteAddress = Self.remoteAddress(from: connection.endpoint) else {
+    guard let remoteAddress = Self.address(from: connection.endpoint) else {
       throw PrivateMacShareError.protocolError("missing peer address")
     }
+
+    // The wide port bind accepts connections from any interface; only the
+    // shared address may proceed, checked before any protocol bytes go out.
+    guard let localAddress = Self.address(from: connection.currentPath?.localEndpoint),
+      localAddress == requiredLocalAddress
+    else {
+      throw PrivateMacShareError.protocolError(
+        "connection did not arrive on the shared tailnet address")
+    }
+
     eventHandler(.authorizing(remoteAddress))
     let isAuthorized = await authorizer.authorize(remoteAddress: remoteAddress)
     try Task.checkCancellation()
@@ -227,6 +268,8 @@ private final class RFBHostSession: @unchecked Sendable {
 
     let io = RFBConnectionIO(connection: connection)
     try await handshake(io: io)
+    withLock { pushIO = io }
+    attachClipboard()
     eventHandler(.connected(remoteAddress))
     try await messageLoop(io: io)
   }
@@ -257,14 +300,13 @@ private final class RFBHostSession: @unchecked Sendable {
     _ = try await io.readUInt8()  // ClientInit shared flag
     try await io.send(
       try RFBWire.serverInit(
-        width: descriptor.frameWidth,
-        height: descriptor.frameHeight,
+        width: currentWidth,
+        height: currentHeight,
         name: desktopName
       ))
   }
 
   private func messageLoop(io: RFBConnectionIO) async throws {
-    var supportsTightEncoding = false
     var hasSentFrame = false
 
     while !Task.isCancelled {
@@ -284,19 +326,38 @@ private final class RFBHostSession: @unchecked Sendable {
           throw PrivateMacShareError.protocolError("too many requested encodings")
         }
         let encodingData = try await io.readExactly(count * 4)
-        supportsTightEncoding = (0..<count).contains {
-          encodingData.readInt32(at: $0 * 4) == RFBWire.tightEncoding
+        let encodings = (0..<count).map { encodingData.readInt32(at: $0 * 4) }
+        supportsTightEncoding = encodings.contains(RFBWire.tightEncoding)
+        if encodings.contains(RFBWire.extendedDesktopSizeEncoding),
+          !supportsExtendedDesktopSize
+        {
+          supportsExtendedDesktopSize = true
+          needsDesktopSizeAnnounce = true
         }
+        withLock {
+          supportsExtendedClipboard = encodings.contains(RFBWire.extendedClipboardEncoding)
+        }
+        try await sendServerClipboardCapsIfNeeded(io: io)
 
       case 3:  // FramebufferUpdateRequest
         _ = try await io.readExactly(9)
         guard supportsTightEncoding else {
           throw PrivateMacShareError.protocolError("the client did not offer Tight encoding")
         }
+        if needsDesktopSizeAnnounce {
+          needsDesktopSizeAnnounce = false
+          try await io.send(
+            try RFBWire.extendedDesktopSizeUpdate(
+              reason: 0,
+              status: 0,
+              width: currentWidth,
+              height: currentHeight
+            ))
+        }
         if hasSentFrame {
           try await Task.sleep(for: .milliseconds(66))
         }
-        let frame = try await waitForFrame()
+        let frame = try await waitForMatchingFrame()
         try await io.send(try RFBWire.tightJPEGUpdate(frame: frame))
         hasSentFrame = true
 
@@ -312,13 +373,11 @@ private final class RFBHostSession: @unchecked Sendable {
           y: payload.readUInt16(at: 3)
         )
 
-      case 6:  // ClientCutText; consume but do not touch the host clipboard.
-        let header = try await io.readExactly(7)
-        let length = Int(header.readUInt32(at: 3))
-        guard length <= RFBWire.maximumClipboardBytes else {
-          throw PrivateMacShareError.protocolError("clipboard payload is too large")
-        }
-        _ = try await io.readExactly(length)
+      case 6:  // ClientCutText
+        try await receiveClientCutText(io: io)
+
+      case 251:  // SetDesktopSize
+        try await receiveSetDesktopSize(io: io)
 
       default:
         throw PrivateMacShareError.protocolError("unsupported client message \(messageType)")
@@ -326,9 +385,185 @@ private final class RFBHostSession: @unchecked Sendable {
     }
   }
 
-  private func waitForFrame() async throws -> CapturedDesktopFrame {
+  // MARK: - Clipboard
+
+  private func attachClipboard() {
+    clipboard?.attach { [weak self] text in
+      self?.pushHostClipboard(text)
+    }
+  }
+
+  private func sendServerClipboardCapsIfNeeded(io: RFBConnectionIO) async throws {
+    let clipboardNegotiated = withLock { supportsExtendedClipboard }
+    guard clipboardNegotiated, clipboard != nil, !sentServerClipboardCaps else { return }
+    sentServerClipboardCaps = true
+    let body = VNCExtendedClipboard.encodeCaps(
+      maximumUnsolicitedTextBytes: UInt32(RFBWire.maximumClipboardBytes)
+    )
+    try await io.send(VNCExtendedClipboard.frame(messageType: 3, body: body))
+  }
+
+  private func receiveClientCutText(io: RFBConnectionIO) async throws {
+    let header = try await io.readExactly(7)
+    let length = Int(header.readInt32(at: 3))
+
+    if length >= 0 {
+      guard length <= RFBWire.maximumClipboardBytes else {
+        throw PrivateMacShareError.protocolError("clipboard payload is too large")
+      }
+      let payload = try await io.readExactly(length)
+      guard let clipboard else { return }
+      guard let text = String(data: payload, encoding: .isoLatin1) else { return }
+      clipboard.receiveClientText(text)
+      return
+    }
+
+    let bodyLength = -length
+    guard bodyLength <= RFBWire.maximumExtendedClipboardBodyBytes else {
+      throw PrivateMacShareError.protocolError("extended clipboard payload is too large")
+    }
+    let body = try await io.readExactly(bodyLength)
+    let clipboardNegotiated = withLock { supportsExtendedClipboard }
+    guard let clipboard, clipboardNegotiated else { return }
+
+    // The body is fully consumed, so malformed messages are dropped without
+    // desynchronizing the connection.
+    guard let message = try? VNCExtendedClipboard.decode(body: body) else { return }
+
+    switch message {
+    case .caps(let caps):
+      withLock { clientClipboardCaps = caps }
+
+    case .notify(let hasText):
+      guard hasText else { return }
+      try await io.send(
+        VNCExtendedClipboard.frame(
+          messageType: 3,
+          body: VNCExtendedClipboard.encodeRequestText()
+        ))
+
+    case .provide(let text):
+      guard let text else { return }
+      clipboard.receiveClientText(text)
+
+    case .request(let wantsText):
+      guard wantsText else { return }
+      let text = clipboard.currentText() ?? ""
+      guard let body = try? VNCExtendedClipboard.encodeProvide(text: text) else { return }
+      try await io.send(VNCExtendedClipboard.frame(messageType: 3, body: body))
+
+    case .peek:
+      try await io.send(
+        VNCExtendedClipboard.frame(
+          messageType: 3,
+          body: VNCExtendedClipboard.encodeNotify(hasText: clipboard.currentText() != nil)
+        ))
+    }
+  }
+
+  private func pushHostClipboard(_ text: String) {
+    let (io, extendedNegotiated, caps) = withLock {
+      (pushIO, supportsExtendedClipboard, clientClipboardCaps)
+    }
+    guard let io else { return }
+
+    let payload: Data?
+    if extendedNegotiated, let caps, caps.supportsText {
+      let wireByteCount = VNCExtendedClipboard.wireTextByteCount(text)
+      switch VNCExtendedClipboard.textRoute(wireByteCount: wireByteCount, caps: caps) {
+      case .provide:
+        payload = (try? VNCExtendedClipboard.encodeProvide(text: text)).map {
+          VNCExtendedClipboard.frame(messageType: 3, body: $0)
+        }
+      case .notify:
+        payload = VNCExtendedClipboard.frame(
+          messageType: 3,
+          body: VNCExtendedClipboard.encodeNotify(hasText: true)
+        )
+      case .legacy:
+        payload = RFBWire.legacyServerCutText(text: text)
+      }
+    } else {
+      // Legacy path: silently skip text that cannot survive Latin-1.
+      payload = RFBWire.legacyServerCutText(text: text)
+    }
+
+    guard let payload else { return }
+    Task {
+      try? await io.send(payload)
+    }
+  }
+
+  // MARK: - Desktop resize
+
+  private func receiveSetDesktopSize(io: RFBConnectionIO) async throws {
+    let header = try await io.readExactly(7)
+    let requestedWidth = Int(header.readUInt16(at: 1))
+    let requestedHeight = Int(header.readUInt16(at: 3))
+    let screenCount = Int(header[5])
+    guard screenCount <= 16 else {
+      throw PrivateMacShareError.protocolError("too many screens in resize request")
+    }
+    _ = try await io.readExactly(screenCount * 16)
+
+    guard supportsExtendedDesktopSize else {
+      throw PrivateMacShareError.protocolError("resize requested without ExtendedDesktopSize")
+    }
+
+    let target = MacScreenCapture.resizedDimensions(
+      requestedWidth: requestedWidth,
+      requestedHeight: requestedHeight,
+      sourcePixelWidth: descriptor.sourcePixelWidth,
+      sourcePixelHeight: descriptor.sourcePixelHeight
+    )
+
+    if target.width == currentWidth, target.height == currentHeight {
+      try await io.send(
+        try RFBWire.extendedDesktopSizeUpdate(
+          reason: 1,
+          status: 0,
+          width: currentWidth,
+          height: currentHeight
+        ))
+      return
+    }
+
+    do {
+      try await capture.updateOutputSize(width: target.width, height: target.height)
+    } catch {
+      // Status 2 = out of resources; the rectangle echoes the attempted layout.
+      try await io.send(
+        try RFBWire.extendedDesktopSizeUpdate(
+          reason: 1,
+          status: 2,
+          width: requestedWidth,
+          height: requestedHeight
+        ))
+      return
+    }
+
+    currentWidth = target.width
+    currentHeight = target.height
+    input.updateFrameSize(width: target.width, height: target.height)
+    try await io.send(
+      try RFBWire.extendedDesktopSizeUpdate(
+        reason: 1,
+        status: 0,
+        width: target.width,
+        height: target.height
+      ))
+  }
+
+  /// Waits for a frame matching the announced framebuffer size, discarding
+  /// stale frames captured before a resize took effect.
+  private func waitForMatchingFrame() async throws -> CapturedDesktopFrame {
     for _ in 0..<150 {
-      if let frame = await frameStore.latest() { return frame }
+      if let frame = await capture.frameStore.latest(),
+        frame.width == currentWidth,
+        frame.height == currentHeight
+      {
+        return frame
+      }
       try await Task.sleep(for: .milliseconds(20))
     }
     throw PrivateMacShareError.captureUnavailable
@@ -341,13 +576,21 @@ private final class RFBHostSession: @unchecked Sendable {
       return
     }
     finished = true
+    pushIO = nil
     lock.unlock()
+    clipboard?.detach()
     connection.cancel()
     eventHandler(event)
     didFinish(self)
   }
 
-  private static func remoteAddress(from endpoint: NWEndpoint) -> String? {
+  private func withLock<T>(_ body: () -> T) -> T {
+    lock.lock()
+    defer { lock.unlock() }
+    return body()
+  }
+
+  private static func address(from endpoint: NWEndpoint?) -> String? {
     guard case .hostPort(let host, _) = endpoint else { return nil }
     let value = String(describing: host)
     return value.split(separator: "%", maxSplits: 1).first.map(String.init)

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/HostShareProtocolTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/HostShareProtocolTests.swift
@@ -1,0 +1,263 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import CrabfleetMac
+
+struct HostShareWireTests {
+  @Test
+  func extendedDesktopSizeUpdateEncodesOneScreen() throws {
+    let update = try RFBWire.extendedDesktopSizeUpdate(
+      reason: 1,
+      status: 0,
+      width: 1_280,
+      height: 720
+    )
+
+    #expect(
+      update == Data([
+        0, 0,  // FramebufferUpdate + padding
+        0, 1,  // one rectangle
+        0, 1,  // x = reason (client-requested)
+        0, 0,  // y = status (no error)
+        0x05, 0x00,  // width 1280
+        0x02, 0xD0,  // height 720
+        0xFF, 0xFF, 0xFE, 0xCC,  // ExtendedDesktopSize (-308)
+        1, 0, 0, 0,  // one screen + padding
+        0, 0, 0, 1,  // screen id
+        0, 0, 0, 0,  // position
+        0x05, 0x00, 0x02, 0xD0,  // screen size
+        0, 0, 0, 0,  // flags
+      ])
+    )
+  }
+
+  @Test
+  func extendedDesktopSizeUpdateRejectsInvalidDimensions() {
+    #expect(throws: (any Error).self) {
+      _ = try RFBWire.extendedDesktopSizeUpdate(reason: 0, status: 0, width: 0, height: 720)
+    }
+    #expect(throws: (any Error).self) {
+      _ = try RFBWire.extendedDesktopSizeUpdate(reason: 0, status: 0, width: 70_000, height: 720)
+    }
+  }
+
+  @Test
+  func legacyServerCutTextRequiresLatin1() {
+    let encoded = RFBWire.legacyServerCutText(text: "héllo")
+
+    #expect(
+      encoded == Data([3, 0, 0, 0, 0, 0, 0, 5]) + Data([0x68, 0xE9, 0x6C, 0x6C, 0x6F])
+    )
+    #expect(RFBWire.legacyServerCutText(text: "emoji 🦀") == nil)
+  }
+
+  @Test
+  func resizedDimensionsAspectFitTheSourceIntoTheRequest() {
+    // Exact aspect match scales cleanly.
+    let exact = MacScreenCapture.resizedDimensions(
+      requestedWidth: 1_280,
+      requestedHeight: 800,
+      sourcePixelWidth: 2_880,
+      sourcePixelHeight: 1_800
+    )
+    #expect(exact.width == 1_280)
+    #expect(exact.height == 800)
+
+    // Requests beyond the native pixel size never upscale.
+    let capped = MacScreenCapture.resizedDimensions(
+      requestedWidth: 5_000,
+      requestedHeight: 5_000,
+      sourcePixelWidth: 1_600,
+      sourcePixelHeight: 1_000
+    )
+    #expect(capped.width == 1_600)
+    #expect(capped.height == 1_000)
+
+    // Tiny requests clamp to the 320×240 floor, aspect-fit within it.
+    let floored = MacScreenCapture.resizedDimensions(
+      requestedWidth: 100,
+      requestedHeight: 100,
+      sourcePixelWidth: 2_880,
+      sourcePixelHeight: 1_800
+    )
+    #expect(floored.width == 320)
+    #expect(floored.height == 200)
+  }
+}
+
+@MainActor
+struct HostClipboardBridgeTests {
+  @Test
+  func baselinesExistingClipboardAndPushesOnlyNewLocalChanges() async throws {
+    let pasteboard = NSPasteboard(name: .init("CrabfleetMacTests.\(UUID().uuidString)"))
+    pasteboard.clearContents()
+    pasteboard.setString("pre-existing", forType: .string)
+
+    let recorder = PushRecorder()
+    let bridge = HostClipboardBridge(pasteboard: pasteboard, pollingInterval: 0.01)
+    bridge.attach { recorder.append($0) }
+
+    try await Task.sleep(for: .milliseconds(60))
+    #expect(recorder.values.isEmpty)
+
+    pasteboard.clearContents()
+    pasteboard.setString("host copy", forType: .string)
+    try await waitUntil { recorder.values == ["host copy"] }
+    #expect(bridge.currentText() == "host copy")
+
+    bridge.detach()
+  }
+
+  @Test
+  func clientTextLandsOnPasteboardWithoutEchoingBack() async throws {
+    let pasteboard = NSPasteboard(name: .init("CrabfleetMacTests.\(UUID().uuidString)"))
+    pasteboard.clearContents()
+
+    let recorder = PushRecorder()
+    let bridge = HostClipboardBridge(pasteboard: pasteboard, pollingInterval: 0.01)
+    bridge.attach { recorder.append($0) }
+    try await Task.sleep(for: .milliseconds(30))
+
+    bridge.receiveClientText("from client")
+    try await waitUntil { pasteboard.string(forType: .string) == "from client" }
+    #expect(bridge.currentText() == "from client")
+
+    // Several poll cycles must not bounce the client's own text back.
+    try await Task.sleep(for: .milliseconds(80))
+    #expect(recorder.values.isEmpty)
+
+    // A genuinely new local copy still goes out.
+    pasteboard.clearContents()
+    pasteboard.setString("newer host copy", forType: .string)
+    try await waitUntil { recorder.values == ["newer host copy"] }
+
+    bridge.detach()
+  }
+
+  private func waitUntil(
+    timeout: Duration = .seconds(1),
+    condition: @escaping @MainActor () -> Bool
+  ) async throws {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while clock.now < deadline {
+      if condition() { return }
+      try await Task.sleep(for: .milliseconds(10))
+    }
+    #expect(condition())
+  }
+}
+
+@MainActor
+struct ClipboardDirectionTests {
+  @Test
+  func sendOnlyKeepsRemoteTextOffTheMacPasteboard() async throws {
+    let pasteboard = NSPasteboard(name: .init("CrabfleetMacTests.\(UUID().uuidString)"))
+    pasteboard.clearContents()
+    pasteboard.setString("local", forType: .string)
+
+    let defaults = try ephemeralDefaults()
+    let coordinator = ClipboardCoordinator(
+      pasteboard: pasteboard,
+      pollingInterval: 0.01,
+      defaults: defaults
+    )
+    coordinator.direction = .sendOnly
+
+    let session = DirectionEndpointRecorder()
+    coordinator.focus(session: session, targetID: "target")
+    try await Task.sleep(for: .milliseconds(30))
+
+    coordinator.receiveRemoteText("remote secret", from: "target")
+    #expect(pasteboard.string(forType: .string) == "local")
+    #expect(coordinator.hasPendingRemoteClipboard(for: "target"))
+    #expect(coordinator.state == .remoteAvailable)
+
+    // The explicit recovery action still applies remote text deliberately.
+    coordinator.applyRemoteClipboard(for: "target")
+    #expect(pasteboard.string(forType: .string) == "remote secret")
+  }
+
+  @Test
+  func receiveOnlyNeverAutoSendsLocalChanges() async throws {
+    let pasteboard = NSPasteboard(name: .init("CrabfleetMacTests.\(UUID().uuidString)"))
+    pasteboard.clearContents()
+
+    let defaults = try ephemeralDefaults()
+    let coordinator = ClipboardCoordinator(
+      pasteboard: pasteboard,
+      pollingInterval: 0.01,
+      defaults: defaults
+    )
+    coordinator.direction = .receiveOnly
+
+    let session = DirectionEndpointRecorder()
+    coordinator.focus(session: session, targetID: "target")
+    try await Task.sleep(for: .milliseconds(30))
+
+    pasteboard.clearContents()
+    pasteboard.setString("local change", forType: .string)
+    try await Task.sleep(for: .milliseconds(100))
+    #expect(session.sentTexts.isEmpty)
+
+    // The explicit toolbar action still sends deliberately.
+    coordinator.sendCurrentClipboard()
+    #expect(session.sentTexts == ["local change"])
+  }
+
+  @Test
+  func directionPersistsThroughDefaults() throws {
+    let defaults = try ephemeralDefaults()
+    let pasteboard = NSPasteboard(name: .init("CrabfleetMacTests.\(UUID().uuidString)"))
+
+    let first = ClipboardCoordinator(
+      pasteboard: pasteboard,
+      pollingInterval: 0.01,
+      defaults: defaults
+    )
+    #expect(first.direction == .bidirectional)
+    first.direction = .receiveOnly
+
+    let second = ClipboardCoordinator(
+      pasteboard: pasteboard,
+      pollingInterval: 0.01,
+      defaults: defaults
+    )
+    #expect(second.direction == .receiveOnly)
+  }
+
+  private func ephemeralDefaults() throws -> UserDefaults {
+    let suiteName = "CrabfleetMacTests.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+}
+
+private final class PushRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var storage = [String]()
+
+  var values: [String] {
+    lock.lock()
+    defer { lock.unlock() }
+    return storage
+  }
+
+  func append(_ value: String) {
+    lock.lock()
+    storage.append(value)
+    lock.unlock()
+  }
+}
+
+private final class DirectionEndpointRecorder: ClipboardSessionEndpoint {
+  var clipboardEnabled = true
+  var isClipboardConnected = true
+  var sentTexts = [String]()
+
+  func sendClipboardText(_ text: String) throws {
+    sentTexts.append(text)
+  }
+}

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
@@ -375,7 +375,9 @@ struct PrivateMacShareTests {
         displayID: 0,
         displayBounds: CGRect(x: 0, y: 0, width: 64, height: 64),
         frameWidth: 64,
-        frameHeight: 64
+        frameHeight: 64,
+        sourcePixelWidth: 64,
+        sourcePixelHeight: 64
       ),
       input: NoopRemoteInput(),
       port: port,
@@ -405,6 +407,106 @@ struct PrivateMacShareTests {
     #expect(session.framebufferUpdateCount > 0)
     #expect(session.framebuffer?.size.width == 64)
     #expect(session.framebuffer?.size.height == 64)
+  }
+
+  @Test @MainActor
+  func syncsUTF8ClipboardAndNegotiatesResizeOverLoopback() async throws {
+    // Full-protocol end-to-end: the production server and the RoyalVNCKit
+    // client exchange handshake, Tight frames, Extended Clipboard, and
+    // ExtendedDesktopSize over a real TCP connection on loopback. The
+    // tailnet-specific pieces (address binding, whois) are injected.
+    let identity = TailnetIdentity(
+      tailnetName: "example.com",
+      loginName: "tester@example.com",
+      dnsName: "workstation.example.ts.net.",
+      hostName: "Workstation",
+      ipv4Address: "127.0.0.1",
+      userID: 42
+    )
+    let capture = MacScreenCapture()
+    let jpeg = try #require(testJPEG())
+    await capture.frameStore.update(
+      .init(jpegData: jpeg, sequence: 1, width: 64, height: 64)
+    )
+
+    let hostPasteboard = NSPasteboard(name: .init("CrabfleetMacTests.host.\(UUID().uuidString)"))
+    hostPasteboard.clearContents()
+    let hostClipboard = HostClipboardBridge(pasteboard: hostPasteboard, pollingInterval: 0.02)
+
+    let port: UInt16 = 5_921
+    let server = TailnetRFBServer(
+      identity: identity,
+      runner: StaticTailscaleRunner(output: ""),
+      capture: capture,
+      descriptor: .init(
+        displayID: 0,
+        displayBounds: CGRect(x: 0, y: 0, width: 64, height: 64),
+        frameWidth: 64,
+        frameHeight: 64,
+        sourcePixelWidth: 256,
+        sourcePixelHeight: 256
+      ),
+      input: NoopRemoteInput(),
+      clipboard: hostClipboard,
+      peerAuthorizer: LoopbackPeerAuthorizer(),
+      port: port,
+      eventHandler: { _ in }
+    )
+    try server.start()
+    defer { server.stop() }
+    try await Task.sleep(for: .milliseconds(250))
+
+    let viewerPasteboard = NSPasteboard(
+      name: .init("CrabfleetMacTests.viewer.\(UUID().uuidString)")
+    )
+    viewerPasteboard.clearContents()
+    let coordinator = ClipboardCoordinator(pasteboard: viewerPasteboard, pollingInterval: 0.02)
+    let session = VNCSessionController(targetID: "smoke", clipboardCoordinator: coordinator)
+    coordinator.focus(session: session, targetID: "smoke")
+    session.connect(
+      host: identity.ipv4Address,
+      port: port,
+      username: "",
+      password: ""
+    )
+    defer { session.disconnect() }
+
+    // The Extended Clipboard caps handshake must complete on the client.
+    try await waitFor { session.connection?.supportsUTF8Clipboard == true }
+
+    // Viewer to host: emoji only survives the extended UTF-8 path.
+    viewerPasteboard.clearContents()
+    viewerPasteboard.setString("client copy 🚀", forType: .string)
+    try await waitFor { hostPasteboard.string(forType: .string) == "client copy 🚀" }
+
+    // Host to server-cut-text: the host push lands on the viewer pasteboard.
+    hostPasteboard.clearContents()
+    hostPasteboard.setString("host copy 🦀", forType: .string)
+    try await waitFor { viewerPasteboard.string(forType: .string) == "host copy 🦀" }
+
+    // The ExtendedDesktopSize announce must unlock client resize requests.
+    try await waitFor { session.requestDesktopSize(.init(width: 128, height: 128)) }
+
+    // The stream must keep flowing after the resize exchange (this test
+    // fixture has no live capture stream, so the server answers the resize
+    // with an out-of-resources status and continues serving frames).
+    let updates = session.framebufferUpdateCount
+    try await waitFor { session.framebufferUpdateCount > updates }
+    #expect(session.phase == .connected)
+  }
+
+  @MainActor
+  private func waitFor(
+    timeout: Duration = .seconds(15),
+    _ condition: @escaping @MainActor () -> Bool
+  ) async throws {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while clock.now < deadline {
+      if condition() { return }
+      try await Task.sleep(for: .milliseconds(25))
+    }
+    #expect(condition())
   }
 
   private func statusDocument() throws -> TailscaleStatusDocument {
@@ -489,4 +591,10 @@ private struct StaticTailscaleRunner: TailscaleCommandRunning {
 private struct NoopRemoteInput: RemoteInputForwarding {
   func keyEvent(down: Bool, keysym: UInt32) {}
   func pointerEvent(buttonMask: UInt8, x: UInt16, y: UInt16) {}
+}
+
+private struct LoopbackPeerAuthorizer: TailnetPeerAuthorizing {
+  func authorize(remoteAddress: String) async -> Bool {
+    remoteAddress == "127.0.0.1"
+  }
 }

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/Compression/ZlibOneShot.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/Compression/ZlibOneShot.swift
@@ -1,0 +1,144 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+import Z
+
+/// Bounded one-shot zlib (RFC 1950) helpers for small payloads such as
+/// Extended Clipboard bodies. Framebuffer decoding keeps using the streaming
+/// wrappers; these helpers trade streaming for strict output caps.
+enum ZlibOneShot {
+	static func deflate(_ data: Data) throws -> Data {
+		let sourceLength = UInt(data.count)
+		var destinationLength = compressBound(sourceLength)
+		var destination = Data(count: Int(destinationLength))
+
+		let status = destination.withUnsafeMutableBytes { destinationBuffer -> Int32 in
+			guard let destinationPointer = destinationBuffer.bindMemory(to: UInt8.self).baseAddress else {
+				return Z_MEM_ERROR
+			}
+
+			return data.withUnsafeBytes { sourceBuffer -> Int32 in
+				guard let sourcePointer = sourceBuffer.bindMemory(to: UInt8.self).baseAddress else {
+					// zlib treats a zero-length source with a null pointer as valid input.
+					return data.isEmpty
+						? compress2(destinationPointer, &destinationLength, nil, 0, Z_DEFAULT_COMPRESSION)
+						: Z_MEM_ERROR
+				}
+
+				return compress2(destinationPointer,
+								 &destinationLength,
+								 sourcePointer,
+								 sourceLength,
+								 Z_DEFAULT_COMPRESSION)
+			}
+		}
+
+		guard status == Z_OK else {
+			throw Self.error(status: status)
+		}
+
+		destination.removeSubrange(Int(destinationLength)..<destination.count)
+
+		return destination
+	}
+
+	static func inflate(_ data: Data,
+						maximumDecompressedBytes: Int) throws -> Data {
+		guard !data.isEmpty else {
+			throw ZlibError.dataError(message: "empty zlib payload")
+		}
+
+		var stream = z_stream()
+
+		var version = ZLIB_VERSION
+		var status = Z_VERSION_ERROR
+
+		withUnsafeMutablePointer(to: &version) { versionPtr in
+			status = inflateInit_(&stream, versionPtr, .init(MemoryLayout<z_stream>.size))
+		}
+
+		guard status == Z_OK else {
+			throw Self.error(status: status)
+		}
+
+		defer {
+			_ = Z.inflateEnd(&stream)
+		}
+
+		var input = data
+		var output = Data()
+		let chunkSize = 64 * 1_024
+		var chunk = [UInt8](repeating: 0, count: chunkSize)
+		var isDone = false
+
+		try input.withUnsafeMutableBytes { (inputBuffer: UnsafeMutableRawBufferPointer) in
+			guard let inputPointer = inputBuffer.bindMemory(to: UInt8.self).baseAddress else {
+				throw ZlibError.dataError(message: "invalid zlib payload")
+			}
+
+			stream.next_in = inputPointer
+			stream.avail_in = UInt32(inputBuffer.count)
+
+			while !isDone {
+				let inflateStatus = chunk.withUnsafeMutableBufferPointer { chunkBuffer -> Int32 in
+					stream.next_out = chunkBuffer.baseAddress
+					stream.avail_out = UInt32(chunkSize)
+
+					return Z.inflate(&stream, Z_NO_FLUSH)
+				}
+
+				let producedBytes = chunkSize - Int(stream.avail_out)
+
+				if producedBytes > 0 {
+					guard output.count + producedBytes <= maximumDecompressedBytes else {
+						throw ZlibError.bufferError(message: "decompressed payload exceeds limit")
+					}
+
+					output.append(contentsOf: chunk[0..<producedBytes])
+				}
+
+				switch inflateStatus {
+					case Z_STREAM_END:
+						isDone = true
+					case Z_OK:
+						// No forward progress means the payload is truncated or corrupt.
+						guard stream.avail_in > 0 || producedBytes > 0 else {
+							throw ZlibError.dataError(message: "truncated zlib payload")
+						}
+					default:
+						throw Self.error(status: inflateStatus)
+				}
+			}
+		}
+
+		return output
+	}
+}
+
+private extension ZlibOneShot {
+	static func error(status: Int32) -> ZlibError {
+		switch status {
+			case Z_STREAM_END:
+				.streamEnd(message: nil)
+			case Z_NEED_DICT:
+				.needDict(message: nil)
+			case Z_ERRNO:
+				.errNo(message: nil)
+			case Z_STREAM_ERROR:
+				.streamError(message: nil)
+			case Z_DATA_ERROR:
+				.dataError(message: nil)
+			case Z_MEM_ERROR:
+				.memoryError(message: nil)
+			case Z_BUF_ERROR:
+				.bufferError(message: nil)
+			case Z_VERSION_ERROR:
+				.versionError(message: nil)
+			default:
+				.unknown(status: status, message: nil)
+		}
+	}
+}

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/Protocol/Messages/ClientToServer/ExtendedClientCutText.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/Protocol/Messages/ClientToServer/ExtendedClientCutText.swift
@@ -1,0 +1,25 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+extension VNCProtocol {
+	/// ClientCutText with a negative length: one Extended Clipboard body.
+	struct ExtendedClientCutText: VNCSendableMessage {
+		let messageType: UInt8 = 6
+
+		let body: Data
+	}
+}
+
+extension VNCProtocol.ExtendedClientCutText {
+	var data: Data {
+		VNCExtendedClipboard.frame(messageType: messageType,
+								   body: body)
+	}
+
+	func send(connection: NetworkConnectionWriting) async throws {
+		try await connection.write(data: data)
+	}
+}

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/Protocol/Messages/ServerToClient/ServerCutText.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/Protocol/Messages/ServerToClient/ServerCutText.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable nesting
-
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
@@ -12,10 +10,16 @@ extension VNCProtocol {
 
 		static let stringEncoding: String.Encoding = .isoLatin1
 
+		/// Flags word plus the codec's bounded compressed payload.
+		static let maximumExtendedBodyBytes = 4 + VNCExtendedClipboard.maximumBodyBytes
+
         let messageType: UInt8
         let text: String
 
-		let extended: ExtendedServerCutText?
+		/// True for negative-length bodies, even when decoding failed, so a
+		/// malformed extended message is never mistaken for legacy cut text.
+		let isExtended: Bool
+		let extended: VNCExtendedClipboardMessage?
     }
 }
 
@@ -24,194 +28,49 @@ extension VNCProtocol.ServerCutText {
                         logger: VNCLogger) async throws -> Self {
         try await connection.readPadding(length: 3)
 
-		let length = try await receiveLength(connection: connection,
-										 logger: logger)
-		guard length >= 0,
-			  length <= VNCProtocolLimits.maximumClipboardBytes else {
+		let length = Int(try await connection.readInt32())
+
+		if length >= 0 {
+			guard length <= VNCProtocolLimits.maximumClipboardBytes else {
+				throw VNCError.protocol(.invalidData)
+			}
+
+			let text = try await connection.readString(encoding: Self.stringEncoding,
+													   length: length)
+
+			return .init(messageType: Self.messageType,
+						 text: text,
+						 isExtended: false,
+						 extended: nil)
+		}
+
+		// A negative length marks an Extended Clipboard body of abs(length) bytes.
+		let bodyLength = -length
+
+		guard bodyLength <= Self.maximumExtendedBodyBytes else {
 			throw VNCError.protocol(.invalidData)
 		}
 
-		let text = try await connection.readString(encoding: Self.stringEncoding,
-											   length: .init(length))
+		let body = try await connection.read(length: bodyLength)
+
+		guard body.count == bodyLength else {
+			throw VNCError.protocol(.invalidData)
+		}
+
+		// The body is fully consumed, so a malformed message is dropped
+		// without desynchronizing or tearing down the connection.
+		let extended: VNCExtendedClipboardMessage?
+
+		do {
+			extended = try VNCExtendedClipboard.decode(body: body)
+		} catch {
+			logger.logWarning("Ignoring malformed extended clipboard message: \(error)")
+			extended = nil
+		}
 
 		return .init(messageType: Self.messageType,
-					 text: text,
-					 extended: nil)
+					 text: "",
+					 isExtended: true,
+					 extended: extended)
     }
 }
-
-private extension VNCProtocol.ServerCutText {
-	static func receiveLength(connection: NetworkConnectionReading,
-							  logger: VNCLogger) async throws -> Int {
-		let lengthDataLength = MemoryLayout<UInt32>.size
-		let lengthData = try await connection.read(length: lengthDataLength)
-
-		guard lengthData.count == lengthDataLength else {
-			throw VNCError.protocol(.invalidData)
-		}
-
-		let bigEndianUnsignedLength = lengthData.withUnsafeBytes {
-			$0.load(as: UInt32.self)
-		}
-
-        let endianess = Endianness.current
-
-        var length = endianess == .little
-			? Int(UInt32(bigEndian: bigEndianUnsignedLength))
-			: Int(bigEndianUnsignedLength)
-
-		// TODO: Is that the correct check?
-		if length > Int32.max {
-			let bigEndianSignedLength = lengthData.withUnsafeBytes {
-				$0.load(as: Int32.self)
-			}
-
-			length = endianess == .little
-				? Int(Int32(bigEndian: bigEndianSignedLength))
-				: Int(bigEndianSignedLength)
-		}
-
-		return length
-	}
-}
-
-extension VNCProtocol.ServerCutText {
-	// TODO: WIP
-	struct ExtendedServerCutText {
-		let serverCapabilities: ServerCapabilities?
-
-		struct ServerCapabilities {
-			let format: Format
-			let action: Action
-		}
-
-		struct Format: OptionSet {
-			let rawValue: UInt32
-
-			/// Plain, unformatted text using the UTF-8 encoding. End of line is represented by carriage-return and linefeed / newline pairs (values 13 and 10). The text must be followed by a terminating null even though the length is also explicitly given.
-			static let text = Self(rawValue: 1)
-
-			/// Microsoft Rich Text Format.
-			static let rtf = Self(rawValue: 1 << 1)
-
-			/// Microsoft HTML clipboard fragments.
-			static let html = Self(rawValue: 1 << 2)
-
-			/// Microsoft Device Independent Bitmap v5. A file header must not be included.
-			static let dib = Self(rawValue: 1 << 3)
-
-			/// Currently reserved but not defined.
-			static let files = Self(rawValue: 1 << 4)
-		}
-
-		struct Action: OptionSet {
-			let rawValue: UInt32
-
-			/// If caps is set then the other bits indicate which formats and actions that the sender is willing to receive.
-			static let caps = Self(rawValue: 1 << 24)
-
-			/// The recipient should respond with a provide message with the clipboard data for the formats indicated in flags. No other data is provided with this message.
-			static let request = Self(rawValue: 1 << 25)
-
-			/// The recipient should send a new notify message indicating which formats are available. No other bits in flags need to be set and no other data is provided with this message.
-			static let peek = Self(rawValue: 1 << 26)
-
-			/// This message indicates which formats are available on the remote side and should be sent whenever the clipboard changes, or as a response to a peek message. The available formats are specified in flags and no other data is provided with this message.
-			static let notify = Self(rawValue: 1 << 27)
-
-			/// This message includes the actual clipboard data and should be sent whenever the clipboard changes and the data for each format is less than the respective specified maximum size, or as a response to a request message.
-			static let provide = Self(rawValue: 1 << 28)
-		}
-
-		// See https://github.com/novnc/noVNC/blob/master/core/rfb.js#L2136
-		static func receive(connection: NetworkConnectionReading,
-							logger: VNCLogger,
-							length: Int32) async throws -> Self {
-			let flagsRawValue = try await connection.readUInt32()
-
-			let formats: Format = .init(rawValue: flagsRawValue)
-			let actions: Action = .init(rawValue: flagsRawValue)
-
-			let isCaps = actions.contains(.caps)
-
-			var serverCapabilities: ServerCapabilities?
-
-			if isCaps {
-				logger.logDebug("ExtendedServerCutText Caps")
-
-				var bytesToSkip = 0
-
-				var serverFormatCapabilities: Format = [ ]
-
-				// Update server format capabilities
-				for idx: UInt32 in 0..<15 {
-					let index: UInt32 = 1 << idx
-					let format = Format(rawValue: index)
-
-					let supportsFormat = formats.contains(format)
-
-					if supportsFormat {
-						serverFormatCapabilities.insert(format)
-
-						// We don't send unsolicited clipboard, so we ignore the size
-						bytesToSkip += 4
-					}
-				}
-
-				var serverActionCapabilities: Action = [ ]
-
-				// Update server action capabilities
-				for idx: UInt32 in 24..<31 {
-					let index: UInt32 = 1 << idx
-					let action = Action(rawValue: index)
-
-					let supportsAction = actions.contains(action)
-
-					if supportsAction {
-						serverActionCapabilities.insert(action)
-					}
-				}
-
-				serverCapabilities = .init(format: serverFormatCapabilities,
-										   action: serverActionCapabilities)
-
-				try await connection.readPadding(length: bytesToSkip)
-
-				// Caps handling done, send caps with the clients capabilities set as a response
-				// TODO:
-				/* let clientActionCapabilities: Action = [
-					Action.caps,
-					Action.request,
-					Action.peek,
-					Action.notify,
-					Action.provide
-				] */
-
-				// TODO: Send (for reference, extendedClipboardCaps in novnc: https://github.com/novnc/noVNC/blob/9761278df8f663f64f13b18e901a80bda799d893/core/rfb.js#L2997)
-			} else if actions == Action.request {
-				logger.logDebug("ExtendedServerCutText Request")
-
-				// TODO
-			} else if actions == Action.peek {
-				logger.logDebug("ExtendedServerCutText Peek")
-
-				// TODO
-			} else if actions == Action.notify {
-				logger.logDebug("ExtendedServerCutText Notify")
-
-				// TODO
-			} else if actions == Action.provide {
-				logger.logDebug("ExtendedServerCutText Provide")
-
-				// TODO
-			} else {
-				// TODO:
-				throw VNCError.protocol(.unexpectedExtendedServerCutTextAction(action: actions.rawValue))
-			}
-
-			return .init(serverCapabilities: serverCapabilities)
-		}
-	}
-}
-
-// swiftlint:enable nesting

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/Protocol/VNCExtendedClipboard.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/Protocol/VNCExtendedClipboard.swift
@@ -1,0 +1,320 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Extended Clipboard (pseudo-encoding 0xc0a1e5ce) message codec.
+///
+/// Both cut-text message types reuse this body layout when their length field
+/// is negative: a 32-bit flags word followed by action-specific data. The
+/// codec is public so an application-owned RFB server can speak the same
+/// dialect as the client connection; only plain UTF-8 text is supported.
+public enum VNCExtendedClipboard {
+	/// Format bit for plain UTF-8 text.
+	public static let textFormat: UInt32 = 1
+
+	public static let capsAction: UInt32 = 1 << 24
+	public static let requestAction: UInt32 = 1 << 25
+	public static let peekAction: UInt32 = 1 << 26
+	public static let notifyAction: UInt32 = 1 << 27
+	public static let provideAction: UInt32 = 1 << 28
+
+	/// Matches the legacy cut-text limit so no path accepts more than 1 MiB of text.
+	public static let maximumTextBytes = 1 * 1_024 * 1_024
+
+	/// Compressed bodies of incompressible maximum-size text can slightly
+	/// exceed the text limit; the slack covers zlib framing overhead.
+	public static let maximumBodyBytes = maximumTextBytes + 65_536
+
+	/// Hard cap for a decompressed provide stream that may carry more formats than text.
+	static let maximumDecompressedProvideBytes = 8 * 1_024 * 1_024
+
+	static let formatMask: UInt32 = 0xffff
+	static let actionMask: UInt32 = ~formatMask
+}
+
+public struct VNCExtendedClipboardCaps: Equatable, Sendable {
+	public let supportsText: Bool
+	public let maximumUnsolicitedTextBytes: UInt32
+	public let actions: UInt32
+
+	public init(supportsText: Bool,
+				maximumUnsolicitedTextBytes: UInt32,
+				actions: UInt32) {
+		self.supportsText = supportsText
+		self.maximumUnsolicitedTextBytes = maximumUnsolicitedTextBytes
+		self.actions = actions
+	}
+
+	public var supportsProvide: Bool {
+		actions & VNCExtendedClipboard.provideAction != 0
+	}
+
+	public var supportsNotify: Bool {
+		actions & VNCExtendedClipboard.notifyAction != 0
+	}
+
+	public var supportsRequest: Bool {
+		actions & VNCExtendedClipboard.requestAction != 0
+	}
+
+	public func allowsUnsolicitedText(byteCount: Int) -> Bool {
+		supportsText
+			&& byteCount >= 0
+			&& UInt32(clamping: byteCount) <= maximumUnsolicitedTextBytes
+	}
+}
+
+/// How an outbound text change should reach a peer, honoring the actions the
+/// peer's caps advertised as receivable.
+public enum VNCExtendedClipboardTextRoute: Equatable, Sendable {
+	case provide
+	case notify
+	case legacy
+}
+
+public extension VNCExtendedClipboard {
+	/// Wire size of `text` as extended clipboard payload: UTF-8 with CR-LF
+	/// line endings plus the terminating NUL. Slightly over-counts existing
+	/// CR-LF pairs, which keeps the bound conservative.
+	static func wireTextByteCount(_ text: String) -> Int {
+		var count = 1
+
+		for byte in text.utf8 {
+			count += byte == 0x0A ? 2 : 1
+		}
+
+		return count
+	}
+
+	/// Picks the outbound path for a text change. Unsolicited provide requires
+	/// the peer to accept the provide action and this payload size; notify
+	/// requires the notify action; otherwise fall back to legacy cut text.
+	static func textRoute(wireByteCount: Int,
+						  caps: VNCExtendedClipboardCaps) -> VNCExtendedClipboardTextRoute {
+		guard caps.supportsText else {
+			return .legacy
+		}
+
+		if caps.supportsProvide,
+		   caps.allowsUnsolicitedText(byteCount: wireByteCount) {
+			return .provide
+		}
+
+		if caps.supportsNotify {
+			return .notify
+		}
+
+		return .legacy
+	}
+}
+
+public enum VNCExtendedClipboardMessage: Equatable, Sendable {
+	case caps(VNCExtendedClipboardCaps)
+	case request(text: Bool)
+	case peek
+	case notify(text: Bool)
+
+	/// `nil` text means the provide stream did not carry the text format.
+	case provide(text: String?)
+}
+
+public enum VNCExtendedClipboardError: Error, Equatable, Sendable {
+	case bodyTooShort
+	case bodyTooLarge
+	case unknownAction(flags: UInt32)
+	case malformedCaps
+	case malformedProvide
+	case textTooLarge
+	case compressionFailed
+}
+
+// MARK: - Encoding
+public extension VNCExtendedClipboard {
+	/// Frames an extended body as a complete cut-text message
+	/// (`3` for server-to-client, `6` for client-to-server).
+	static func frame(messageType: UInt8, body: Data) -> Data {
+		var data = Data(capacity: 8 + body.count)
+		data.append(messageType)
+		data.append(contentsOf: [0, 0, 0])
+		data.append(Int32(-body.count), bigEndian: true)
+		data.append(body)
+		return data
+	}
+
+	static func encodeCaps(maximumUnsolicitedTextBytes: UInt32) -> Data {
+		let flags = capsAction
+			| requestAction
+			| peekAction
+			| notifyAction
+			| provideAction
+			| textFormat
+
+		var body = Data(capacity: 8)
+		body.append(flags, bigEndian: true)
+		body.append(maximumUnsolicitedTextBytes, bigEndian: true)
+		return body
+	}
+
+	static func encodeRequestText() -> Data {
+		flagsOnlyBody(requestAction | textFormat)
+	}
+
+	static func encodePeek() -> Data {
+		flagsOnlyBody(peekAction)
+	}
+
+	static func encodeNotify(hasText: Bool) -> Data {
+		flagsOnlyBody(notifyAction | (hasText ? textFormat : 0))
+	}
+
+	static func encodeProvide(text: String) throws -> Data {
+		let wireText = text
+			.replacingOccurrences(of: "\r\n", with: "\n")
+			.replacingOccurrences(of: "\n", with: "\r\n")
+
+		var textData = Data(wireText.utf8)
+		textData.append(0)
+
+		guard textData.count <= maximumTextBytes else {
+			throw VNCExtendedClipboardError.textTooLarge
+		}
+
+		var uncompressed = Data(capacity: 4 + textData.count)
+		uncompressed.append(UInt32(textData.count), bigEndian: true)
+		uncompressed.append(textData)
+
+		guard let compressed = try? ZlibOneShot.deflate(uncompressed) else {
+			throw VNCExtendedClipboardError.compressionFailed
+		}
+
+		var body = Data(capacity: 4 + compressed.count)
+		body.append(provideAction | textFormat, bigEndian: true)
+		body.append(compressed)
+		return body
+	}
+
+	private static func flagsOnlyBody(_ flags: UInt32) -> Data {
+		var body = Data(capacity: 4)
+		body.append(flags, bigEndian: true)
+		return body
+	}
+}
+
+// MARK: - Decoding
+public extension VNCExtendedClipboard {
+	/// Decodes one extended cut-text body (flags word plus action data).
+	static func decode(body: Data) throws -> VNCExtendedClipboardMessage {
+		guard body.count >= 4 else {
+			throw VNCExtendedClipboardError.bodyTooShort
+		}
+
+		guard body.count <= 4 + maximumBodyBytes else {
+			throw VNCExtendedClipboardError.bodyTooLarge
+		}
+
+		let bytes = Data(body)
+		let flags = UInt32(bytes[0]) << 24
+			| UInt32(bytes[1]) << 16
+			| UInt32(bytes[2]) << 8
+			| UInt32(bytes[3])
+
+		let formats = flags & formatMask
+		let remainder = bytes.dropFirst(4)
+
+		if flags & capsAction != 0 {
+			return .caps(try decodeCaps(formats: formats,
+										flags: flags,
+										data: remainder))
+		}
+
+		switch flags & actionMask {
+			case requestAction:
+				return .request(text: formats & textFormat != 0)
+			case peekAction:
+				return .peek
+			case notifyAction:
+				return .notify(text: formats & textFormat != 0)
+			case provideAction:
+				return .provide(text: try decodeProvideText(formats: formats,
+															compressed: remainder))
+			default:
+				throw VNCExtendedClipboardError.unknownAction(flags: flags)
+		}
+	}
+
+	private static func decodeCaps(formats: UInt32,
+								   flags: UInt32,
+								   data: Data.SubSequence) throws -> VNCExtendedClipboardCaps {
+		var announcedFormatCount = 0
+
+		for bit in 0..<16 where formats & (1 << UInt32(bit)) != 0 {
+			announcedFormatCount += 1
+		}
+
+		guard data.count >= announcedFormatCount * 4 else {
+			throw VNCExtendedClipboardError.malformedCaps
+		}
+
+		var maximumUnsolicitedTextBytes: UInt32 = 0
+		var offset = data.startIndex
+
+		for bit in 0..<16 where formats & (1 << UInt32(bit)) != 0 {
+			let size = UInt32(data[offset]) << 24
+				| UInt32(data[offset + 1]) << 16
+				| UInt32(data[offset + 2]) << 8
+				| UInt32(data[offset + 3])
+			offset += 4
+
+			if UInt32(1 << bit) == textFormat {
+				maximumUnsolicitedTextBytes = size
+			}
+		}
+
+		return .init(supportsText: formats & textFormat != 0,
+					 maximumUnsolicitedTextBytes: maximumUnsolicitedTextBytes,
+					 actions: flags & actionMask)
+	}
+
+	private static func decodeProvideText(formats: UInt32,
+										  compressed: Data.SubSequence) throws -> String? {
+		guard formats & textFormat != 0 else {
+			return nil
+		}
+
+		guard let decompressed = try? ZlibOneShot.inflate(
+			Data(compressed),
+			maximumDecompressedBytes: maximumDecompressedProvideBytes
+		) else {
+			throw VNCExtendedClipboardError.malformedProvide
+		}
+
+		// Text is format bit zero, so its chunk is always first in the stream.
+		guard decompressed.count >= 4 else {
+			throw VNCExtendedClipboardError.malformedProvide
+		}
+
+		let length = Int(UInt32(decompressed[0]) << 24
+			| UInt32(decompressed[1]) << 16
+			| UInt32(decompressed[2]) << 8
+			| UInt32(decompressed[3]))
+
+		guard length <= maximumTextBytes,
+			  decompressed.count >= 4 + length else {
+			throw VNCExtendedClipboardError.malformedProvide
+		}
+
+		var textBytes = decompressed.subdata(in: 4..<(4 + length))
+
+		if let nulIndex = textBytes.firstIndex(of: 0) {
+			textBytes = textBytes.prefix(upTo: nulIndex)
+		}
+
+		guard let wireText = String(bytes: textBytes, encoding: .utf8) else {
+			throw VNCExtendedClipboardError.malformedProvide
+		}
+
+		return wireText.replacingOccurrences(of: "\r\n", with: "\n")
+	}
+}

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Connection/State.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Connection/State.swift
@@ -20,6 +20,8 @@ extension VNCConnection {
 		private var _incrementalUpdatesEnabled = false
 		private var _areContinuousUpdatesSupported = false
 		private var _areContinuousUpdatesEnabled = false
+		private var _extendedClipboardServerCaps: VNCExtendedClipboardCaps?
+		private var _lastExtendedClipboardText: String?
 
 		var disconnectRequested: Bool { withLock { _disconnectRequested } }
 
@@ -76,6 +78,16 @@ extension VNCConnection {
 		var areContinuousUpdatesEnabled: Bool {
 			get { withLock { _areContinuousUpdatesEnabled } }
 			set { withLock { _areContinuousUpdatesEnabled = newValue } }
+		}
+
+		var extendedClipboardServerCaps: VNCExtendedClipboardCaps? {
+			get { withLock { _extendedClipboardServerCaps } }
+			set { withLock { _extendedClipboardServerCaps = newValue } }
+		}
+
+		var lastExtendedClipboardText: String? {
+			get { withLock { _lastExtendedClipboardText } }
+			set { withLock { _lastExtendedClipboardText = newValue } }
 		}
 
 		func requestDisconnect() -> Bool {

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Connection/VNCConnection+Clipboard.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Connection/VNCConnection+Clipboard.swift
@@ -25,12 +25,23 @@ public enum VNCClipboardError: Error, Equatable, LocalizedError, Sendable {
 }
 
 public extension VNCConnection {
+	/// True once the server negotiated the Extended Clipboard extension,
+	/// which lifts the ISO-8859-1 restriction on clipboard text.
+	var supportsUTF8Clipboard: Bool {
+		state.extendedClipboardServerCaps?.supportsText == true
+	}
+
 	func sendClipboardText(_ text: String) throws {
 		guard settings.clipboardMode != .disabled else {
 			throw VNCClipboardError.disabled
 		}
 		guard connectionState.status == .connected else {
 			throw VNCClipboardError.notConnected
+		}
+
+		if let caps = state.extendedClipboardServerCaps, caps.supportsText,
+		   try sendExtendedClipboardText(text, caps: caps) {
+			return
 		}
 
 		var byteCount = 0
@@ -47,5 +58,47 @@ public extension VNCConnection {
 		}
 
 		enqueueClientCutTextMessage(text)
+	}
+}
+
+private extension VNCConnection {
+	/// Returns false when neither an unsolicited provide nor a notify is
+	/// receivable by the server, so the caller falls back to legacy cut text.
+	func sendExtendedClipboardText(_ text: String,
+								   caps: VNCExtendedClipboardCaps) throws -> Bool {
+		let wireByteCount = VNCExtendedClipboard.wireTextByteCount(text)
+
+		guard wireByteCount <= VNCProtocolLimits.maximumClipboardBytes else {
+			throw VNCClipboardError.payloadTooLarge(
+				maximumBytes: VNCProtocolLimits.maximumClipboardBytes
+			)
+		}
+
+		// Kept regardless of route so a later server request can be answered.
+		state.lastExtendedClipboardText = text
+
+		switch VNCExtendedClipboard.textRoute(wireByteCount: wireByteCount,
+											  caps: caps) {
+			case .provide:
+				guard let body = try? VNCExtendedClipboard.encodeProvide(text: text) else {
+					throw VNCClipboardError.payloadTooLarge(
+						maximumBytes: VNCProtocolLimits.maximumClipboardBytes
+					)
+				}
+
+				enqueueClientToServerMessage(VNCProtocol.ExtendedClientCutText(body: body))
+
+				return true
+
+			case .notify:
+				enqueueClientToServerMessage(VNCProtocol.ExtendedClientCutText(
+					body: VNCExtendedClipboard.encodeNotify(hasText: true)
+				))
+
+				return true
+
+			case .legacy:
+				return false
+		}
 	}
 }

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Connection/VNCConnection+ClipboardMonitor.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Connection/VNCConnection+ClipboardMonitor.swift
@@ -32,6 +32,12 @@ extension VNCConnection: VNCClipboardMonitorDelegate {
 
 		guard settings.clipboardMode == .systemPasteboard else { return }
 
-		enqueueClientCutTextMessage(text)
+		// Route through the extended-aware sender so UTF-8 text reaches
+		// Extended Clipboard servers instead of being dropped as non-Latin-1.
+		do {
+			try sendClipboardText(text)
+		} catch {
+			logger.logWarning("Ignoring unsendable clipboard change: \(error)")
+		}
 	}
 }

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Connection/VNCConnection+Receive.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Connection/VNCConnection+Receive.swift
@@ -104,10 +104,68 @@ private extension VNCConnection {
 		let serverCutText = try await VNCProtocol.ServerCutText.receive(connection: connection,
 																		logger: logger)
 
-		let text = serverCutText.text
-
 		logger.logDebug("Received Clipboard Text from Server")
 
+		if let extended = serverCutText.extended {
+			await handleExtendedClipboardMessage(extended)
+
+			return
+		}
+
+		// A malformed extended body is dropped, not treated as empty legacy text.
+		guard !serverCutText.isExtended else { return }
+
+		await deliverServerClipboardText(serverCutText.text)
+	}
+
+	func handleExtendedClipboardMessage(_ message: VNCExtendedClipboardMessage) async {
+		guard settings.clipboardMode != .disabled else { return }
+
+		switch message {
+			case .caps(let caps):
+				state.extendedClipboardServerCaps = caps
+
+				// Announce the text format plus every action so servers may
+				// push provide messages without a notify/request round trip.
+				let capsBody = VNCExtendedClipboard.encodeCaps(
+					maximumUnsolicitedTextBytes: UInt32(VNCProtocolLimits.maximumClipboardBytes)
+				)
+
+				enqueueClientToServerMessage(VNCProtocol.ExtendedClientCutText(body: capsBody))
+
+			case .notify(let hasText):
+				guard hasText else { return }
+
+				enqueueClientToServerMessage(VNCProtocol.ExtendedClientCutText(
+					body: VNCExtendedClipboard.encodeRequestText()
+				))
+
+			case .provide(let text):
+				guard let text else { return }
+
+				await deliverServerClipboardText(text)
+
+			case .request(let wantsText):
+				guard wantsText else { return }
+
+				let text = state.lastExtendedClipboardText ?? ""
+
+				guard let body = try? VNCExtendedClipboard.encodeProvide(text: text) else {
+					return
+				}
+
+				enqueueClientToServerMessage(VNCProtocol.ExtendedClientCutText(body: body))
+
+			case .peek:
+				enqueueClientToServerMessage(VNCProtocol.ExtendedClientCutText(
+					body: VNCExtendedClipboard.encodeNotify(
+						hasText: state.lastExtendedClipboardText != nil
+					)
+				))
+		}
+	}
+
+	func deliverServerClipboardText(_ text: String) async {
 		switch settings.clipboardMode {
 			case .disabled:
 				return

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Connection/VNCConnection.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Connection/VNCConnection.swift
@@ -253,12 +253,14 @@ public final class VNCConnection: NSObjectOrAnyObject, @unchecked Sendable {
 			VNCPseudoEncodingType.desktopSize.rawValue,
 			VNCPseudoEncodingType.desktopName.rawValue,
 			VNCPseudoEncodingType.cursor.rawValue,
-			// TODO: Implement
-//			VNCPseudoEncodingType.extendedClipboard.rawValue,
 
             // TODO: Make configurable
 			VNCPseudoEncodingType.compressionLevel6.rawValue
 		])
+
+		if settings.clipboardMode != .disabled {
+			encs.append(VNCPseudoEncodingType.extendedClipboard.rawValue)
+		}
 
 		if usesTightEncoding {
             // TODO: Make configurable

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Error/ProtocolError.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Error/ProtocolError.swift
@@ -25,7 +25,6 @@ public extension VNCError {
 		case zrlePaletteIndexOverflow(paletteIndex: Int, paletteSize: UInt8)
 		case zrlePaletteRLELengthOverflow
 		case zrleUnexpectedRLEStreamEnd
-		case unexpectedExtendedServerCutTextAction(action: UInt32)
 
 		// MARK: - LocalizedError
 		public var errorDescription: String? {
@@ -71,8 +70,6 @@ public extension VNCError {
 					return "An invalid ZRLE RLE length was encountered."
 				case .zrleUnexpectedRLEStreamEnd:
 					return "End of stream reached while reading ZRLE RLE run-length."
-				case .unexpectedExtendedServerCutTextAction(let action):
-					return "An unexpected ExtendedServerCutText Action (\(action)) was retrieved."
 			}
 		}
 	}

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Tests/RoyalVNCKitTests/ExtendedClipboardTests.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Tests/RoyalVNCKitTests/ExtendedClipboardTests.swift
@@ -1,0 +1,227 @@
+import Foundation
+import Testing
+
+@testable import RoyalVNCKit
+
+struct ExtendedClipboardTests {
+  @Test
+  func capsBodyAnnouncesTextFormatAndAllActions() {
+    let body = VNCExtendedClipboard.encodeCaps(maximumUnsolicitedTextBytes: 1_048_576)
+
+    #expect(
+      body == Data([
+        0x1F, 0x00, 0x00, 0x01,  // caps|request|peek|notify|provide + text
+        0x00, 0x10, 0x00, 0x00,  // 1 MiB unsolicited text limit
+      ])
+    )
+  }
+
+  @Test
+  func provideRoundtripPreservesUnicodeTextAndNewlines() throws {
+    let text = "héllo 🦀\nsecond line\twith tab"
+    let body = try VNCExtendedClipboard.encodeProvide(text: text)
+
+    let message = try VNCExtendedClipboard.decode(body: body)
+
+    #expect(message == .provide(text: text))
+  }
+
+  @Test
+  func provideNormalizesCarriageReturnLineFeedPairs() throws {
+    let body = try VNCExtendedClipboard.encodeProvide(text: "a\r\nb\nc")
+
+    let message = try VNCExtendedClipboard.decode(body: body)
+
+    #expect(message == .provide(text: "a\nb\nc"))
+  }
+
+  @Test
+  func decodeParsesServerCapsAndPerFormatLimits() throws {
+    var body = Data()
+    let flags =
+      VNCExtendedClipboard.capsAction
+      | VNCExtendedClipboard.provideAction
+      | VNCExtendedClipboard.requestAction
+      | VNCExtendedClipboard.textFormat
+    var bigEndianFlags = flags.bigEndian
+    withUnsafeBytes(of: &bigEndianFlags) { body.append(contentsOf: $0) }
+    var bigEndianSize = UInt32(4_096).bigEndian
+    withUnsafeBytes(of: &bigEndianSize) { body.append(contentsOf: $0) }
+
+    guard case .caps(let caps) = try VNCExtendedClipboard.decode(body: body) else {
+      Issue.record("expected caps message")
+      return
+    }
+
+    #expect(caps.supportsText)
+    #expect(caps.maximumUnsolicitedTextBytes == 4_096)
+    #expect(caps.supportsProvide)
+    #expect(caps.supportsRequest)
+    #expect(!caps.supportsNotify)
+    #expect(caps.allowsUnsolicitedText(byteCount: 4_096))
+    #expect(!caps.allowsUnsolicitedText(byteCount: 4_097))
+  }
+
+  @Test
+  func decodeParsesFlagOnlyActions() throws {
+    #expect(
+      try VNCExtendedClipboard.decode(body: VNCExtendedClipboard.encodeRequestText())
+        == .request(text: true)
+    )
+    #expect(
+      try VNCExtendedClipboard.decode(body: VNCExtendedClipboard.encodePeek()) == .peek
+    )
+    #expect(
+      try VNCExtendedClipboard.decode(body: VNCExtendedClipboard.encodeNotify(hasText: true))
+        == .notify(text: true)
+    )
+    #expect(
+      try VNCExtendedClipboard.decode(body: VNCExtendedClipboard.encodeNotify(hasText: false))
+        == .notify(text: false)
+    )
+  }
+
+  @Test
+  func decodeRejectsTruncatedAndAmbiguousBodies() {
+    #expect(throws: VNCExtendedClipboardError.bodyTooShort) {
+      _ = try VNCExtendedClipboard.decode(body: Data([0x02, 0x00]))
+    }
+
+    let twoActions =
+      VNCExtendedClipboard.requestAction | VNCExtendedClipboard.notifyAction
+    var body = Data()
+    var bigEndianFlags = twoActions.bigEndian
+    withUnsafeBytes(of: &bigEndianFlags) { body.append(contentsOf: $0) }
+
+    #expect(throws: VNCExtendedClipboardError.unknownAction(flags: twoActions)) {
+      _ = try VNCExtendedClipboard.decode(body: body)
+    }
+  }
+
+  @Test
+  func provideWithoutTextFormatYieldsNilText() throws {
+    var body = Data()
+    let flags = VNCExtendedClipboard.provideAction | (1 << 2)  // HTML only
+    var bigEndianFlags = UInt32(flags).bigEndian
+    withUnsafeBytes(of: &bigEndianFlags) { body.append(contentsOf: $0) }
+    body.append(try ZlibOneShot.deflate(Data([0, 0, 0, 0])))
+
+    let message = try VNCExtendedClipboard.decode(body: body)
+
+    #expect(message == .provide(text: nil))
+  }
+
+  @Test
+  func encodeProvideRejectsOversizedText() {
+    let oversized = String(repeating: "a", count: VNCExtendedClipboard.maximumTextBytes)
+
+    #expect(throws: VNCExtendedClipboardError.textTooLarge) {
+      _ = try VNCExtendedClipboard.encodeProvide(text: oversized)
+    }
+  }
+
+  @Test
+  func textRouteHonorsPeerReceivableActions() {
+    func caps(actions: UInt32, unsolicited: UInt32 = 1_024) -> VNCExtendedClipboardCaps {
+      .init(supportsText: true, maximumUnsolicitedTextBytes: unsolicited, actions: actions)
+    }
+
+    let allActions =
+      VNCExtendedClipboard.provideAction
+      | VNCExtendedClipboard.notifyAction
+      | VNCExtendedClipboard.requestAction
+
+    #expect(
+      VNCExtendedClipboard.textRoute(wireByteCount: 100, caps: caps(actions: allActions))
+        == .provide
+    )
+    // Payload beyond the unsolicited limit downgrades to notify.
+    #expect(
+      VNCExtendedClipboard.textRoute(wireByteCount: 2_048, caps: caps(actions: allActions))
+        == .notify
+    )
+    // Peers that never advertised provide must not receive one.
+    #expect(
+      VNCExtendedClipboard.textRoute(
+        wireByteCount: 100,
+        caps: caps(actions: VNCExtendedClipboard.notifyAction)
+      ) == .notify
+    )
+    // Neither provide nor notify receivable: fall back to legacy cut text.
+    #expect(
+      VNCExtendedClipboard.textRoute(
+        wireByteCount: 100,
+        caps: caps(actions: VNCExtendedClipboard.requestAction)
+      ) == .legacy
+    )
+    // No text format at all: legacy.
+    #expect(
+      VNCExtendedClipboard.textRoute(
+        wireByteCount: 100,
+        caps: .init(supportsText: false, maximumUnsolicitedTextBytes: 0, actions: allActions)
+      ) == .legacy
+    )
+  }
+
+  @Test
+  func wireTextByteCountCountsCRLFExpansionAndNul() {
+    #expect(VNCExtendedClipboard.wireTextByteCount("") == 1)
+    #expect(VNCExtendedClipboard.wireTextByteCount("ab") == 3)
+    #expect(VNCExtendedClipboard.wireTextByteCount("a\nb") == 5)
+  }
+
+  @Test
+  func frameUsesNegativeBigEndianLength() {
+    let framed = VNCExtendedClipboard.frame(messageType: 6, body: Data([0xAA, 0xBB]))
+
+    #expect(framed == Data([6, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFE, 0xAA, 0xBB]))
+  }
+
+  @Test
+  func inflateEnforcesDecompressionCap() throws {
+    let compressed = try ZlibOneShot.deflate(Data(count: 100_000))
+
+    #expect(throws: (any Error).self) {
+      _ = try ZlibOneShot.inflate(compressed, maximumDecompressedBytes: 10_000)
+    }
+
+    let roundtrip = try ZlibOneShot.inflate(compressed, maximumDecompressedBytes: 100_000)
+    #expect(roundtrip == Data(count: 100_000))
+  }
+
+  @Test
+  func receivesExtendedProvideThroughServerCutText() async throws {
+    let body = try VNCExtendedClipboard.encodeProvide(text: "π ≠ 3 🚀")
+    var payload = Data([0, 0, 0])
+    var bigEndianLength = Int32(-body.count).bigEndian
+    withUnsafeBytes(of: &bigEndianLength) { payload.append(contentsOf: $0) }
+    payload.append(body)
+
+    let message = try await VNCProtocol.ServerCutText.receive(
+      connection: ExtendedClipboardBufferConnection(payload),
+      logger: VNCPrintLogger()
+    )
+
+    #expect(message.extended == .provide(text: "π ≠ 3 🚀"))
+  }
+}
+
+private final class ExtendedClipboardBufferConnection: NetworkConnectionReading {
+  private let data: Data
+  private var offset = 0
+
+  init(_ data: Data) {
+    self.data = data
+  }
+
+  func read(minimumLength: Int, maximumLength: Int) async throws -> Data {
+    let remaining = data.count - offset
+    guard minimumLength > 0, maximumLength >= minimumLength, remaining >= minimumLength else {
+      throw VNCError.protocol(.noData)
+    }
+
+    let count = min(maximumLength, remaining)
+    defer { offset += count }
+    return data.subdata(in: offset..<(offset + count))
+  }
+}

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Tests/RoyalVNCKitTests/ProtocolLimitsTests.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Tests/RoyalVNCKitTests/ProtocolLimitsTests.swift
@@ -228,13 +228,24 @@ struct ProtocolLimitsTests {
   }
 
   @Test
-  func rejectsUnadvertisedExtendedClipboardMessages() async {
-    let negativeLength = UInt32(bitPattern: Int32(-8))
-    let connection = BufferConnection(serverCutTextHeader(length: negativeLength))
+  func dropsMalformedExtendedClipboardBodiesWithoutDesynchronizing() async throws {
+    // Two action bits at once is invalid; the fully-read body must be dropped
+    // without tearing down the connection.
+    let malformedFlags: UInt32 =
+      VNCExtendedClipboard.requestAction | VNCExtendedClipboard.notifyAction
+    var payload = serverCutTextHeader(length: UInt32(bitPattern: Int32(-4)))
+    var bigEndianFlags = malformedFlags.bigEndian
+    withUnsafeBytes(of: &bigEndianFlags) { payload.append(contentsOf: $0) }
+    let connection = BufferConnection(payload)
 
-    await #expect(throws: (any Error).self) {
-      try await VNCProtocol.ServerCutText.receive(connection: connection, logger: VNCPrintLogger())
-    }
+    let message = try await VNCProtocol.ServerCutText.receive(
+      connection: connection,
+      logger: VNCPrintLogger()
+    )
+
+    #expect(message.extended == nil)
+    #expect(message.isExtended)
+    #expect(message.text.isEmpty)
   }
 
   @Test

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/UPSTREAM.md
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/UPSTREAM.md
@@ -15,5 +15,13 @@ coalesces inbound clipboard delivery; paces framebuffer pulls; renders an
 attached warm framebuffer immediately; negotiates RFB 3.3/3.7/3.8 security
 framing; prefers supported Apple Remote Desktop authentication when macOS
 Screen Sharing advertises it; validates palette ranges; and materializes bounded framebuffer
-previews. Keep product changes in the Crabfleet target; keep this fork small
-and suitable for upstreaming.
+previews.
+
+The fork completes the upstream Extended Clipboard stub (pseudo-encoding
+`0xc0a1e5ce`): the client advertises the extension when clipboard sync is
+enabled, answers server caps, exchanges UTF-8 text through bounded
+notify/request/provide flows with one-shot zlib coding, and transparently
+falls back to Latin-1 cut text against servers without the extension. The
+`VNCExtendedClipboard` codec is public so the application's own RFB host can
+speak the same dialect. Keep product changes in the Crabfleet target; keep
+this fork small and suitable for upstreaming.


### PR DESCRIPTION
Closes the Jump Desktop-parity gaps in the native Mac client, focused on making Share This Mac a real remote-desktop host.

## What changed

- **UTF-8 clipboard end to end.** Completes the RoyalVNCKit fork's Extended Clipboard stub (pseudo-encoding 0xc0a1e5ce): caps negotiation, notify/request/provide with bounded one-shot zlib coding, a public codec shared by the app's RFB host, capability-honoring send routing (never sends provide/notify a peer did not advertise), Latin-1 legacy fallback, and malformed extension bodies dropped without desyncing or being misdelivered as empty legacy text.
- **Host clipboard, both directions.** Share This Mac previously discarded client cut text and never sent its own clipboard. A new HostClipboardBridge syncs the host pasteboard with the connected peer, echo-suppressed and bounded at 1 MiB, with a pre-share opt-out.
- **Viewer clipboard directions.** Persisted Send & Receive / Send Only / Receive Only picker in the focus toolbar; explicit Send/Get actions bypass the gating.
- **Display selection.** The host can share any connected display instead of always the primary one.
- **Remote resize on the host.** Announces ExtendedDesktopSize, handles SetDesktopSize by aspect-fitting the request up to the display's native pixel resolution (bounded 2560x1600), re-targets the live capture, keeps pointer scaling in sync, and gates frames on the announced size.
- **Unattended access.** "Start sharing when I log in" registers the bundled app via SMAppService and auto-starts the share; the persisted request is reconciled against the live login-item status so disabling it in System Settings sticks.
- **Listener fix for current macOS.** NWListener with requiredLocalEndpoint hands out child connections that re-bind the endpoint and fail with EADDRINUSE, so Share This Mac could never accept a connection. The port now binds wide and every accepted connection must prove it arrived on the exact Tailscale address before any protocol bytes; the same-user whois gate is unchanged.

## Proof

- 39 fork tests + 88 app tests green, including a new ungated loopback end-to-end test that runs the production server against the real RoyalVNCKit client over TCP and verifies emoji clipboard in both directions plus ExtendedDesktopSize negotiation.
- Bundled app builds and signs via pnpm macos:bundle; repo pnpm check green.
- Codex autoreview (gpt-5.5) run to clean across four cycles; accepted findings (provide-capability gating, stale auto-share reconciliation, malformed-extended-body delivery) are fixed in this diff.

Docs: macos-native-client.md limits/host sections and the fork's UPSTREAM.md updated; changelog entries included.
