### PR TITLE
feat(macos): hardware H.264 video pipeline for Share This Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add a VideoToolbox-backed Open H.264 RFB pipeline for Share This Mac with up to 60 fps capture, adaptive 1.5–30 Mbit/s rate control, automatic Tight/JPEG fallback, live stream stats, larger resize limits, and a persisted host-enforced view-only mode.
 - Exchange full UTF-8 clipboard text between the native Mac viewer, Share This Mac hosts, and any Extended Clipboard-capable VNC server by completing the RoyalVNCKit fork's extension stub, keeping Latin-1 cut text as the fallback and dropping malformed extension bodies without tearing down the connection.
 - Add persisted send-only and receive-only clipboard directions to the native viewer's focus toolbar; automatic sync respects the direction while the explicit Send and Get actions keep working.
 - Sync the host Mac's clipboard with the connected peer in both directions during Share This Mac sessions, with a pre-share opt-out, echo suppression, and the shared 1 MiB text bound; previously client cut text was discarded and the host never sent its clipboard.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Crabfleet gives OpenClaw maintainers a fleet dashboard where every Codex crabbox
 - **Issue/PR lookup.** Type `#123` in search to preview matching GitHub issues or PRs across enabled OpenClaw repos and create a card from the match.
 - **Codex run control.** Start durable run attempts, track heartbeats, watch the Ghostty WASM session grid, and take over only when the selected runtime advertises that capability.
 - **Interactive Crabboxes.** Start a standalone Codex CLI workspace for manual cloud work and attach it in the same fullscreen Ghostty grid or WebVNC.
+- **Share This Mac.** Stream a selected Mac display privately over Tailscale with hardware H.264 at up to 60 fps, adaptive bitrate, automatic Tight/JPEG fallback, and a live view-only mode.
 - **Steerable GitHub Actions.** Register an Actions job as a durable `github_actions` session, stream its PTY outbound into Ghostty, steer it from the browser, and report work state and Codex thread/turn IDs.
 - **Worker-owned sandbox credentials.** Built-in Cloudflare Sandbox sessions get placeholder env credentials; Worker-controlled outbound routing injects model and GitHub credentials only for approved upstream requests.
 - **Diff previews.** Card tiles show changed files and totals; the run drawer shows a compact Codiff-style patch view.

--- a/docs/macos-native-client.md
+++ b/docs/macos-native-client.md
@@ -27,8 +27,9 @@ app-owned private desktop host for Mac-to-Mac access.
 - RFB 3.3, 3.7, and 3.8 framing is supported, including server-selected RFB
   3.3 None and VNC-password authentication.
 - Client-side fit scaling and rendering use RoyalVNCKit's IOSurface/Metal path.
-- Share This Mac captures the primary display with ScreenCaptureKit and serves
-  RFB 3.8 Tight/JPEG frames without enabling Apple's Screen Sharing daemon.
+- Share This Mac captures a selected display with ScreenCaptureKit and serves
+  RFB 3.8 Open H.264 or Tight/JPEG frames without enabling Apple's Screen
+  Sharing daemon.
 - The host binds port 5901 only to a verified Tailscale `100.64.0.0/10` address,
   requires a valid identity on the active tailnet, and admits only a
   Tailscale-authorized peer owned by that same user.
@@ -62,11 +63,12 @@ relay, Cloudflare, or the Crabfleet Worker.
 1. Tailscale status must report `BackendState=Running`, a valid active tailnet,
    an online signed-in user, and a CGNAT address in `100.64.0.0/10`.
 2. The app captures the selected display (default: main) at a bounded even
-   resolution no larger than 1600×1000 and encodes at most 15 Tight/JPEG frames
-   per second. When the connected viewer requests a desktop size, the host
+   resolution no larger than 2560×1600. Open H.264 viewers receive up to 60
+   frames per second; other viewers receive at most 15 Tight/JPEG frames per
+   second. When the connected viewer requests a desktop size, the host
    re-targets the capture to aspect-fit that request up to the display's native
-   pixel resolution (bounded at 2560×1600), so the remote desktop follows the
-   viewer window.
+   pixel resolution and the active codec's cap, so the remote desktop follows
+   the viewer window.
 3. An RFB listener binds port 5901. Binding the Tailscale address directly is
    not viable on current macOS — accepted Network-framework child connections
    re-bind a required local endpoint and fail with `EADDRINUSE` — so instead
@@ -90,6 +92,20 @@ relay, Cloudflare, or the Crabfleet Worker.
    reboot without manual setup (the equivalent of `--share-this-mac` for
    unattended hosts).
 
+### Video pipeline
+
+The viewer prefers the community RFB Open H.264 encoding (type 50). The host
+uses VideoToolbox's low-latency rate control with the constrained baseline
+profile the encoding prescribes, prepends SPS/PPS to IDR frames, and sends
+Annex-B video with explicit decoder resets on session start and resize. The
+viewer decodes every access unit in a rectangle (third-party servers may glue
+several frames together) and displays the last. Initial capture is capped at 2560×1600 at 60 fps; H.264 resize may
+reach 4096×2304 within the selected display's native pixel size. An AIMD
+controller adapts from 8 Mbit/s within a 1.5–30 Mbit/s range based on network
+send time. If H.264 setup or encoding fails, the session automatically returns
+to the negotiated 15 fps Tight/JPEG path. The share sheet reports codec,
+hardware acceleration, frame rate, and throughput while connected.
+
 After the first Screen Recording grant, restart the bundled app before starting
 the share. Ad-hoc development signatures do not provide a stable TCC identity,
 so a rebuilt prototype may need permission again. Sign every iterative build
@@ -97,7 +113,8 @@ with the same Apple Development or Developer ID identity to preserve the app's
 code requirement and permission identity.
 
 Accessibility is not required to start the listener. Without it, Crabfleet
-serves a view-only desktop and discards remote keyboard and pointer events.
+serves a view-only desktop. The persisted View only toggle can also discard
+remote keyboard and pointer events live even when Accessibility is available.
 
 Tailscale supplies the encrypted, ACL-controlled transport and peer identity;
 RFB None authentication is accepted only inside that already-authenticated
@@ -148,9 +165,9 @@ from the build, or obtain written provenance approval.
   disabled until their parsers and cryptography are replaced or fully tested.
 - Password authentication uses a process-global DES key schedule. The fork
   serializes that path; replace it before concurrent password-auth sessions.
-- App-owned hosting shares one selected display at a time to a single client,
-  as lossy Tight/JPEG at most 15 fps, capped at 1600×1000 until the viewer
-  requests a size (then up to native pixels, bounded at 2560×1600).
+- App-owned hosting shares one selected display at a time to a single client.
+  Open H.264 reaches 60 fps at an initial 2560×1600 cap and resizes up to
+  4096×2304; Tight/JPEG fallback remains capped at 15 fps and 2560×1600.
 - Audio is not implemented.
 - A connecting peer must be another device owned by the same Tailscale user.
   Team-wide or named-user sharing is intentionally unsupported.

--- a/macos/CrabfleetMac/Package.swift
+++ b/macos/CrabfleetMac/Package.swift
@@ -23,7 +23,9 @@ let package = Package(
         .swiftLanguageMode(.v5)
       ],
       linkerSettings: [
-        .linkedFramework("Security")
+        .linkedFramework("Security"),
+        .linkedFramework("VideoToolbox"),
+        .linkedFramework("CoreMedia"),
       ]
     ),
     .testTarget(

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/MacRemoteInput.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/MacRemoteInput.swift
@@ -6,10 +6,12 @@ protocol RemoteInputForwarding: Sendable {
   func keyEvent(down: Bool, keysym: UInt32)
   func pointerEvent(buttonMask: UInt8, x: UInt16, y: UInt16)
   func updateFrameSize(width: Int, height: Int)
+  func releaseAllInput()
 }
 
 extension RemoteInputForwarding {
   func updateFrameSize(width: Int, height: Int) {}
+  func releaseAllInput() {}
 }
 
 final class MacRemoteInputController: RemoteInputForwarding, @unchecked Sendable {
@@ -22,11 +24,14 @@ final class MacRemoteInputController: RemoteInputForwarding, @unchecked Sendable
   private var frameWidth: Int
   private var frameHeight: Int
   private var previousButtonMask: UInt8 = 0
+  private var previousPointerLocation: CGPoint
+  private var pressedKeysyms: Set<UInt32> = []
 
   init(descriptor: CapturedDisplayDescriptor) {
     self.descriptor = descriptor
     frameWidth = descriptor.frameWidth
     frameHeight = descriptor.frameHeight
+    previousPointerLocation = descriptor.displayBounds.origin
   }
 
   /// Keeps pointer scaling aligned with the announced framebuffer size after
@@ -54,21 +59,12 @@ final class MacRemoteInputController: RemoteInputForwarding, @unchecked Sendable
   func keyEvent(down: Bool, keysym: UInt32) {
     eventQueue.async { [self] in
       guard Self.isAccessibilityGranted else { return }
-      let event: CGEvent?
-      if let keyCode = Self.keyCode(for: keysym) {
-        event = CGEvent(keyboardEventSource: eventSource(), virtualKey: keyCode, keyDown: down)
-      } else if let scalar = UnicodeScalar(keysym) {
-        let candidate = CGEvent(keyboardEventSource: eventSource(), virtualKey: 0, keyDown: down)
-        var codeUnits = Array(String(scalar).utf16)
-        candidate?.keyboardSetUnicodeString(
-          stringLength: codeUnits.count,
-          unicodeString: &codeUnits
-        )
-        event = candidate
+      postKeyEvent(down: down, keysym: keysym)
+      if down {
+        pressedKeysyms.insert(keysym)
       } else {
-        event = nil
+        pressedKeysyms.remove(keysym)
       }
-      event?.post(tap: .cghidEventTap)
     }
   }
 
@@ -76,6 +72,7 @@ final class MacRemoteInputController: RemoteInputForwarding, @unchecked Sendable
     eventQueue.async { [self] in
       guard Self.isAccessibilityGranted else { return }
       let location = mappedLocation(x: x, y: y)
+      previousPointerLocation = location
       let changedButtons = previousButtonMask ^ buttonMask
       var postedButtonChange = false
 
@@ -117,6 +114,44 @@ final class MacRemoteInputController: RemoteInputForwarding, @unchecked Sendable
       if newWheelBits & 0x40 != 0 { postScroll(vertical: 0, horizontal: -1) }
       previousButtonMask = buttonMask
     }
+  }
+
+  func releaseAllInput() {
+    eventQueue.async { [self] in
+      guard Self.isAccessibilityGranted else { return }
+      for keysym in pressedKeysyms {
+        postKeyEvent(down: false, keysym: keysym)
+      }
+      pressedKeysyms.removeAll()
+
+      for button in Self.mouseButtons where previousButtonMask & button.mask != 0 {
+        CGEvent(
+          mouseEventSource: eventSource(),
+          mouseType: button.upType,
+          mouseCursorPosition: previousPointerLocation,
+          mouseButton: button.button
+        )?.post(tap: .cghidEventTap)
+      }
+      previousButtonMask = 0
+    }
+  }
+
+  private func postKeyEvent(down: Bool, keysym: UInt32) {
+    let event: CGEvent?
+    if let keyCode = Self.keyCode(for: keysym) {
+      event = CGEvent(keyboardEventSource: eventSource(), virtualKey: keyCode, keyDown: down)
+    } else if let scalar = UnicodeScalar(keysym) {
+      let candidate = CGEvent(keyboardEventSource: eventSource(), virtualKey: 0, keyDown: down)
+      var codeUnits = Array(String(scalar).utf16)
+      candidate?.keyboardSetUnicodeString(
+        stringLength: codeUnits.count,
+        unicodeString: &codeUnits
+      )
+      event = candidate
+    } else {
+      event = nil
+    }
+    event?.post(tap: .cghidEventTap)
   }
 
   private func eventSource() -> CGEventSource? {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/MacScreenCapture.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/MacScreenCapture.swift
@@ -29,6 +29,33 @@ actor CapturedDesktopFrameStore {
   }
 }
 
+private actor CaptureConfigurationGate {
+  private var tail = Task<Void, Never> {}
+
+  func run<T: Sendable>(
+    _ operation: @escaping @Sendable () async throws -> T
+  ) async throws -> T {
+    let predecessor = tail
+    let result = Task<Result<T, Error>, Never> {
+      await predecessor.value
+      do {
+        return .success(try await operation())
+      } catch {
+        return .failure(error)
+      }
+    }
+    tail = Task { _ = await result.value }
+    return try await result.value.get()
+  }
+}
+
+/// A captured frame handed from the ScreenCaptureKit callback to the encode
+/// path. CVPixelBuffer is thread-safe to retain and read across queues.
+struct VideoPixelSource: @unchecked Sendable {
+  let pixelBuffer: CVPixelBuffer
+  let presentationTime: CMTime
+}
+
 struct CapturedDisplayDescriptor: Equatable, Sendable {
   let displayID: CGDirectDisplayID
   let displayBounds: CGRect
@@ -60,10 +87,14 @@ final class MacScreenCapture: NSObject, @unchecked Sendable {
     .cacheIntermediates: false
   ])
   private let frameLock = NSLock()
+  private let configurationGate = CaptureConfigurationGate()
   private var sequence: UInt64 = 0
   private var consumerActive = false
+  private var videoFrameHandler: (@Sendable (CVPixelBuffer, CMTime) -> Void)?
+  private var latestVideoSource: (pixelBuffer: CVPixelBuffer, presentationTime: CMTime)?
   private var stream: SCStream?
   private var configuration: SCStreamConfiguration?
+  private var contentFilter: SCContentFilter?
 
   static func availableDisplays() async -> [ShareableDisplayOption] {
     guard let shareableContent = try? await SCShareableContent.current else { return [] }
@@ -115,8 +146,11 @@ final class MacScreenCapture: NSObject, @unchecked Sendable {
     let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
     try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: captureQueue)
     try await stream.startCapture()
-    self.stream = stream
-    self.configuration = configuration
+    try await configurationGate.run { [self] in
+      self.stream = stream
+      self.configuration = configuration
+      self.contentFilter = filter
+    }
 
     return CapturedDisplayDescriptor(
       displayID: displayID,
@@ -130,19 +164,38 @@ final class MacScreenCapture: NSObject, @unchecked Sendable {
 
   /// Re-targets the running stream to a new output size for remote-resize.
   func updateOutputSize(width: Int, height: Int) async throws {
-    guard let stream, let configuration else {
-      throw PrivateMacShareError.captureUnavailable
+    try await configurationGate.run { [self] in
+      guard let stream, let configuration else {
+        throw PrivateMacShareError.captureUnavailable
+      }
+      configuration.width = width
+      configuration.height = height
+      try await stream.updateConfiguration(configuration)
     }
-    configuration.width = width
-    configuration.height = height
-    try await stream.updateConfiguration(configuration)
+  }
+
+  func updateFrameInterval(framesPerSecond: Int) async throws {
+    try await configurationGate.run { [self] in
+      guard framesPerSecond > 0, let stream, let configuration else {
+        throw PrivateMacShareError.captureUnavailable
+      }
+      configuration.minimumFrameInterval = CMTime(
+        value: 1, timescale: CMTimeScale(framesPerSecond))
+      try await stream.updateConfiguration(configuration)
+    }
   }
 
   func stop() async {
-    guard let stream else { return }
-    self.stream = nil
-    self.configuration = nil
-    try? await stream.stopCapture()
+    let stopped = try? await configurationGate.run { [self] in
+      guard let stream else { return false }
+      self.stream = nil
+      self.configuration = nil
+      self.contentFilter = nil
+      try? await stream.stopCapture()
+      return true
+    }
+    guard stopped == true else { return }
+    clearLatestVideoSource()
     await frameStore.clear()
   }
 
@@ -152,12 +205,69 @@ final class MacScreenCapture: NSObject, @unchecked Sendable {
     frameLock.unlock()
   }
 
+  func setVideoFrameHandler(
+    _ handler: (@Sendable (CVPixelBuffer, CMTime) -> Void)?
+  ) {
+    frameLock.lock()
+    videoFrameHandler = handler
+    frameLock.unlock()
+  }
+
+  func latestVideoFrame() -> (pixelBuffer: CVPixelBuffer, presentationTime: CMTime)? {
+    frameLock.lock()
+    defer { frameLock.unlock() }
+    return latestVideoSource
+  }
+
+  /// Renders a one-shot screenshot into the JPEG frame store. The store goes
+  /// stale while a video handler consumes capture output, so the Tight path
+  /// needs this after an H.264 fallback on a static screen.
+  func refreshJPEGFrame() async -> Bool {
+    guard let source = await snapshotVideoFrame(),
+      let jpegData = encodeJPEG(source.pixelBuffer),
+      jpegData.count <= 4 * 1_024 * 1_024
+    else {
+      return false
+    }
+    let frame = CapturedDesktopFrame(
+      jpegData: jpegData,
+      sequence: nextSequence(),
+      width: CVPixelBufferGetWidth(source.pixelBuffer),
+      height: CVPixelBufferGetHeight(source.pixelBuffer)
+    )
+    await frameStore.update(frame)
+    return true
+  }
+
+  /// One-shot capture for when a frame is needed but the stream has nothing
+  /// cached — a fresh session or resize on a static screen delivers no stream
+  /// output until content changes.
+  func snapshotVideoFrame() async -> (pixelBuffer: CVPixelBuffer, presentationTime: CMTime)? {
+    let source = try? await configurationGate.run { [self] in
+      guard let contentFilter, let configuration else {
+        throw PrivateMacShareError.captureUnavailable
+      }
+      let sampleBuffer = try await SCScreenshotManager.captureSampleBuffer(
+        contentFilter: contentFilter,
+        configuration: configuration)
+      guard let pixelBuffer = sampleBuffer.imageBuffer else {
+        throw PrivateMacShareError.captureUnavailable
+      }
+      return VideoPixelSource(
+        pixelBuffer: pixelBuffer,
+        presentationTime: sampleBuffer.presentationTimeStamp)
+    }
+    guard let source else { return nil }
+    retainVideoSource(source.pixelBuffer, presentationTime: source.presentationTime)
+    return (source.pixelBuffer, source.presentationTime)
+  }
+
   static func captureDimensions(sourceWidth: Int, sourceHeight: Int) -> (
     width: Int,
     height: Int
   ) {
-    let maximumWidth = 1_600.0
-    let maximumHeight = 1_000.0
+    let maximumWidth = 2_560.0
+    let maximumHeight = 1_600.0
     let width = max(Double(sourceWidth), 1)
     let height = max(Double(sourceHeight), 1)
     let scale = min(1, maximumWidth / width, maximumHeight / height)
@@ -172,10 +282,10 @@ final class MacScreenCapture: NSObject, @unchecked Sendable {
     requestedWidth: Int,
     requestedHeight: Int,
     sourcePixelWidth: Int,
-    sourcePixelHeight: Int
+    sourcePixelHeight: Int,
+    maximumWidth: Double = 2_560,
+    maximumHeight: Double = 1_600
   ) -> (width: Int, height: Int) {
-    let maximumWidth = 2_560.0
-    let maximumHeight = 1_600.0
     let requestWidth = min(max(Double(requestedWidth), 320), maximumWidth)
     let requestHeight = min(max(Double(requestedHeight), 240), maximumHeight)
     let sourceWidth = max(Double(sourcePixelWidth), 1)
@@ -221,6 +331,24 @@ final class MacScreenCapture: NSObject, @unchecked Sendable {
     frameLock.lock()
     defer { frameLock.unlock() }
     return consumerActive
+  }
+
+  private func currentVideoFrameHandler() -> (@Sendable (CVPixelBuffer, CMTime) -> Void)? {
+    frameLock.lock()
+    defer { frameLock.unlock() }
+    return videoFrameHandler
+  }
+
+  private func retainVideoSource(_ pixelBuffer: CVPixelBuffer, presentationTime: CMTime) {
+    frameLock.lock()
+    latestVideoSource = (pixelBuffer, presentationTime)
+    frameLock.unlock()
+  }
+
+  private func clearLatestVideoSource() {
+    frameLock.lock()
+    latestVideoSource = nil
+    frameLock.unlock()
   }
 
   private func encodeJPEG(_ pixelBuffer: CVPixelBuffer) -> Data? {
@@ -274,7 +402,19 @@ extension MacScreenCapture: SCStreamOutput, SCStreamDelegate {
       let attachments = attachmentsArray.first,
       let statusRawValue = attachments[.status] as? Int,
       SCFrameStatus(rawValue: statusRawValue) == .complete,
-      let pixelBuffer = sampleBuffer.imageBuffer,
+      let pixelBuffer = sampleBuffer.imageBuffer
+    else {
+      return
+    }
+
+    retainVideoSource(pixelBuffer, presentationTime: sampleBuffer.presentationTimeStamp)
+
+    if let handler = currentVideoFrameHandler() {
+      handler(pixelBuffer, sampleBuffer.presentationTimeStamp)
+      return
+    }
+
+    guard
       let jpegData = encodeJPEG(pixelBuffer),
       jpegData.count <= 4 * 1_024 * 1_024
     else {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/MacVideoEncoder.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/MacVideoEncoder.swift
@@ -1,0 +1,404 @@
+import CoreMedia
+import Foundation
+import VideoToolbox
+
+struct EncodedVideoFrame: Sendable {
+  let data: Data
+  let isKeyframe: Bool
+  let width: Int
+  let height: Int
+}
+
+enum MacVideoEncoderError: Error {
+  case creationFailed(OSStatus)
+  case invalidSample
+  case malformedNALUnits
+}
+
+struct VideoKeyframePolicy: Sendable {
+  private var framesSinceKeyframe = 0
+  private var lastKeyframeTime: Double?
+
+  mutating func shouldForceKeyframe(
+    explicit: Bool,
+    recovery: Bool,
+    presentationSeconds: Double
+  ) -> Bool {
+    if lastKeyframeTime == nil, presentationSeconds.isFinite {
+      lastKeyframeTime = presentationSeconds
+    }
+    let intervalElapsed = presentationSeconds.isFinite
+      && presentationSeconds - (lastKeyframeTime ?? presentationSeconds) >= 30
+    let shouldForce = explicit || recovery || framesSinceKeyframe >= 1_799 || intervalElapsed
+    if shouldForce {
+      framesSinceKeyframe = 0
+      if presentationSeconds.isFinite { lastKeyframeTime = presentationSeconds }
+    } else {
+      framesSinceKeyframe += 1
+    }
+    return shouldForce
+  }
+}
+
+final class MacVideoEncoder: @unchecked Sendable {
+  let isHardwareAccelerated: Bool
+  let frames: AsyncStream<EncodedVideoFrame>
+
+  private let lock = NSLock()
+  private let continuation: AsyncStream<EncodedVideoFrame>.Continuation
+  private let callbackContext: CallbackContext
+  private let configuredWidth: Int
+  private let configuredHeight: Int
+  private var session: VTCompressionSession?
+  private var invalidated = false
+  private var keyframePolicy = VideoKeyframePolicy()
+  private var lastPresentationTime: CMTime?
+
+  init(width: Int, height: Int) throws {
+    let stream = AsyncStream<EncodedVideoFrame>.makeStream(
+      bufferingPolicy: .bufferingNewest(2))
+    frames = stream.stream
+    continuation = stream.continuation
+    callbackContext = CallbackContext(continuation: stream.continuation)
+    configuredWidth = width
+    configuredHeight = height
+
+    let lowLatencySpecification: CFDictionary = [
+      kVTVideoEncoderSpecification_EnableLowLatencyRateControl: true
+    ] as CFDictionary
+    let hardwareSpecification: CFDictionary = [
+      kVTVideoEncoderSpecification_EnableHardwareAcceleratedVideoEncoder: true
+    ] as CFDictionary
+
+    var createdSession: VTCompressionSession?
+    var usedLowLatency = false
+    var status = VTCompressionSessionCreate(
+      allocator: kCFAllocatorDefault,
+      width: Int32(width),
+      height: Int32(height),
+      codecType: kCMVideoCodecType_H264,
+      encoderSpecification: lowLatencySpecification,
+      imageBufferAttributes: nil,
+      compressedDataAllocator: nil,
+      outputCallback: Self.outputCallback,
+      refcon: Unmanaged.passUnretained(callbackContext).toOpaque(),
+      compressionSessionOut: &createdSession
+    )
+    if status == noErr {
+      usedLowLatency = true
+    } else {
+      status = VTCompressionSessionCreate(
+        allocator: kCFAllocatorDefault,
+        width: Int32(width),
+        height: Int32(height),
+        codecType: kCMVideoCodecType_H264,
+        encoderSpecification: hardwareSpecification,
+        imageBufferAttributes: nil,
+        compressedDataAllocator: nil,
+        outputCallback: Self.outputCallback,
+        refcon: Unmanaged.passUnretained(callbackContext).toOpaque(),
+        compressionSessionOut: &createdSession
+      )
+    }
+    if status != noErr {
+      status = VTCompressionSessionCreate(
+        allocator: kCFAllocatorDefault,
+        width: Int32(width),
+        height: Int32(height),
+        codecType: kCMVideoCodecType_H264,
+        encoderSpecification: nil,
+        imageBufferAttributes: nil,
+        compressedDataAllocator: nil,
+        outputCallback: Self.outputCallback,
+        refcon: Unmanaged.passUnretained(callbackContext).toOpaque(),
+        compressionSessionOut: &createdSession
+      )
+    }
+    guard status == noErr, let createdSession else {
+      stream.continuation.finish()
+      throw MacVideoEncoderError.creationFailed(status)
+    }
+
+    session = createdSession
+    Self.setProperty(createdSession, key: kVTCompressionPropertyKey_RealTime, value: true)
+    // The Open H.264 RFB encoding prescribes the baseline profile; third-party
+    // viewers may not decode anything richer.
+    Self.setProperty(
+      createdSession,
+      key: kVTCompressionPropertyKey_ProfileLevel,
+      value: kVTProfileLevel_H264_ConstrainedBaseline_AutoLevel)
+    Self.setProperty(
+      createdSession, key: kVTCompressionPropertyKey_AllowFrameReordering, value: false)
+    Self.setProperty(
+      createdSession, key: kVTCompressionPropertyKey_MaxKeyFrameInterval, value: 1_800)
+    Self.setProperty(
+      createdSession, key: kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration, value: 30)
+    Self.setProperty(
+      createdSession, key: kVTCompressionPropertyKey_ExpectedFrameRate, value: 60)
+    Self.setProperty(
+      createdSession, key: kVTCompressionPropertyKey_AverageBitRate, value: 8_000_000)
+    _ = VTCompressionSessionPrepareToEncodeFrames(createdSession)
+
+    var hardwareValuePointer: UnsafeRawPointer?
+    let queryStatus = VTSessionCopyProperty(
+      createdSession,
+      key: kVTCompressionPropertyKey_UsingHardwareAcceleratedVideoEncoder,
+      allocator: kCFAllocatorDefault,
+      valueOut: &hardwareValuePointer)
+    let hardwareValue = hardwareValuePointer.map {
+      CFBooleanGetValue(Unmanaged<CFBoolean>.fromOpaque($0).takeRetainedValue())
+    } ?? false
+    isHardwareAccelerated = usedLowLatency
+      || (queryStatus == noErr && hardwareValue)
+  }
+
+  deinit {
+    invalidate()
+  }
+
+  /// Submits one frame; the encoded output arrives on `frames`. Returns false
+  /// when the frame is rejected (stale size, non-monotonic timestamp, or an
+  /// invalidated session) so callers can tell "no output coming" from failure.
+  @discardableResult
+  func encode(
+    _ pixelBuffer: CVPixelBuffer,
+    presentationTime: CMTime,
+    forceKeyframe: Bool
+  ) -> Bool {
+    lock.lock()
+    guard !invalidated, let activeSession = session,
+      CVPixelBufferGetWidth(pixelBuffer) == configuredWidth,
+      CVPixelBufferGetHeight(pixelBuffer) == configuredHeight,
+      presentationTime.isValid,
+      CMTimeGetSeconds(presentationTime).isFinite,
+      lastPresentationTime.map({ CMTimeCompare(presentationTime, $0) > 0 }) ?? true
+    else {
+      lock.unlock()
+      return false
+    }
+    let shouldForceKeyframe = keyframePolicy.shouldForceKeyframe(
+      explicit: forceKeyframe,
+      recovery: callbackContext.consumeKeyframeRequest(),
+      presentationSeconds: CMTimeGetSeconds(presentationTime))
+    lastPresentationTime = presentationTime
+    let properties: CFDictionary? = shouldForceKeyframe
+      ? [kVTEncodeFrameOptionKey_ForceKeyFrame: true] as CFDictionary
+      : nil
+    let status = VTCompressionSessionEncodeFrame(
+      activeSession,
+      imageBuffer: pixelBuffer,
+      presentationTimeStamp: presentationTime,
+      duration: .invalid,
+      frameProperties: properties,
+      sourceFrameRefcon: nil,
+      infoFlagsOut: nil)
+    lock.unlock()
+    if status != noErr {
+      fail()
+      return false
+    }
+    return true
+  }
+
+  func setAverageBitrate(_ bitsPerSecond: Int) {
+    guard let activeSession = withLock({ invalidated ? nil : session }) else { return }
+    Self.setProperty(
+      activeSession,
+      key: kVTCompressionPropertyKey_AverageBitRate,
+      value: bitsPerSecond)
+  }
+
+  func invalidate() {
+    let activeSession = withLock { () -> VTCompressionSession? in
+      guard !invalidated else { return nil }
+      invalidated = true
+      defer { session = nil }
+      return session
+    }
+    guard let activeSession else { return }
+    VTCompressionSessionCompleteFrames(activeSession, untilPresentationTimeStamp: .invalid)
+    VTCompressionSessionInvalidate(activeSession)
+    continuation.finish()
+  }
+
+  static func annexBData(
+    lengthPrefixedData: Data,
+    nalUnitHeaderLength: Int,
+    parameterSets: [Data] = [],
+    isKeyframe: Bool = false
+  ) throws -> Data {
+    guard (1...4).contains(nalUnitHeaderLength) else {
+      throw MacVideoEncoderError.malformedNALUnits
+    }
+    var output = Data()
+    if isKeyframe {
+      for parameterSet in parameterSets where !parameterSet.isEmpty {
+        output.append(contentsOf: [0, 0, 0, 1])
+        output.append(parameterSet)
+      }
+    }
+
+    var offset = 0
+    while offset < lengthPrefixedData.count {
+      guard offset + nalUnitHeaderLength <= lengthPrefixedData.count else {
+        throw MacVideoEncoderError.malformedNALUnits
+      }
+      var length = 0
+      for byte in lengthPrefixedData[offset..<(offset + nalUnitHeaderLength)] {
+        length = (length << 8) | Int(byte)
+      }
+      offset += nalUnitHeaderLength
+      guard length > 0, offset + length <= lengthPrefixedData.count else {
+        throw MacVideoEncoderError.malformedNALUnits
+      }
+      output.append(contentsOf: [0, 0, 0, 1])
+      output.append(lengthPrefixedData[offset..<(offset + length)])
+      offset += length
+    }
+    return output
+  }
+
+  private static let outputCallback: VTCompressionOutputCallback = {
+    outputCallbackRefCon, _, status, infoFlags, sampleBuffer in
+    guard let outputCallbackRefCon else { return }
+    let context = Unmanaged<CallbackContext>.fromOpaque(outputCallbackRefCon)
+      .takeUnretainedValue()
+    guard status == noErr else {
+      context.continuation.finish()
+      return
+    }
+    guard !infoFlags.contains(.frameDropped), let sampleBuffer else { return }
+    do {
+      let frame = try MacVideoEncoder.encodedFrame(from: sampleBuffer)
+      context.yield(frame)
+    } catch {
+      context.continuation.finish()
+    }
+  }
+
+  private final class CallbackContext: @unchecked Sendable {
+    let continuation: AsyncStream<EncodedVideoFrame>.Continuation
+    private let lock = NSLock()
+    private var needsKeyframe = false
+
+    init(continuation: AsyncStream<EncodedVideoFrame>.Continuation) {
+      self.continuation = continuation
+    }
+
+    func yield(_ frame: EncodedVideoFrame) {
+      lock.lock()
+      defer { lock.unlock() }
+      switch continuation.yield(frame) {
+      case .enqueued, .terminated:
+        break
+      case .dropped:
+        // The consumer never saw this frame, so later deltas would reference
+        // pixels the client is missing; resync at the next submitted frame.
+        needsKeyframe = true
+      @unknown default:
+        needsKeyframe = true
+      }
+    }
+
+    func consumeKeyframeRequest() -> Bool {
+      lock.lock()
+      defer { lock.unlock() }
+      defer { needsKeyframe = false }
+      return needsKeyframe
+    }
+  }
+
+  private static func encodedFrame(from sampleBuffer: CMSampleBuffer) throws
+    -> EncodedVideoFrame
+  {
+    guard CMSampleBufferDataIsReady(sampleBuffer),
+      let dataBuffer = CMSampleBufferGetDataBuffer(sampleBuffer),
+      let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer)
+    else {
+      throw MacVideoEncoderError.invalidSample
+    }
+
+    let dataLength = CMBlockBufferGetDataLength(dataBuffer)
+    guard dataLength > 0 else { throw MacVideoEncoderError.invalidSample }
+    var lengthPrefixedData = Data(count: dataLength)
+    let copyStatus = lengthPrefixedData.withUnsafeMutableBytes { bytes in
+      CMBlockBufferCopyDataBytes(
+        dataBuffer,
+        atOffset: 0,
+        dataLength: dataLength,
+        destination: bytes.baseAddress!)
+    }
+    guard copyStatus == kCMBlockBufferNoErr else {
+      throw MacVideoEncoderError.invalidSample
+    }
+
+    let attachments = CMSampleBufferGetSampleAttachmentsArray(
+      sampleBuffer, createIfNecessary: false) as? [[CFString: Any]]
+    let isKeyframe = !(attachments?.first?[kCMSampleAttachmentKey_NotSync] as? Bool ?? false)
+    let parameterSetInfo = try h264ParameterSets(from: formatDescription)
+    let data = try annexBData(
+      lengthPrefixedData: lengthPrefixedData,
+      nalUnitHeaderLength: parameterSetInfo.nalUnitHeaderLength,
+      parameterSets: parameterSetInfo.parameterSets,
+      isKeyframe: isKeyframe)
+    let dimensions = CMVideoFormatDescriptionGetDimensions(formatDescription)
+    return EncodedVideoFrame(
+      data: data,
+      isKeyframe: isKeyframe,
+      width: Int(dimensions.width),
+      height: Int(dimensions.height))
+  }
+
+  private static func h264ParameterSets(from formatDescription: CMFormatDescription) throws
+    -> (parameterSets: [Data], nalUnitHeaderLength: Int)
+  {
+    var parameterSetCount = 0
+    var nalUnitHeaderLength: Int32 = 0
+    var pointer: UnsafePointer<UInt8>?
+    var size = 0
+    let firstStatus = CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+      formatDescription,
+      parameterSetIndex: 0,
+      parameterSetPointerOut: &pointer,
+      parameterSetSizeOut: &size,
+      parameterSetCountOut: &parameterSetCount,
+      nalUnitHeaderLengthOut: &nalUnitHeaderLength)
+    guard firstStatus == noErr else { throw MacVideoEncoderError.invalidSample }
+
+    var parameterSets: [Data] = []
+    for index in 0..<parameterSetCount {
+      pointer = nil
+      size = 0
+      let status = CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+        formatDescription,
+        parameterSetIndex: index,
+        parameterSetPointerOut: &pointer,
+        parameterSetSizeOut: &size,
+        parameterSetCountOut: nil,
+        nalUnitHeaderLengthOut: nil)
+      guard status == noErr, let pointer, size > 0 else {
+        throw MacVideoEncoderError.invalidSample
+      }
+      parameterSets.append(Data(bytes: pointer, count: size))
+    }
+    return (parameterSets, Int(nalUnitHeaderLength))
+  }
+
+  private func fail() {
+    invalidate()
+  }
+
+  private static func setProperty(
+    _ session: VTCompressionSession,
+    key: CFString,
+    value: Any
+  ) {
+    _ = VTSessionSetProperty(session, key: key, value: value as CFTypeRef)
+  }
+
+  private func withLock<T>(_ body: () -> T) -> T {
+    lock.lock()
+    defer { lock.unlock() }
+    return body()
+  }
+}

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
@@ -62,6 +62,7 @@ final class PrivateMacShareController: ObservableObject {
   nonisolated static let selectedDisplayDefaultsKey = "org.openclaw.crabfleet.share.display"
   nonisolated static let clipboardSyncDefaultsKey = "org.openclaw.crabfleet.share.clipboard"
   nonisolated static let autoShareDefaultsKey = "org.openclaw.crabfleet.share.auto-share"
+  nonisolated static let viewOnlyDefaultsKey = "org.openclaw.crabfleet.share.view-only"
 
   @Published private(set) var identity: TailnetIdentity?
   @Published private(set) var phase: Phase = .idle
@@ -74,6 +75,7 @@ final class PrivateMacShareController: ObservableObject {
   @Published private(set) var registryPhase: RegistryPhase
   @Published private(set) var availableDisplays: [ShareableDisplayOption] = []
   @Published private(set) var launchAtLoginEnabled = false
+  @Published private(set) var streamStats: TailnetStreamStats?
 
   @Published var selectedDisplayID: CGDirectDisplayID {
     didSet {
@@ -84,6 +86,13 @@ final class PrivateMacShareController: ObservableObject {
   @Published var clipboardSyncEnabled: Bool {
     didSet {
       defaults.set(clipboardSyncEnabled, forKey: Self.clipboardSyncDefaultsKey)
+    }
+  }
+
+  @Published var viewOnlyEnabled: Bool {
+    didSet {
+      defaults.set(viewOnlyEnabled, forKey: Self.viewOnlyDefaultsKey)
+      server?.setViewOnly(viewOnlyEnabled)
     }
   }
 
@@ -109,6 +118,7 @@ final class PrivateMacShareController: ObservableObject {
     selectedDisplayID = savedDisplayID.map(CGDirectDisplayID.init) ?? CGMainDisplayID()
     clipboardSyncEnabled =
       defaults.object(forKey: Self.clipboardSyncDefaultsKey) as? Bool ?? true
+    viewOnlyEnabled = defaults.object(forKey: Self.viewOnlyDefaultsKey) as? Bool ?? false
     launchAtLoginEnabled = SMAppService.mainApp.status == .enabled
     if let runner {
       self.runner = runner
@@ -201,6 +211,7 @@ final class PrivateMacShareController: ObservableObject {
     phase = .starting
     notice = nil
     connectedPeer = nil
+    streamStats = nil
     registryPhase = desktopRegistration == nil ? .notConfigured : .registering
     await loadIdentity()
     refreshPermissions()
@@ -242,6 +253,7 @@ final class PrivateMacShareController: ObservableObject {
           Task { @MainActor in self?.handle(event, generation: generation) }
         }
       )
+      server.setViewOnly(viewOnlyEnabled)
       try server.start()
       self.capture = capture
       self.server = server
@@ -258,6 +270,7 @@ final class PrivateMacShareController: ObservableObject {
     guard phase.isRunning || phase == .failed else { return }
     phase = .stopping
     connectedPeer = nil
+    streamStats = nil
     registrationTask?.cancel()
     registrationTask = nil
     serverGeneration = nil
@@ -346,15 +359,20 @@ final class PrivateMacShareController: ObservableObject {
     case .connected(let peer):
       phase = .connected
       connectedPeer = peer
+      streamStats = nil
       notice = nil
+    case .streaming(let stats):
+      streamStats = stats
     case .disconnected:
       phase = .sharing
       connectedPeer = nil
+      streamStats = nil
     case .listenerFailed(let message):
       registrationTask?.cancel()
       registrationTask = nil
       phase = .failed
       connectedPeer = nil
+      streamStats = nil
       notice = PrivateMacShareError.listenerFailed(message).localizedDescription
       serverGeneration = nil
       server?.stop()
@@ -367,6 +385,7 @@ final class PrivateMacShareController: ObservableObject {
     case .sessionFailed(let message):
       phase = .sharing
       connectedPeer = nil
+      streamStats = nil
       notice = message
     }
   }

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
@@ -87,6 +87,12 @@ struct PrivateMacShareSheet: View {
         .help("Text copied on either Mac is available on the other while connected.")
 
         Toggle(
+          "View only (ignore remote input)",
+          isOn: $controller.viewOnlyEnabled
+        )
+        .help("Applies immediately and keeps remote keyboard and pointer events from reaching this Mac.")
+
+        Toggle(
           "Start sharing when I log in",
           isOn: Binding(
             get: { controller.launchAtLoginEnabled },
@@ -184,6 +190,17 @@ struct PrivateMacShareSheet: View {
   }
 
   private var phaseDetail: String {
+    if let stats = controller.streamStats, controller.phase == .connected {
+      let hardware = stats.codec == "H.264"
+        ? stats.hardwareAccelerated ? " (hardware)" : " (software)"
+        : ""
+      return String(
+        format: "%@%@ · %.0f fps · %.1f Mbit/s",
+        stats.codec,
+        hardware,
+        stats.framesPerSecond,
+        stats.megabitsPerSecond)
+    }
     if let peer = controller.connectedPeer {
       return "\(controller.phase.title) · \(peer)"
     }

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/RFBWire.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/RFBWire.swift
@@ -101,9 +101,15 @@ struct RFBPixelFormat: Equatable, Sendable {
 
 enum RFBWire {
   static let tightEncoding: Int32 = 7
+  static let openH264Encoding: Int32 = 50
   static let extendedDesktopSizeEncoding: Int32 = -308
   static let extendedClipboardEncoding = Int32(bitPattern: 0xc0a1_e5ce)
   static let maximumClipboardBytes = 1 * 1_024 * 1_024
+
+  enum FrameEncodingSelection: Equatable, Sendable {
+    case openH264
+    case tight
+  }
 
   /// Flags word plus the codec's bounded compressed payload.
   static let maximumExtendedClipboardBodyBytes = 4 + VNCExtendedClipboard.maximumBodyBytes
@@ -129,6 +135,15 @@ enum RFBWire {
     return data
   }
 
+  static func preferredFrameEncoding(
+    from encodings: [Int32],
+    videoPathBroken: Bool = false
+  ) -> FrameEncodingSelection? {
+    if !videoPathBroken, encodings.contains(openH264Encoding) { return .openH264 }
+    if encodings.contains(tightEncoding) { return .tight }
+    return nil
+  }
+
   static func tightJPEGUpdate(frame: CapturedDesktopFrame) throws -> Data {
     guard
       (1...Int(UInt16.max)).contains(frame.width),
@@ -151,6 +166,43 @@ enum RFBWire {
     data.append(0x90)  // Tight JPEG subencoding
     data.append(tightCompactLength(frame.jpegData.count))
     data.append(frame.jpegData)
+    return data
+  }
+
+  /// FramebufferUpdate with zero rectangles: a legal no-op that answers an
+  /// outstanding update request when the screen has not changed, so idle
+  /// sessions stay responsive without resending pixels.
+  static func emptyUpdate() -> Data {
+    Data([0, 0, 0, 0])
+  }
+
+  static func openH264Update(
+    width: Int,
+    height: Int,
+    payload: Data,
+    flags: UInt32
+  ) throws -> Data {
+    guard
+      (1...Int(UInt16.max)).contains(width),
+      (1...Int(UInt16.max)).contains(height),
+      !payload.isEmpty,
+      payload.count < 16 * 1_024 * 1_024
+    else {
+      throw PrivateMacShareError.protocolError("invalid Open H.264 frame")
+    }
+
+    var data = Data(capacity: payload.count + 24)
+    data.append(0)
+    data.append(0)
+    data.appendBigEndian(UInt16(1))
+    data.appendBigEndian(UInt16(0))
+    data.appendBigEndian(UInt16(0))
+    data.appendBigEndian(UInt16(width))
+    data.appendBigEndian(UInt16(height))
+    data.appendBigEndian(openH264Encoding)
+    data.appendBigEndian(UInt32(payload.count))
+    data.appendBigEndian(flags)
+    data.append(payload)
     return data
   }
 

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetRFBServer.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetRFBServer.swift
@@ -1,3 +1,4 @@
+import CoreMedia
 import Foundation
 import Network
 import RoyalVNCKit
@@ -6,9 +7,17 @@ enum TailnetRFBServerEvent: Equatable, Sendable {
   case listening
   case authorizing(String)
   case connected(String)
+  case streaming(TailnetStreamStats)
   case disconnected
   case listenerFailed(String)
   case sessionFailed(String)
+}
+
+struct TailnetStreamStats: Equatable, Sendable {
+  let codec: String
+  let hardwareAccelerated: Bool
+  let framesPerSecond: Double
+  let megabitsPerSecond: Double
 }
 
 final class TailnetRFBServer: @unchecked Sendable {
@@ -27,6 +36,7 @@ final class TailnetRFBServer: @unchecked Sendable {
   private let eventHandler: EventHandler
   private var listener: NWListener?
   private var session: RFBHostSession?
+  private var viewOnly = false
 
   init(
     identity: TailnetIdentity,
@@ -94,6 +104,14 @@ final class TailnetRFBServer: @unchecked Sendable {
     capture.setConsumerActive(false)
   }
 
+  func setViewOnly(_ enabled: Bool) {
+    let activeSession = withLock { () -> RFBHostSession? in
+      viewOnly = enabled
+      return session
+    }
+    activeSession?.setViewOnly(enabled)
+  }
+
   private func accept(_ connection: NWConnection) {
     let hasActiveSession = withLock { self.session != nil }
     guard !hasActiveSession else {
@@ -116,13 +134,17 @@ final class TailnetRFBServer: @unchecked Sendable {
       clipboard: clipboard,
       requiredLocalAddress: identity.ipv4Address,
       desktopName: "Crabfleet — \(identity.hostName)",
+      viewOnly: false,
       didAuthorize: { [weak capture] in capture?.setConsumerActive(true) },
       eventHandler: eventHandler,
       didFinish: { [weak self] finishedSession in
         self?.clear(finishedSession)
       }
     )
-    withLock { self.session = newSession }
+    withLock {
+      self.session = newSession
+      newSession.setViewOnly(viewOnly)
+    }
     newSession.start()
   }
 
@@ -163,6 +185,7 @@ private final class RFBHostSession: @unchecked Sendable {
 
   // Negotiated per-connection state; only the protocol task mutates it.
   private var supportsTightEncoding = false
+  private var supportsOpenH264 = false
   private var supportsExtendedDesktopSize = false
   private var supportsExtendedClipboard = false
   private var sentServerClipboardCaps = false
@@ -170,6 +193,16 @@ private final class RFBHostSession: @unchecked Sendable {
   private var clientClipboardCaps: VNCExtendedClipboardCaps?
   private var currentWidth: Int
   private var currentHeight: Int
+  private var viewOnly: Bool
+  private var videoEncoder: MacVideoEncoder?
+  private var videoFrameMailbox: VideoMailbox<EncodedVideoFrame>?
+  private var videoPixelMailbox: VideoMailbox<VideoPixelSource>?
+  private var videoFrameConsumer: Task<Void, Never>?
+  private var videoPathBroken = false
+  private var needsContextReset = false
+  private var forceNextKeyframe = false
+  private var rateController = VideoRateController()
+  private var lastStatsTimestamp = ProcessInfo.processInfo.systemUptime
 
   init(
     connection: NWConnection,
@@ -180,6 +213,7 @@ private final class RFBHostSession: @unchecked Sendable {
     clipboard: (any HostClipboardSyncing)?,
     requiredLocalAddress: String,
     desktopName: String,
+    viewOnly: Bool,
     didAuthorize: @escaping @Sendable () -> Void,
     eventHandler: @escaping TailnetRFBServer.EventHandler,
     didFinish: @escaping @Sendable (RFBHostSession) -> Void
@@ -192,6 +226,7 @@ private final class RFBHostSession: @unchecked Sendable {
     self.clipboard = clipboard
     self.requiredLocalAddress = requiredLocalAddress
     self.desktopName = desktopName
+    self.viewOnly = viewOnly
     self.didAuthorize = didAuthorize
     self.eventHandler = eventHandler
     self.didFinish = didFinish
@@ -220,6 +255,14 @@ private final class RFBHostSession: @unchecked Sendable {
     task?.cancel()
     connection.cancel()
     finish(event: .disconnected)
+  }
+
+  func setViewOnly(_ enabled: Bool) {
+    let shouldReleaseInput = withLock { () -> Bool in
+      defer { viewOnly = enabled }
+      return enabled && !viewOnly
+    }
+    if shouldReleaseInput { input.releaseAllInput() }
   }
 
   private func beginProtocolIfNeeded() {
@@ -271,6 +314,8 @@ private final class RFBHostSession: @unchecked Sendable {
     withLock { pushIO = io }
     attachClipboard()
     eventHandler(.connected(remoteAddress))
+    rateController = VideoRateController()
+    lastStatsTimestamp = ProcessInfo.processInfo.systemUptime
     try await messageLoop(io: io)
   }
 
@@ -307,7 +352,8 @@ private final class RFBHostSession: @unchecked Sendable {
   }
 
   private func messageLoop(io: RFBConnectionIO) async throws {
-    var hasSentFrame = false
+    var hasSentJPEGFrame = false
+    var lastSentJPEGSequence: UInt64 = 0
 
     while !Task.isCancelled {
       let messageType = try await io.readUInt8()
@@ -328,6 +374,7 @@ private final class RFBHostSession: @unchecked Sendable {
         let encodingData = try await io.readExactly(count * 4)
         let encodings = (0..<count).map { encodingData.readInt32(at: $0 * 4) }
         supportsTightEncoding = encodings.contains(RFBWire.tightEncoding)
+        supportsOpenH264 = encodings.contains(RFBWire.openH264Encoding)
         if encodings.contains(RFBWire.extendedDesktopSizeEncoding),
           !supportsExtendedDesktopSize
         {
@@ -337,12 +384,17 @@ private final class RFBHostSession: @unchecked Sendable {
         withLock {
           supportsExtendedClipboard = encodings.contains(RFBWire.extendedClipboardEncoding)
         }
+        if !supportsOpenH264 {
+          if activeVideoEncoder != nil { await stopVideoPath(markBroken: false) }
+          if supportsTightEncoding { try await prepareTightFallback(io: io) }
+        }
         try await sendServerClipboardCapsIfNeeded(io: io)
 
       case 3:  // FramebufferUpdateRequest
-        _ = try await io.readExactly(9)
-        guard supportsTightEncoding else {
-          throw PrivateMacShareError.protocolError("the client did not offer Tight encoding")
+        let payload = try await io.readExactly(9)
+        let incremental = payload[0] != 0
+        guard selectedFrameEncoding != nil else {
+          throw PrivateMacShareError.protocolError("the client did not offer a supported encoding")
         }
         if needsDesktopSizeAnnounce {
           needsDesktopSizeAnnounce = false
@@ -354,24 +406,93 @@ private final class RFBHostSession: @unchecked Sendable {
               height: currentHeight
             ))
         }
-        if hasSentFrame {
-          try await Task.sleep(for: .milliseconds(66))
+        if selectedFrameEncoding == .openH264 {
+          if activeVideoEncoder == nil {
+            do {
+              try await startVideoPath()
+            } catch {
+              await stopVideoPath(markBroken: true)
+              if supportsTightEncoding {
+                try await prepareTightFallback(io: io)
+              }
+            }
+          }
+          if let encoder = activeVideoEncoder {
+            if !incremental { requestKeyframe() }
+            switch await nextVideoUpdate(encoder: encoder) {
+            case .frame(let frame):
+              let flags: UInt32 = needsContextReset ? 0x2 : 0
+              let update = try RFBWire.openH264Update(
+                width: currentWidth,
+                height: currentHeight,
+                payload: frame.data,
+                flags: flags)
+              let sendSeconds = try await timedSend(update, io: io)
+              needsContextReset = false
+              recordFrameStats(
+                byteCount: frame.data.count,
+                sendSeconds: sendSeconds,
+                codec: "H.264",
+                hardwareAccelerated: encoder.isHardwareAccelerated,
+                encoder: encoder)
+              continue
+            case .idle:
+              // Nothing changed on screen; answer the request anyway so the
+              // client's request loop and input keep flowing.
+              try await io.send(RFBWire.emptyUpdate())
+              emitStatsIfDue(codec: "H.264", hardwareAccelerated: encoder.isHardwareAccelerated)
+              continue
+            case .failed:
+              await stopVideoPath(markBroken: true)
+              if supportsTightEncoding {
+                try await prepareTightFallback(io: io)
+              }
+            }
+          }
         }
+
+        guard selectedFrameEncoding == .tight else {
+          throw PrivateMacShareError.protocolError("the Open H.264 encoder failed and Tight was not offered")
+        }
+        if hasSentJPEGFrame { try await Task.sleep(for: .milliseconds(66)) }
         let frame = try await waitForMatchingFrame()
-        try await io.send(try RFBWire.tightJPEGUpdate(frame: frame))
-        hasSentFrame = true
+        // Deduplicate only incremental requests: a non-incremental request is
+        // an explicit ask for the full framebuffer contents.
+        if incremental, frame.sequence == lastSentJPEGSequence {
+          try await io.send(RFBWire.emptyUpdate())
+          emitStatsIfDue(codec: "JPEG", hardwareAccelerated: false)
+          continue
+        }
+        let update = try RFBWire.tightJPEGUpdate(frame: frame)
+        let sendSeconds = try await timedSend(update, io: io)
+        recordFrameStats(
+          byteCount: frame.jpegData.count,
+          sendSeconds: sendSeconds,
+          codec: "JPEG",
+          hardwareAccelerated: false,
+          encoder: nil)
+        lastSentJPEGSequence = frame.sequence
+        hasSentJPEGFrame = true
 
       case 4:  // KeyEvent
         let payload = try await io.readExactly(7)
-        input.keyEvent(down: payload[0] != 0, keysym: payload.readUInt32(at: 3))
+        withLock {
+          if !viewOnly {
+            input.keyEvent(down: payload[0] != 0, keysym: payload.readUInt32(at: 3))
+          }
+        }
 
       case 5:  // PointerEvent
         let payload = try await io.readExactly(5)
-        input.pointerEvent(
-          buttonMask: payload[0],
-          x: payload.readUInt16(at: 1),
-          y: payload.readUInt16(at: 3)
-        )
+        withLock {
+          if !viewOnly {
+            input.pointerEvent(
+              buttonMask: payload[0],
+              x: payload.readUInt16(at: 1),
+              y: payload.readUInt16(at: 3)
+            )
+          }
+        }
 
       case 6:  // ClientCutText
         try await receiveClientCutText(io: io)
@@ -510,11 +631,15 @@ private final class RFBHostSession: @unchecked Sendable {
       throw PrivateMacShareError.protocolError("resize requested without ExtendedDesktopSize")
     }
 
+    let videoWasActive = activeVideoEncoder != nil
+    let isUsingH264 = selectedFrameEncoding == .openH264
     let target = MacScreenCapture.resizedDimensions(
       requestedWidth: requestedWidth,
       requestedHeight: requestedHeight,
       sourcePixelWidth: descriptor.sourcePixelWidth,
-      sourcePixelHeight: descriptor.sourcePixelHeight
+      sourcePixelHeight: descriptor.sourcePixelHeight,
+      maximumWidth: isUsingH264 ? 4_096 : 2_560,
+      maximumHeight: isUsingH264 ? 2_304 : 1_600
     )
 
     if target.width == currentWidth, target.height == currentHeight {
@@ -545,24 +670,321 @@ private final class RFBHostSession: @unchecked Sendable {
     currentWidth = target.width
     currentHeight = target.height
     input.updateFrameSize(width: target.width, height: target.height)
+    if videoWasActive {
+      do {
+        try await restartVideoPath()
+      } catch {
+        await stopVideoPath(markBroken: true)
+        guard supportsTightEncoding else {
+          throw PrivateMacShareError.protocolError(
+            "the Open H.264 encoder failed after resize and Tight was not offered")
+        }
+        let tightTarget = MacScreenCapture.resizedDimensions(
+          requestedWidth: requestedWidth,
+          requestedHeight: requestedHeight,
+          sourcePixelWidth: descriptor.sourcePixelWidth,
+          sourcePixelHeight: descriptor.sourcePixelHeight)
+        if tightTarget.width != currentWidth || tightTarget.height != currentHeight {
+          try await capture.updateOutputSize(width: tightTarget.width, height: tightTarget.height)
+          currentWidth = tightTarget.width
+          currentHeight = tightTarget.height
+          input.updateFrameSize(width: currentWidth, height: currentHeight)
+        }
+      }
+    }
     try await io.send(
       try RFBWire.extendedDesktopSizeUpdate(
         reason: 1,
         status: 0,
-        width: target.width,
-        height: target.height
+        width: currentWidth,
+        height: currentHeight
       ))
   }
 
+  // MARK: - Video
+
+  /// Captured pixel buffers flow into a latest-wins mailbox and are encoded
+  /// one at a time as the connection drains: every encoded frame is sent, so
+  /// the H.264 reference chain stays intact and stale frames are dropped
+  /// before they cost encoder time.
+  private func startVideoPath() async throws {
+    let encoder = try MacVideoEncoder(width: currentWidth, height: currentHeight)
+    let pixelMailbox = VideoMailbox<VideoPixelSource>()
+    _ = replaceVideoEncoder(with: encoder)
+    withLock { videoPixelMailbox = pixelMailbox }
+    startVideoFrameConsumer(for: encoder)
+    rateController = VideoRateController()
+    lastStatsTimestamp = ProcessInfo.processInfo.systemUptime
+    needsContextReset = true
+    requestKeyframe()
+    capture.setVideoFrameHandler { pixelBuffer, presentationTime in
+      pixelMailbox.offer(
+        VideoPixelSource(pixelBuffer: pixelBuffer, presentationTime: presentationTime))
+    }
+    do {
+      try await capture.updateFrameInterval(framesPerSecond: 60)
+    } catch {
+      capture.setVideoFrameHandler(nil)
+      stopVideoFrameConsumer()
+      finishPixelMailbox()
+      encoder.invalidate()
+      _ = replaceVideoEncoder(with: nil)
+      throw error
+    }
+  }
+
+  private func restartVideoPath() async throws {
+    capture.setVideoFrameHandler(nil)
+    stopVideoFrameConsumer()
+    finishPixelMailbox()
+    replaceVideoEncoder(with: nil)?.invalidate()
+    try await startVideoPath()
+  }
+
+  private func stopVideoPath(markBroken: Bool) async {
+    if markBroken { videoPathBroken = true }
+    capture.setVideoFrameHandler(nil)
+    stopVideoFrameConsumer()
+    finishPixelMailbox()
+    replaceVideoEncoder(with: nil)?.invalidate()
+    needsContextReset = false
+    withLock { forceNextKeyframe = false }
+    rateController = VideoRateController()
+    lastStatsTimestamp = ProcessInfo.processInfo.systemUptime
+    try? await capture.updateFrameInterval(framesPerSecond: 15)
+  }
+
+  private func finishPixelMailbox() {
+    let mailbox = withLock { () -> VideoMailbox<VideoPixelSource>? in
+      defer { videoPixelMailbox = nil }
+      return videoPixelMailbox
+    }
+    mailbox?.finish()
+  }
+
+  private func prepareTightFallback(io: RFBConnectionIO) async throws {
+    guard currentWidth > 2_560 || currentHeight > 1_600 else { return }
+    let target = MacScreenCapture.resizedDimensions(
+      requestedWidth: currentWidth,
+      requestedHeight: currentHeight,
+      sourcePixelWidth: descriptor.sourcePixelWidth,
+      sourcePixelHeight: descriptor.sourcePixelHeight)
+    guard target.width != currentWidth || target.height != currentHeight else { return }
+    try await capture.updateOutputSize(width: target.width, height: target.height)
+    currentWidth = target.width
+    currentHeight = target.height
+    input.updateFrameSize(width: currentWidth, height: currentHeight)
+    if supportsExtendedDesktopSize {
+      try await io.send(
+        try RFBWire.extendedDesktopSizeUpdate(
+          reason: 0,
+          status: 0,
+          width: currentWidth,
+          height: currentHeight))
+    }
+  }
+
+  private var selectedFrameEncoding: RFBWire.FrameEncodingSelection? {
+    var encodings: [Int32] = []
+    if supportsOpenH264 { encodings.append(RFBWire.openH264Encoding) }
+    if supportsTightEncoding { encodings.append(RFBWire.tightEncoding) }
+    return RFBWire.preferredFrameEncoding(
+      from: encodings, videoPathBroken: videoPathBroken)
+  }
+
+  private var activeVideoEncoder: MacVideoEncoder? {
+    withLock { videoEncoder }
+  }
+
+  @discardableResult
+  private func replaceVideoEncoder(with encoder: MacVideoEncoder?) -> MacVideoEncoder? {
+    withLock {
+      defer { videoEncoder = encoder }
+      return videoEncoder
+    }
+  }
+
+  private func requestKeyframe() {
+    withLock { forceNextKeyframe = true }
+  }
+
+  private func startVideoFrameConsumer(for encoder: MacVideoEncoder) {
+    let mailbox = VideoMailbox<EncodedVideoFrame>()
+    let consumer = Task { [weak self] in
+      for await frame in encoder.frames {
+        // With one frame in flight a drop cannot happen; if it ever does the
+        // client missed pixels, so resync with a keyframe.
+        mailbox.offer(frame, onDrop: { self?.requestKeyframe() })
+      }
+      mailbox.finish()
+    }
+    let previous = withLock { () -> (Task<Void, Never>?, VideoMailbox<EncodedVideoFrame>?) in
+      defer {
+        videoFrameConsumer = consumer
+        videoFrameMailbox = mailbox
+      }
+      return (videoFrameConsumer, videoFrameMailbox)
+    }
+    previous.0?.cancel()
+    previous.1?.finish()
+  }
+
+  private func stopVideoFrameConsumer() {
+    let previous = withLock { () -> (Task<Void, Never>?, VideoMailbox<EncodedVideoFrame>?) in
+      defer {
+        videoFrameConsumer = nil
+        videoFrameMailbox = nil
+      }
+      return (videoFrameConsumer, videoFrameMailbox)
+    }
+    previous.0?.cancel()
+    previous.1?.finish()
+  }
+
+  private func consumeForceNextKeyframe() -> Bool {
+    withLock {
+      defer { forceNextKeyframe = false }
+      return forceNextKeyframe
+    }
+  }
+
+  private func pendingKeyframeRequested() -> Bool {
+    withLock { forceNextKeyframe }
+  }
+
+  private enum VideoUpdateOutcome {
+    case frame(EncodedVideoFrame)
+    case idle
+    case failed
+  }
+
+  /// Encodes at most one captured frame for this update request. `.idle`
+  /// means the screen has not changed (and no keyframe is owed), `.failed`
+  /// means the encoder produced no output for a submitted frame.
+  private func nextVideoUpdate(encoder: MacVideoEncoder) async -> VideoUpdateOutcome {
+    let mailboxes = withLock { (videoPixelMailbox, videoFrameMailbox) }
+    guard let pixelMailbox = mailboxes.0, let encodedMailbox = mailboxes.1,
+      !encodedMailbox.isFinished
+    else {
+      return .failed
+    }
+
+    var source = await pixelMailbox.next(timeout: .milliseconds(100))
+    if let candidate = source, !matchesCurrentSize(candidate.pixelBuffer) {
+      source = nil  // stale capture output from before a resize
+    }
+    if source == nil, needsContextReset || pendingKeyframeRequested() {
+      source = await keyframeSource()
+    }
+    guard let source else { return .idle }
+
+    let forceKeyframe = consumeForceNextKeyframe() || needsContextReset
+    guard
+      encoder.encode(
+        source.pixelBuffer,
+        presentationTime: source.presentationTime,
+        forceKeyframe: forceKeyframe)
+    else {
+      // Rejected input (for example a timestamp raced behind a synthetic
+      // keyframe stamp) produces no output; try again on the next request.
+      if forceKeyframe { requestKeyframe() }
+      return .idle
+    }
+
+    while let frame = await encodedMailbox.next(timeout: .seconds(1)) {
+      guard frame.width >= currentWidth, frame.height >= currentHeight,
+        frame.width <= currentWidth + 15, frame.height <= currentHeight + 15
+      else { continue }
+      return .frame(frame)
+    }
+    return .failed
+  }
+
+  /// A source for keyframes owed while the screen is idle: the last streamed
+  /// buffer if it still matches, otherwise a one-shot screenshot. Re-encoded
+  /// buffers get a fresh host-clock stamp to stay monotonic.
+  private func keyframeSource() async -> VideoPixelSource? {
+    if let cached = capture.latestVideoFrame(), matchesCurrentSize(cached.pixelBuffer) {
+      return VideoPixelSource(
+        pixelBuffer: cached.pixelBuffer,
+        presentationTime: CMClockGetTime(CMClockGetHostTimeClock()))
+    }
+    guard let snapshot = await capture.snapshotVideoFrame(),
+      matchesCurrentSize(snapshot.pixelBuffer)
+    else {
+      return nil
+    }
+    return VideoPixelSource(
+      pixelBuffer: snapshot.pixelBuffer,
+      presentationTime: CMClockGetTime(CMClockGetHostTimeClock()))
+  }
+
+  private func matchesCurrentSize(_ pixelBuffer: CVPixelBuffer) -> Bool {
+    CVPixelBufferGetWidth(pixelBuffer) == currentWidth
+      && CVPixelBufferGetHeight(pixelBuffer) == currentHeight
+  }
+
+  private func timedSend(_ data: Data, io: RFBConnectionIO) async throws -> Double {
+    let clock = ContinuousClock()
+    let start = clock.now
+    try await io.send(data)
+    let duration = start.duration(to: clock.now)
+    let components = duration.components
+    return Double(components.seconds) + Double(components.attoseconds) / 1e18
+  }
+
+  private func recordFrameStats(
+    byteCount: Int,
+    sendSeconds: Double,
+    codec: String,
+    hardwareAccelerated: Bool,
+    encoder: MacVideoEncoder?
+  ) {
+    let now = ProcessInfo.processInfo.systemUptime
+    if let bitrate = rateController.recordFrame(
+      byteCount: byteCount,
+      sendSeconds: sendSeconds,
+      timestamp: now)
+    {
+      encoder?.setAverageBitrate(bitrate)
+    }
+    emitStatsIfDue(codec: codec, hardwareAccelerated: hardwareAccelerated, now: now)
+  }
+
+  private func emitStatsIfDue(
+    codec: String,
+    hardwareAccelerated: Bool,
+    now: Double = ProcessInfo.processInfo.systemUptime
+  ) {
+    guard now - lastStatsTimestamp >= 2 else { return }
+    lastStatsTimestamp = now
+    let snapshot = rateController.statsSnapshot(now: now)
+    eventHandler(
+      .streaming(
+        TailnetStreamStats(
+          codec: codec,
+          hardwareAccelerated: hardwareAccelerated,
+          framesPerSecond: snapshot.fps,
+          megabitsPerSecond: snapshot.megabitsPerSecond)))
+  }
+
   /// Waits for a frame matching the announced framebuffer size, discarding
-  /// stale frames captured before a resize took effect.
+  /// stale frames captured before a resize took effect. The store can be
+  /// stale after an H.264 fallback on a static screen, so one snapshot
+  /// refresh is attempted before giving up.
   private func waitForMatchingFrame() async throws -> CapturedDesktopFrame {
-    for _ in 0..<150 {
+    var didRequestSnapshot = false
+    for iteration in 0..<150 {
       if let frame = await capture.frameStore.latest(),
         frame.width == currentWidth,
         frame.height == currentHeight
       {
         return frame
+      }
+      if iteration >= 25, !didRequestSnapshot {
+        didRequestSnapshot = true
+        _ = await capture.refreshJPEGFrame()
+        continue
       }
       try await Task.sleep(for: .milliseconds(20))
     }
@@ -578,8 +1000,24 @@ private final class RFBHostSession: @unchecked Sendable {
     finished = true
     pushIO = nil
     lock.unlock()
+    capture.setVideoFrameHandler(nil)
+    stopVideoFrameConsumer()
+    finishPixelMailbox()
+    let encoder = replaceVideoEncoder(with: nil)
+    encoder?.invalidate()
     clipboard?.detach()
     connection.cancel()
+    guard encoder != nil else {
+      completeFinish(event: event)
+      return
+    }
+    Task { [self] in
+      try? await capture.updateFrameInterval(framesPerSecond: 15)
+      completeFinish(event: event)
+    }
+  }
+
+  private func completeFinish(event: TailnetRFBServerEvent) {
     eventHandler(event)
     didFinish(self)
   }

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/VNCSessionController.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/VNCSessionController.swift
@@ -20,7 +20,7 @@ struct VNCViewportSize: Equatable {
     )
     guard pixelSize.width >= 320, pixelSize.height >= 240 else { return nil }
 
-    let maximum = CGSize(width: 2_560, height: 1_600)
+    let maximum = CGSize(width: 4_096, height: 2_304)
     let fitScale = min(1, maximum.width / pixelSize.width, maximum.height / pixelSize.height)
     let width = max(320, Int((pixelSize.width * fitScale).rounded(.down)) & ~1)
     let height = max(240, Int((pixelSize.height * fitScale).rounded(.down)) & ~1)
@@ -119,7 +119,7 @@ final class VNCSessionController: NSObject, ObservableObject {
       inputMode: .forwardKeyboardShortcutsIfNotInUseLocally,
       clipboardMode: clipboardEnabled ? .externallyManaged : .disabled,
       colorDepth: .depth24Bit,
-      frameEncodings: [.tight, .hextile]
+      frameEncodings: [.openH264, .tight, .hextile]
     )
     let connection = VNCConnection(settings: settings)
     connection.delegate = self

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/VideoMailbox.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/VideoMailbox.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Single-slot, latest-wins handoff between a producer callback (capture or
+/// encoder output) and one async consumer. Offering while a value is pending
+/// replaces it and reports the drop so the producer can react.
+final class VideoMailbox<Element>: @unchecked Sendable {
+  private typealias Waiter = (
+    id: UUID,
+    continuation: CheckedContinuation<Element?, Never>
+  )
+
+  private let lock = NSLock()
+  private var latestElement: Element?
+  private var waiter: Waiter?
+  private var finished = false
+
+  var isFinished: Bool {
+    withLock { finished }
+  }
+
+  func offer(_ element: Element, onDrop: () -> Void = {}) {
+    let continuation = withLock { () -> CheckedContinuation<Element?, Never>? in
+      guard !finished else { return nil }
+      guard let waiter else {
+        if latestElement != nil { onDrop() }
+        latestElement = element
+        return nil
+      }
+      self.waiter = nil
+      return waiter.continuation
+    }
+    continuation?.resume(returning: element)
+  }
+
+  func finish() {
+    let continuation = withLock { () -> CheckedContinuation<Element?, Never>? in
+      guard !finished else { return nil }
+      finished = true
+      latestElement = nil
+      defer { waiter = nil }
+      return waiter?.continuation
+    }
+    continuation?.resume(returning: nil)
+  }
+
+  /// Returns the pending element, waits until one is offered, or returns nil
+  /// after `timeout` or once the mailbox is finished. Only one consumer may
+  /// wait at a time; a second waiter displaces the first.
+  func next(timeout: Duration) async -> Element? {
+    let id = UUID()
+    return await withTaskCancellationHandler {
+      await withCheckedContinuation { continuation in
+        var immediateElement: Element?
+        var shouldResume = false
+        var replacedWaiter: Waiter?
+        lock.lock()
+        if let latestElement {
+          immediateElement = latestElement
+          self.latestElement = nil
+          shouldResume = true
+        } else if finished {
+          shouldResume = true
+        } else {
+          replacedWaiter = waiter
+          waiter = (id, continuation)
+        }
+        lock.unlock()
+
+        replacedWaiter?.continuation.resume(returning: nil)
+        if shouldResume {
+          continuation.resume(returning: immediateElement)
+        } else {
+          Task {
+            try? await Task.sleep(for: timeout)
+            self.expire(id: id)
+          }
+        }
+      }
+    } onCancel: {
+      self.expire(id: id)
+    }
+  }
+
+  private func expire(id: UUID) {
+    let continuation = withLock { () -> CheckedContinuation<Element?, Never>? in
+      guard waiter?.id == id else { return nil }
+      defer { waiter = nil }
+      return waiter?.continuation
+    }
+    continuation?.resume(returning: nil)
+  }
+
+  private func withLock<T>(_ body: () -> T) -> T {
+    lock.lock()
+    defer { lock.unlock() }
+    return body()
+  }
+}

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/VideoRateController.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/VideoRateController.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+struct VideoRateController: Sendable {
+  private struct FrameMeasurement: Sendable {
+    let byteCount: Int
+    let timestamp: Double
+  }
+
+  private(set) var averageBitrate = 8_000_000
+  private var fastFrameStreak = 0
+  private var lastDecreaseTimestamp = -Double.infinity
+  private var measurements: [FrameMeasurement] = []
+
+  mutating func recordFrame(
+    byteCount: Int,
+    sendSeconds: Double,
+    timestamp: Double
+  ) -> Int? {
+    measurements.append(
+      FrameMeasurement(byteCount: max(0, byteCount), timestamp: timestamp))
+    measurements.removeAll { $0.timestamp < timestamp - 2 }
+
+    if sendSeconds > 0.08 {
+      fastFrameStreak = 0
+      guard timestamp - lastDecreaseTimestamp >= 1 else { return nil }
+      lastDecreaseTimestamp = timestamp
+      let bitrate = max(1_500_000, averageBitrate * 7 / 10)
+      guard bitrate != averageBitrate else { return nil }
+      averageBitrate = bitrate
+      return bitrate
+    }
+
+    if sendSeconds < 0.025 {
+      fastFrameStreak += 1
+    } else {
+      fastFrameStreak = 0
+    }
+
+    guard fastFrameStreak >= 60 else { return nil }
+    fastFrameStreak = 0
+    let bitrate = min(30_000_000, averageBitrate * 11 / 10)
+    guard bitrate != averageBitrate else { return nil }
+    averageBitrate = bitrate
+    return bitrate
+  }
+
+  func statsSnapshot(now: Double) -> (fps: Double, megabitsPerSecond: Double) {
+    let recent = measurements.filter { $0.timestamp >= now - 2 && $0.timestamp <= now }
+    let bytes = recent.reduce(0) { $0 + $1.byteCount }
+    return (
+      fps: Double(recent.count) / 2,
+      megabitsPerSecond: Double(bytes) * 8 / 2 / 1_000_000
+    )
+  }
+}

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/FleetModelsTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/FleetModelsTests.swift
@@ -24,7 +24,7 @@ struct FleetModelsTests {
     )
     #expect(
       VNCViewportSize.fitting(CGSize(width: 5_120, height: 3_200))
-        == .init(width: 2_560, height: 1_600)
+        == .init(width: 3_686, height: 2_304)
     )
     #expect(
       VNCViewportSize.fitting(CGSize(width: 1_200, height: 700), backingScale: 2)

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/HostShareProtocolTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/HostShareProtocolTests.swift
@@ -83,6 +83,17 @@ struct HostShareWireTests {
     )
     #expect(floored.width == 320)
     #expect(floored.height == 200)
+
+    let h264 = MacScreenCapture.resizedDimensions(
+      requestedWidth: 4_096,
+      requestedHeight: 2_304,
+      sourcePixelWidth: 5_120,
+      sourcePixelHeight: 2_880,
+      maximumWidth: 4_096,
+      maximumHeight: 2_304
+    )
+    #expect(h264.width == 4_096)
+    #expect(h264.height == 2_304)
   }
 }
 

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
@@ -329,8 +329,8 @@ struct PrivateMacShareTests {
   @Test
   func scalesCaptureWithinBoundedEvenDimensions() {
     let retina = MacScreenCapture.captureDimensions(sourceWidth: 5_120, sourceHeight: 2_880)
-    #expect(retina.width == 1_600)
-    #expect(retina.height == 900)
+    #expect(retina.width == 2_560)
+    #expect(retina.height == 1_440)
     #expect(retina.width.isMultiple(of: 2))
     #expect(retina.height.isMultiple(of: 2))
 
@@ -489,8 +489,13 @@ struct PrivateMacShareTests {
 
     // The stream must keep flowing after the resize exchange (this test
     // fixture has no live capture stream, so the server answers the resize
-    // with an out-of-resources status and continues serving frames).
+    // with an out-of-resources status and continues serving frames). An
+    // unchanged frame is deduplicated into rectangle-free heartbeats, so new
+    // content must arrive as a fresh framebuffer update.
     let updates = session.framebufferUpdateCount
+    await capture.frameStore.update(
+      .init(jpegData: jpeg, sequence: 2, width: 64, height: 64)
+    )
     try await waitFor { session.framebufferUpdateCount > updates }
     #expect(session.phase == .connected)
   }

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/VideoPipelineTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/VideoPipelineTests.swift
@@ -1,0 +1,204 @@
+import Foundation
+import Testing
+
+@testable import CrabfleetMac
+
+struct VideoPipelineTests {
+  @Test
+  func openH264UpdateMatchesWireFormat() throws {
+    let payload = Data([0, 0, 0, 1, 0x65, 0xAA])
+    let update = try RFBWire.openH264Update(
+      width: 1_280,
+      height: 720,
+      payload: payload,
+      flags: 0x2)
+
+    #expect(
+      update == Data([
+        0, 0, 0, 1,
+        0, 0, 0, 0, 0x05, 0x00, 0x02, 0xD0,
+        0, 0, 0, 50,
+        0, 0, 0, 6,
+        0, 0, 0, 2,
+        0, 0, 0, 1, 0x65, 0xAA,
+      ]))
+  }
+
+  @Test
+  func openH264UpdateRejectsInvalidFrames() {
+    #expect(throws: (any Error).self) {
+      _ = try RFBWire.openH264Update(width: 1, height: 1, payload: Data(), flags: 0)
+    }
+    #expect(throws: (any Error).self) {
+      _ = try RFBWire.openH264Update(
+        width: 1, height: 1, payload: Data(count: 16 * 1_024 * 1_024), flags: 0)
+    }
+    #expect(throws: (any Error).self) {
+      _ = try RFBWire.openH264Update(
+        width: Int(UInt16.max) + 1, height: 1, payload: Data([1]), flags: 0)
+    }
+  }
+
+  @Test
+  func convertsLengthPrefixedNALUnitsToAnnexB() throws {
+    let input = Data([0, 0, 0, 2, 0x41, 0x01, 0, 0, 0, 3, 0x65, 0x02, 0x03])
+    let output = try MacVideoEncoder.annexBData(
+      lengthPrefixedData: input,
+      nalUnitHeaderLength: 4)
+
+    #expect(
+      output == Data([
+        0, 0, 0, 1, 0x41, 0x01,
+        0, 0, 0, 1, 0x65, 0x02, 0x03,
+      ]))
+  }
+
+  @Test
+  func keyframeConversionPrependsParameterSets() throws {
+    let output = try MacVideoEncoder.annexBData(
+      lengthPrefixedData: Data([0, 2, 0x65, 0x09]),
+      nalUnitHeaderLength: 2,
+      parameterSets: [Data([0x67, 0x64]), Data([0x68, 0xEE])],
+      isKeyframe: true)
+
+    #expect(
+      output == Data([
+        0, 0, 0, 1, 0x67, 0x64,
+        0, 0, 0, 1, 0x68, 0xEE,
+        0, 0, 0, 1, 0x65, 0x09,
+      ]))
+  }
+
+  @Test
+  func keyframePolicyRecoversDropsAndForcesPeriodicIDRs() {
+    var recovery = VideoKeyframePolicy()
+    var decision = recovery.shouldForceKeyframe(
+      explicit: false, recovery: true, presentationSeconds: 1)
+    #expect(decision)
+
+    var frameInterval = VideoKeyframePolicy()
+    for frame in 0..<1_799 {
+      decision = frameInterval.shouldForceKeyframe(
+        explicit: false,
+        recovery: false,
+        presentationSeconds: Double(frame) / 60)
+      #expect(!decision)
+    }
+    decision = frameInterval.shouldForceKeyframe(
+      explicit: false, recovery: false, presentationSeconds: 30)
+    #expect(decision)
+
+    var timeInterval = VideoKeyframePolicy()
+    decision = timeInterval.shouldForceKeyframe(
+      explicit: false, recovery: false, presentationSeconds: 10)
+    #expect(!decision)
+    decision = timeInterval.shouldForceKeyframe(
+      explicit: false, recovery: false, presentationSeconds: 40)
+    #expect(decision)
+  }
+
+  @Test
+  func rateControllerDecreasesWithCooldownAndFloor() {
+    var controller = VideoRateController()
+    #expect(controller.recordFrame(byteCount: 1, sendSeconds: 0.09, timestamp: 0) == 5_600_000)
+    #expect(controller.recordFrame(byteCount: 1, sendSeconds: 0.09, timestamp: 0.5) == nil)
+    #expect(controller.recordFrame(byteCount: 1, sendSeconds: 0.09, timestamp: 1) == 3_920_000)
+    _ = controller.recordFrame(byteCount: 1, sendSeconds: 0.09, timestamp: 2)
+    _ = controller.recordFrame(byteCount: 1, sendSeconds: 0.09, timestamp: 3)
+    #expect(controller.recordFrame(byteCount: 1, sendSeconds: 0.09, timestamp: 4) == 1_500_000)
+    #expect(controller.recordFrame(byteCount: 1, sendSeconds: 0.09, timestamp: 5) == nil)
+    #expect(controller.averageBitrate == 1_500_000)
+  }
+
+  @Test
+  func rateControllerIncreasesAfterSixtyFastFramesAndCaps() {
+    var controller = VideoRateController()
+    var change: Int?
+    for frame in 0..<60 {
+      change = controller.recordFrame(
+        byteCount: 1,
+        sendSeconds: 0.01,
+        timestamp: Double(frame) / 60)
+    }
+    #expect(change == 8_800_000)
+
+    for cycle in 1...20 {
+      for frame in 0..<60 {
+        _ = controller.recordFrame(
+          byteCount: 1,
+          sendSeconds: 0.01,
+          timestamp: Double(cycle) + Double(frame) / 60)
+      }
+    }
+    #expect(controller.averageBitrate == 30_000_000)
+  }
+
+  @Test
+  func rateControllerReportsTwoSecondWindow() {
+    var controller = VideoRateController()
+    for timestamp in [0.5, 1.0, 2.0, 2.5] {
+      _ = controller.recordFrame(
+        byteCount: 250_000,
+        sendSeconds: 0.04,
+        timestamp: timestamp)
+    }
+    let stats = controller.statsSnapshot(now: 2.5)
+    #expect(stats.fps == 2)
+    #expect(stats.megabitsPerSecond == 4)
+  }
+
+  @Test
+  func emptyUpdateIsARectangleFreeFramebufferUpdate() {
+    #expect(RFBWire.emptyUpdate() == Data([0, 0, 0, 0]))
+  }
+
+  @Test
+  func mailboxDeliversPendingElementImmediately() async {
+    let mailbox = VideoMailbox<Int>()
+    mailbox.offer(7)
+    #expect(await mailbox.next(timeout: .milliseconds(10)) == 7)
+  }
+
+  @Test
+  func mailboxKeepsLatestAndReportsDrops() async {
+    let mailbox = VideoMailbox<Int>()
+    var droppedCount = 0
+    mailbox.offer(1, onDrop: { droppedCount += 1 })
+    mailbox.offer(2, onDrop: { droppedCount += 1 })
+    #expect(droppedCount == 1)
+    #expect(await mailbox.next(timeout: .milliseconds(10)) == 2)
+  }
+
+  @Test
+  func mailboxWakesWaiterOnOffer() async {
+    let mailbox = VideoMailbox<Int>()
+    async let waited = mailbox.next(timeout: .seconds(5))
+    try? await Task.sleep(for: .milliseconds(20))
+    mailbox.offer(9)
+    #expect(await waited == 9)
+  }
+
+  @Test
+  func mailboxTimesOutAndFinishes() async {
+    let mailbox = VideoMailbox<Int>()
+    #expect(await mailbox.next(timeout: .milliseconds(10)) == nil)
+    #expect(!mailbox.isFinished)
+    mailbox.finish()
+    #expect(mailbox.isFinished)
+    mailbox.offer(3)
+    #expect(await mailbox.next(timeout: .milliseconds(10)) == nil)
+  }
+
+  @Test
+  func openH264NegotiationPrefersVideoAndFallsBackToTight() {
+    #expect(
+      RFBWire.preferredFrameEncoding(
+        from: [RFBWire.tightEncoding, RFBWire.openH264Encoding]) == .openH264)
+    #expect(
+      RFBWire.preferredFrameEncoding(
+        from: [RFBWire.tightEncoding, RFBWire.openH264Encoding],
+        videoPathBroken: true) == .tight)
+    #expect(RFBWire.preferredFrameEncoding(from: [RFBWire.tightEncoding]) == .tight)
+    #expect(RFBWire.preferredFrameEncoding(from: [5]) == nil)
+  }
+}

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Package.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Package.swift
@@ -24,7 +24,11 @@ let package = Package(
       name: "RoyalVNCKit",
       dependencies: ["d3des", "Z", "CryptoSwift"],
       exclude: ["SDK/CSDK"],
-      swiftSettings: [.swiftLanguageMode(.v5)]
+      swiftSettings: [.swiftLanguageMode(.v5)],
+      linkerSettings: [
+        .linkedFramework("VideoToolbox", .when(platforms: [.macOS])),
+        .linkedFramework("CoreMedia", .when(platforms: [.macOS])),
+      ]
     ),
     .testTarget(
       name: "RoyalVNCKitTests",

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/Protocol/Encodings/Frame/OpenH264Encoding.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/Protocol/Encodings/Frame/OpenH264Encoding.swift
@@ -1,0 +1,556 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+struct OpenH264AnnexB {
+	static let maximumNALUnitCount = 4_096
+	static let maximumParameterSetBytes = 64 * 1_024
+
+	static func nalUnits(from data: Data) -> [Data] {
+		func startCode(at offset: Int) -> Int? {
+			guard offset + 3 <= data.count,
+				  data[offset] == 0,
+				  data[offset + 1] == 0 else { return nil }
+			if data[offset + 2] == 1 { return 3 }
+			guard offset + 4 <= data.count,
+				  data[offset + 2] == 0,
+				  data[offset + 3] == 1 else { return nil }
+			return 4
+		}
+
+		var starts: [(offset: Int, length: Int)] = []
+		var offset = 0
+		while offset + 3 <= data.count {
+			if let length = startCode(at: offset) {
+				starts.append((offset, length))
+				guard starts.count <= maximumNALUnitCount else { return [] }
+				offset += length
+			} else {
+				offset += 1
+			}
+		}
+
+		return starts.enumerated().compactMap { index, start in
+			let payloadStart = start.offset + start.length
+			let payloadEnd = index + 1 < starts.count ? starts[index + 1].offset : data.count
+			guard payloadStart < payloadEnd else { return nil }
+			return Data(data[payloadStart..<payloadEnd])
+		}
+	}
+
+	static func parameterSets(in nalUnits: [Data]) -> (sps: Data?, pps: Data?) {
+		var sps: Data?
+		var pps: Data?
+		for unit in nalUnits {
+			guard let first = unit.first else { continue }
+			switch first & 0x1f {
+				case 7: sps = unit
+				case 8: pps = unit
+				default: break
+			}
+		}
+		return (sps, pps)
+	}
+
+	static func parameterSetsFitLimit(sps: Data?, pps: Data?) -> Bool {
+		let spsCount = sps?.count ?? 0
+		let ppsCount = pps?.count ?? 0
+		guard spsCount <= maximumParameterSetBytes,
+			  ppsCount <= maximumParameterSetBytes else { return false }
+		return spsCount <= maximumParameterSetBytes - ppsCount
+	}
+
+	static func containsIDR(_ nalUnits: [Data]) -> Bool {
+		nalUnits.contains { ($0.first ?? 0) & 0x1f == 5 }
+	}
+
+	/// Groups NAL units into access units: an Open H.264 rectangle may carry
+	/// several whole frames glued together, and each must be decoded in order.
+	/// A slice with first_mb_in_slice == 0 begins a new primary picture, while
+	/// non-VCL units (SPS/PPS/SEI/AUD) after a slice belong to the next one.
+	static func accessUnits(from nalUnits: [Data]) -> [[Data]] {
+		var units: [[Data]] = []
+		var current: [Data] = []
+		var currentHasSlice = false
+		for nalUnit in nalUnits {
+			let nalType = (nalUnit.first ?? 0) & 0x1f
+			let isSlice = nalType >= 1 && nalType <= 5
+			let beginsNewUnit = currentHasSlice
+				&& (!isSlice || firstMacroblockInSliceIsZero(nalUnit))
+			if beginsNewUnit {
+				units.append(current)
+				current = []
+				currentHasSlice = false
+			}
+			current.append(nalUnit)
+			if isSlice { currentHasSlice = true }
+		}
+		if !current.isEmpty { units.append(current) }
+		return units
+	}
+
+	/// first_mb_in_slice is the slice header's leading ue(v); the value 0 is
+	/// encoded as a single '1' bit, so continuation slices of the same frame
+	/// (first_mb_in_slice > 0) start with a '0' bit instead.
+	static func firstMacroblockInSliceIsZero(_ nalUnit: Data) -> Bool {
+		guard nalUnit.count >= 2 else { return true }
+		return nalUnit[nalUnit.index(after: nalUnit.startIndex)] & 0x80 != 0
+	}
+
+	static func avccData(from nalUnits: [Data]) -> Data? {
+		guard !nalUnits.isEmpty else { return nil }
+		var data = Data()
+		for unit in nalUnits {
+			guard !unit.isEmpty, unit.count <= Int(UInt32.max) else { return nil }
+			var length = UInt32(unit.count).bigEndian
+			Swift.withUnsafeBytes(of: &length) { data.append(contentsOf: $0) }
+			data.append(unit)
+		}
+		return data
+	}
+}
+
+struct OpenH264DecodeGate {
+	private(set) var waitingForIDR = true
+
+	mutating func reset() {
+		waitingForIDR = true
+	}
+
+	mutating func shouldDecode(_ nalUnits: [Data]) -> Bool {
+		guard waitingForIDR else { return true }
+		guard OpenH264AnnexB.containsIDR(nalUnits) else { return false }
+		waitingForIDR = false
+		return true
+	}
+
+	mutating func decodeFailed() {
+		waitingForIDR = true
+	}
+}
+
+#if canImport(VideoToolbox)
+import CoreMedia
+import CoreVideo
+import VideoToolbox
+
+extension VNCProtocol {
+	final class OpenH264Encoding: VNCFrameEncoding {
+		let encodingType = VNCFrameEncodingType.openH264.rawValue
+
+		private struct Geometry: Hashable {
+			let x: UInt16
+			let y: UInt16
+			let width: UInt16
+			let height: UInt16
+		}
+
+		private final class DecoderContext {
+			var decoderSession: VTDecompressionSession?
+			var formatDescription: CMVideoFormatDescription?
+			var sps: Data?
+			var pps: Data?
+			var decodeGate = OpenH264DecodeGate()
+			var codedByteCount = 0
+		}
+
+		private var contexts: [Geometry: DecoderContext] = [:]
+		private var contextOrder: [Geometry] = []
+		private static let maximumContextCount = 64
+
+		deinit {
+			invalidateAllDecoders()
+		}
+
+		static func supportsPixelFormat(_ pixelFormat: VNCProtocol.PixelFormat) -> Bool {
+			pixelFormat.trueColor &&
+			pixelFormat.bitsPerPixel == 32 &&
+			pixelFormat.depth == 24 &&
+			pixelFormat.redMax == 255 &&
+			pixelFormat.greenMax == 255 &&
+			pixelFormat.blueMax == 255
+		}
+
+		func decodeRectangle(_ rectangle: VNCProtocol.Rectangle,
+						 framebuffer: VNCFramebuffer,
+						 connection: NetworkConnectionReading,
+						 logger: VNCLogger) async throws {
+			let length = Int(try await connection.readUInt32())
+			guard length <= 16 * 1_024 * 1_024 else {
+				throw VNCError.protocol(.invalidData)
+			}
+			let flags = try await connection.readUInt32()
+			let payload = try await connection.read(length: length)
+			let nalUnits = OpenH264AnnexB.nalUnits(from: payload)
+
+			let newGeometry = Geometry(
+				x: rectangle.xPosition,
+				y: rectangle.yPosition,
+				width: rectangle.width,
+				height: rectangle.height)
+			if flags & 0x2 != 0 {
+				invalidateAllDecoders()
+			} else if flags & 0x1 != 0, let context = contexts.removeValue(forKey: newGeometry) {
+				invalidateDecoder(context)
+				contextOrder.removeAll { $0 == newGeometry }
+			}
+			let context = context(for: newGeometry)
+			guard !nalUnits.isEmpty else {
+				logger.logError("Open H.264 frame has no Annex-B NAL units")
+				context.decodeGate.decodeFailed()
+				return
+			}
+			// A rectangle may contain several whole frames; decode all of them
+			// in order to keep the decoder's reference state, display the last.
+			var lastImageBuffer: CVPixelBuffer?
+			for accessUnit in OpenH264AnnexB.accessUnits(from: nalUnits) {
+				guard updateParameterSets(in: accessUnit, context: context, logger: logger) else {
+					return
+				}
+				guard context.decodeGate.shouldDecode(accessUnit) else { continue }
+
+				do {
+					if context.formatDescription == nil {
+						let formatDescription = try makeFormatDescription(context: context)
+						let codedByteCount = try validateCodedDimensions(
+							formatDescription,
+							rectangleWidth: Int(rectangle.width),
+							rectangleHeight: Int(rectangle.height))
+						let aggregateByteCount = contexts.values.reduce(0) {
+							$0 + $1.codedByteCount
+						}
+						guard aggregateByteCount <= VNCProtocolLimits.maximumFramebufferBytes - codedByteCount else {
+							throw OpenH264DecodeError.resourceLimit
+						}
+						context.codedByteCount = codedByteCount
+						context.formatDescription = formatDescription
+					}
+					guard let formatDescription = context.formatDescription else {
+						throw OpenH264DecodeError.missingParameterSets
+					}
+					if context.decoderSession == nil {
+						context.decoderSession = try makeDecoder(formatDescription: formatDescription)
+					}
+					guard let decoderSession = context.decoderSession,
+						  let avccData = OpenH264AnnexB.avccData(from: accessUnit) else {
+						throw OpenH264DecodeError.invalidSample
+					}
+					let sampleBuffer = try makeSampleBuffer(
+						data: avccData, formatDescription: formatDescription)
+					lastImageBuffer = try decode(sampleBuffer, with: decoderSession)
+				} catch {
+					logger.logError("Open H.264 decode failed: \(error.localizedDescription)")
+					context.decodeGate.decodeFailed()
+					invalidateDecoder(context)
+					break
+				}
+			}
+
+			guard let lastImageBuffer else { return }
+			do {
+				var pixels = try tightlyPackedBGRA(
+					lastImageBuffer,
+					width: Int(rectangle.width),
+					height: Int(rectangle.height))
+				framebuffer.update(region: rectangle.region, data: &pixels)
+				framebuffer.didUpdate(region: rectangle.region)
+			} catch {
+				logger.logError("Open H.264 blit failed: \(error.localizedDescription)")
+				context.decodeGate.decodeFailed()
+				invalidateDecoder(context)
+			}
+		}
+
+		/// Applies SPS/PPS carried by one access unit, resetting the decoder
+		/// on change. Returns false when resource limits are exceeded and the
+		/// rest of the rectangle payload should be dropped.
+		private func updateParameterSets(
+			in accessUnit: [Data],
+			context: DecoderContext,
+			logger: VNCLogger
+		) -> Bool {
+			let parameterSets = OpenH264AnnexB.parameterSets(in: accessUnit)
+			let candidateSPS = parameterSets.sps ?? context.sps
+			let candidatePPS = parameterSets.pps ?? context.pps
+			guard OpenH264AnnexB.parameterSetsFitLimit(
+				sps: candidateSPS,
+				pps: candidatePPS) else {
+				logger.logError("Open H.264 parameter sets exceed the resource limit")
+				context.decodeGate.decodeFailed()
+				invalidateDecoder(context)
+				context.sps = nil
+				context.pps = nil
+				return false
+			}
+			var needsReset = false
+			if let newSPS = parameterSets.sps, newSPS != context.sps {
+				context.sps = newSPS
+				needsReset = true
+			}
+			if let newPPS = parameterSets.pps, newPPS != context.pps {
+				context.pps = newPPS
+				needsReset = true
+			}
+			if needsReset {
+				invalidateDecoder(context)
+				context.decodeGate.reset()
+			}
+			return true
+		}
+
+		private func invalidateDecoder(_ context: DecoderContext) {
+			if let decoderSession = context.decoderSession {
+				VTDecompressionSessionInvalidate(decoderSession)
+			}
+			context.decoderSession = nil
+			context.formatDescription = nil
+			context.codedByteCount = 0
+		}
+
+		private func invalidateAllDecoders() {
+			for context in contexts.values { invalidateDecoder(context) }
+			contexts.removeAll()
+			contextOrder.removeAll()
+		}
+
+		private func context(for geometry: Geometry) -> DecoderContext {
+			if let context = contexts[geometry] {
+				contextOrder.removeAll { $0 == geometry }
+				contextOrder.append(geometry)
+				return context
+			}
+			if contexts.count >= Self.maximumContextCount,
+				  let oldestGeometry = contextOrder.first,
+				  let oldestContext = contexts.removeValue(forKey: oldestGeometry) {
+				contextOrder.removeFirst()
+				invalidateDecoder(oldestContext)
+			}
+			let context = DecoderContext()
+			contexts[geometry] = context
+			contextOrder.append(geometry)
+			return context
+		}
+
+		private func makeFormatDescription(context: DecoderContext) throws
+			-> CMVideoFormatDescription {
+			guard let sps = context.sps, let pps = context.pps else {
+				throw OpenH264DecodeError.missingParameterSets
+			}
+			return try sps.withUnsafeBytes { spsBytes in
+				try pps.withUnsafeBytes { ppsBytes in
+					guard let spsBase = spsBytes.bindMemory(to: UInt8.self).baseAddress,
+						  let ppsBase = ppsBytes.bindMemory(to: UInt8.self).baseAddress else {
+						throw OpenH264DecodeError.invalidParameterSets
+					}
+					var pointers: [UnsafePointer<UInt8>] = [spsBase, ppsBase]
+					var sizes = [sps.count, pps.count]
+					var description: CMFormatDescription?
+					let status = CMVideoFormatDescriptionCreateFromH264ParameterSets(
+						allocator: kCFAllocatorDefault,
+						parameterSetCount: 2,
+						parameterSetPointers: &pointers,
+						parameterSetSizes: &sizes,
+						nalUnitHeaderLength: 4,
+						formatDescriptionOut: &description)
+					guard status == noErr, let description else {
+						throw OpenH264DecodeError.videoToolbox(status)
+					}
+					return description
+				}
+			}
+		}
+
+		private func makeDecoder(formatDescription: CMVideoFormatDescription) throws
+			-> VTDecompressionSession {
+			let attributes: CFDictionary = [
+				kCVPixelBufferPixelFormatTypeKey: kCVPixelFormatType_32BGRA,
+				kCVPixelBufferIOSurfacePropertiesKey: [:] as CFDictionary
+			] as CFDictionary
+			var session: VTDecompressionSession?
+			let status = VTDecompressionSessionCreate(
+				allocator: kCFAllocatorDefault,
+				formatDescription: formatDescription,
+				decoderSpecification: nil,
+				imageBufferAttributes: attributes,
+				outputCallback: nil,
+				decompressionSessionOut: &session)
+			guard status == noErr, let session else {
+				throw OpenH264DecodeError.videoToolbox(status)
+			}
+			return session
+		}
+
+		private func validateCodedDimensions(
+			_ formatDescription: CMVideoFormatDescription,
+			rectangleWidth: Int,
+			rectangleHeight: Int
+		) throws -> Int {
+			let dimensions = CMVideoFormatDescriptionGetDimensions(formatDescription)
+			let width = Int(dimensions.width)
+			let height = Int(dimensions.height)
+			guard width >= rectangleWidth,
+				  height >= rectangleHeight,
+				  width <= rectangleWidth + 15,
+				  height <= rectangleHeight + 15,
+				  width <= VNCProtocolLimits.maximumFramebufferDimension,
+				  height <= VNCProtocolLimits.maximumFramebufferDimension else {
+				throw OpenH264DecodeError.invalidDimensions
+			}
+			let (pixelCount, pixelOverflow) = width.multipliedReportingOverflow(by: height)
+			let (byteCount, byteOverflow) = pixelCount.multipliedReportingOverflow(by: 4)
+			guard !pixelOverflow,
+				  !byteOverflow,
+				  byteCount <= VNCProtocolLimits.maximumFramebufferBytes else {
+				throw OpenH264DecodeError.invalidDimensions
+			}
+			return byteCount
+		}
+
+		private func makeSampleBuffer(
+			data: Data,
+			formatDescription: CMVideoFormatDescription
+		) throws -> CMSampleBuffer {
+			var blockBuffer: CMBlockBuffer?
+			var status = CMBlockBufferCreateWithMemoryBlock(
+				allocator: kCFAllocatorDefault,
+				memoryBlock: nil,
+				blockLength: data.count,
+				blockAllocator: kCFAllocatorDefault,
+				customBlockSource: nil,
+				offsetToData: 0,
+				dataLength: data.count,
+				flags: 0,
+				blockBufferOut: &blockBuffer)
+			guard status == kCMBlockBufferNoErr, let blockBuffer else {
+				throw OpenH264DecodeError.videoToolbox(status)
+			}
+			status = data.withUnsafeBytes { bytes in
+				CMBlockBufferReplaceDataBytes(
+					with: bytes.baseAddress!, blockBuffer: blockBuffer, offsetIntoDestination: 0,
+					dataLength: data.count)
+			}
+			guard status == kCMBlockBufferNoErr else {
+				throw OpenH264DecodeError.videoToolbox(status)
+			}
+
+			var sampleBuffer: CMSampleBuffer?
+			var sampleSize = data.count
+			status = CMSampleBufferCreateReady(
+				allocator: kCFAllocatorDefault,
+				dataBuffer: blockBuffer,
+				formatDescription: formatDescription,
+				sampleCount: 1,
+				sampleTimingEntryCount: 0,
+				sampleTimingArray: nil,
+				sampleSizeEntryCount: 1,
+				sampleSizeArray: &sampleSize,
+				sampleBufferOut: &sampleBuffer)
+			guard status == noErr, let sampleBuffer else {
+				throw OpenH264DecodeError.videoToolbox(status)
+			}
+			return sampleBuffer
+		}
+
+		private func decode(
+			_ sampleBuffer: CMSampleBuffer,
+			with session: VTDecompressionSession
+		) throws -> CVPixelBuffer {
+			let result = DecodeOutputBox()
+			var infoFlags = VTDecodeInfoFlags()
+			let status = VTDecompressionSessionDecodeFrame(
+				session,
+				sampleBuffer: sampleBuffer,
+				flags: [],
+				infoFlagsOut: &infoFlags
+			) { status, _, imageBuffer, _, _ in
+				result.set(status: status, imageBuffer: imageBuffer)
+			}
+			guard status == noErr else { throw OpenH264DecodeError.videoToolbox(status) }
+			let output = result.get()
+			guard output.status == noErr, let imageBuffer = output.imageBuffer else {
+				throw OpenH264DecodeError.videoToolbox(output.status)
+			}
+			return imageBuffer
+		}
+
+		private func tightlyPackedBGRA(
+			_ pixelBuffer: CVPixelBuffer,
+			width: Int,
+			height: Int
+		) throws -> Data {
+			guard CVPixelBufferGetWidth(pixelBuffer) >= width,
+				  CVPixelBufferGetHeight(pixelBuffer) >= height,
+				  CVPixelBufferGetPixelFormatType(pixelBuffer) == kCVPixelFormatType_32BGRA else {
+				throw OpenH264DecodeError.invalidDimensions
+			}
+			CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+			defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
+			guard let source = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+				throw OpenH264DecodeError.invalidSample
+			}
+			let sourceBytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+			let packedBytesPerRow = width * 4
+			guard sourceBytesPerRow >= packedBytesPerRow else {
+				throw OpenH264DecodeError.invalidDimensions
+			}
+			var data = Data(count: packedBytesPerRow * height)
+			data.withUnsafeMutableBytes { destination in
+				guard let destinationBase = destination.baseAddress else { return }
+				for row in 0..<height {
+					destinationBase.advanced(by: row * packedBytesPerRow).copyMemory(
+						from: source.advanced(by: row * sourceBytesPerRow),
+						byteCount: packedBytesPerRow)
+				}
+			}
+			return data
+		}
+	}
+}
+
+private enum OpenH264DecodeError: Error {
+	case missingParameterSets
+	case invalidParameterSets
+	case invalidSample
+	case invalidDimensions
+	case resourceLimit
+	case videoToolbox(OSStatus)
+}
+
+private final class DecodeOutputBox: @unchecked Sendable {
+	private let lock = NSLock()
+	private var status: OSStatus = -1
+	private var imageBuffer: CVPixelBuffer?
+
+	func set(status: OSStatus, imageBuffer: CVPixelBuffer?) {
+		lock.lock()
+		self.status = status
+		self.imageBuffer = imageBuffer
+		lock.unlock()
+	}
+
+	func get() -> (status: OSStatus, imageBuffer: CVPixelBuffer?) {
+		lock.lock()
+		defer { lock.unlock() }
+		return (status, imageBuffer)
+	}
+}
+#else
+extension VNCProtocol {
+	final class OpenH264Encoding: VNCFrameEncoding {
+		let encodingType = VNCFrameEncodingType.openH264.rawValue
+
+		static func supportsPixelFormat(_ pixelFormat: VNCProtocol.PixelFormat) -> Bool {
+			false
+		}
+
+		func decodeRectangle(_ rectangle: VNCProtocol.Rectangle,
+						 framebuffer: VNCFramebuffer,
+						 connection: NetworkConnectionReading,
+						 logger: VNCLogger) async throws {
+			throw VNCError.protocol(.notImplemented(feature: "Open H.264 encoding"))
+		}
+	}
+}
+#endif

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Connection/VNCConnection.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/Connection/VNCConnection.swift
@@ -171,7 +171,7 @@ public final class VNCConnection: NSObjectOrAnyObject, @unchecked Sendable {
 		let jpegQualityLevelEncodingType = VNCPseudoEncodingType.jpegQualityLevel6.rawValue
 		let jpegQualityLevelEncoding = VNCProtocol.JPEGQualityLevelEncoding(encodingType: jpegQualityLevelEncodingType)
 
-		let encs: Encodings = [
+		var encs: Encodings = [
 			// Frame Encodings
 			VNCFrameEncodingType.copyRect.rawValue: VNCProtocol.CopyRectEncoding(),
             VNCFrameEncodingType.tight.rawValue: VNCProtocol.TightEncoding(),
@@ -192,6 +192,9 @@ public final class VNCConnection: NSObjectOrAnyObject, @unchecked Sendable {
 			compressionLevelEncodingType: compressionLevelEncoding,
 			jpegQualityLevelEncodingType: jpegQualityLevelEncoding
 		]
+#if canImport(VideoToolbox)
+		encs[VNCFrameEncodingType.openH264.rawValue] = VNCProtocol.OpenH264Encoding()
+#endif
 		let requestedFrameEncodings = Set(settings.frameEncodings.map(\.rawValue))
 		let mandatoryFrameEncodings: Set<VNCEncodingType> = [
 			VNCFrameEncodingType.raw.rawValue,
@@ -237,6 +240,16 @@ public final class VNCConnection: NSObjectOrAnyObject, @unchecked Sendable {
 		   !VNCProtocol.TightEncoding.supportsPixelFormat(pixelFormat) {
 			customizedFrameEncodings.removeAll(where: { $0 == VNCFrameEncodingType.tight.rawValue })
 		}
+
+#if canImport(VideoToolbox)
+		if let pixelFormat = state.pixelFormat,
+		   customizedFrameEncodings.contains(VNCFrameEncodingType.openH264.rawValue),
+		   !VNCProtocol.OpenH264Encoding.supportsPixelFormat(pixelFormat) {
+			customizedFrameEncodings.removeAll(where: { $0 == VNCFrameEncodingType.openH264.rawValue })
+		}
+#else
+		customizedFrameEncodings.removeAll(where: { $0 == VNCFrameEncodingType.openH264.rawValue })
+#endif
 
 		let usesTightEncoding = customizedFrameEncodings.contains(VNCFrameEncodingType.tight.rawValue)
 

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/VNCFrameEncodingType.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Sources/RoyalVNCKit/SDK/VNCFrameEncodingType.swift
@@ -17,6 +17,7 @@ public enum _ObjC_VNCFrameEncodingType: Int64 {
 	case zlib = 6
 	case tight = 7
 	case zrle = 16
+	case openH264 = 50
 }
 
 public enum VNCFrameEncodingType: VNCEncodingType {
@@ -28,6 +29,7 @@ public enum VNCFrameEncodingType: VNCEncodingType {
 	case zlib = 6
 	case tight = 7
 	case zrle = 16
+	case openH264 = 50
 }
 
 extension VNCFrameEncodingType: CustomStringConvertible {
@@ -49,6 +51,8 @@ extension VNCFrameEncodingType: CustomStringConvertible {
 				"Tight"
 			case .zrle:
 				"ZRLE"
+			case .openH264:
+				"Open H.264"
 		}
 	}
 }
@@ -134,6 +138,8 @@ extension VNCFrameEncodingType {
 				.tight
 			case .zrle:
 				.zrle
+			case .openH264:
+				.openH264
 		}
 	}
 }

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/Tests/RoyalVNCKitTests/OpenH264EncodingTests.swift
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/Tests/RoyalVNCKitTests/OpenH264EncodingTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Testing
+
+@testable import RoyalVNCKit
+
+struct OpenH264EncodingTests {
+	@Test
+	func splitsThreeAndFourByteAnnexBStartCodes() {
+		let data = Data([
+			0, 0, 0, 1, 0x67, 0x64,
+			0, 0, 1, 0x68, 0xEE,
+			0, 0, 0, 1, 0x65, 0x01,
+		])
+		let units = OpenH264AnnexB.nalUnits(from: data)
+
+		#expect(units == [Data([0x67, 0x64]), Data([0x68, 0xEE]), Data([0x65, 0x01])])
+	}
+
+	@Test
+	func extractsLatestParameterSets() {
+		let units = [
+			Data([0x67, 1]), Data([0x68, 2]), Data([0x41, 3]),
+			Data([0x67, 4]), Data([0x68, 5]),
+		]
+		let sets = OpenH264AnnexB.parameterSets(in: units)
+
+		#expect(sets.sps == Data([0x67, 4]))
+		#expect(sets.pps == Data([0x68, 5]))
+	}
+
+	@Test
+	func boundsRetainedParameterSets() {
+		let maximum = OpenH264AnnexB.maximumParameterSetBytes
+		#expect(OpenH264AnnexB.parameterSetsFitLimit(
+			sps: Data(repeating: 0, count: maximum - 1),
+			pps: Data([0])))
+		#expect(!OpenH264AnnexB.parameterSetsFitLimit(
+			sps: Data(repeating: 0, count: maximum),
+			pps: Data([0])))
+	}
+
+	@Test
+	func rejectsExcessiveNALUnitCounts() {
+		var data = Data()
+		for _ in 0...OpenH264AnnexB.maximumNALUnitCount {
+			data.append(contentsOf: [0, 0, 1, 0x09])
+		}
+		#expect(OpenH264AnnexB.nalUnits(from: data).isEmpty)
+	}
+
+	@Test
+	func groupsGluedFramesIntoAccessUnits() {
+		// SPS + PPS + IDR, then two inter frames glued into one rectangle.
+		let sps = Data([0x67, 0x64])
+		let pps = Data([0x68, 0xEE])
+		let idr = Data([0x65, 0x88])
+		let interOne = Data([0x41, 0x9A])
+		let interTwo = Data([0x41, 0x9B])
+		let units = OpenH264AnnexB.accessUnits(
+			from: [sps, pps, idr, interOne, interTwo])
+
+		#expect(units == [[sps, pps, idr], [interOne], [interTwo]])
+	}
+
+	@Test
+	func keepsContinuationSlicesInTheSameAccessUnit() {
+		// A second slice of the same frame has first_mb_in_slice > 0, which
+		// encodes with a leading '0' bit.
+		let firstSlice = Data([0x65, 0x88])
+		let continuationSlice = Data([0x65, 0x08])
+		let nextFrame = Data([0x41, 0x9A])
+		let units = OpenH264AnnexB.accessUnits(
+			from: [firstSlice, continuationSlice, nextFrame])
+
+		#expect(units == [[firstSlice, continuationSlice], [nextFrame]])
+	}
+
+	@Test
+	func startsANewAccessUnitForParameterSetsAfterSlices() {
+		let idr = Data([0x65, 0x88])
+		let sps = Data([0x67, 0x64])
+		let pps = Data([0x68, 0xEE])
+		let nextIDR = Data([0x65, 0x89])
+		let units = OpenH264AnnexB.accessUnits(from: [idr, sps, pps, nextIDR])
+
+		#expect(units == [[idr], [sps, pps, nextIDR]])
+	}
+
+	@Test
+	func waitsForIDRAfterResetOrDecodeFailure() {
+		let inter = [Data([0x41, 1])]
+		let idr = [Data([0x65, 1])]
+		var gate = OpenH264DecodeGate()
+
+		var decision = gate.shouldDecode(inter)
+		#expect(!decision)
+		decision = gate.shouldDecode(idr)
+		#expect(decision)
+		decision = gate.shouldDecode(inter)
+		#expect(decision)
+		gate.reset()
+		decision = gate.shouldDecode(inter)
+		#expect(!decision)
+		decision = gate.shouldDecode(idr)
+		#expect(decision)
+		gate.decodeFailed()
+		decision = gate.shouldDecode(inter)
+		#expect(!decision)
+	}
+}

--- a/macos/CrabfleetMac/Vendor/RoyalVNCKit/UPSTREAM.md
+++ b/macos/CrabfleetMac/Vendor/RoyalVNCKit/UPSTREAM.md
@@ -17,6 +17,10 @@ framing; prefers supported Apple Remote Desktop authentication when macOS
 Screen Sharing advertises it; validates palette ranges; and materializes bounded framebuffer
 previews.
 
+The fork also negotiates and decodes the community Open H.264 RFB frame
+encoding (type 50) through VideoToolbox on supported Apple platforms, with
+Annex-B parsing, decoder-context resets, and IDR recovery kept in one encoding.
+
 The fork completes the upstream Extended Clipboard stub (pseudo-encoding
 `0xc0a1e5ce`): the client advertises the extension when clipboard sync is
 enabled, answers server caps, exchanges UTF-8 text through bounded


### PR DESCRIPTION
Brings Share This Mac to Jump-Desktop-class streaming: hardware H.264 over the community RFB Open H.264 encoding (type 50), with the existing Tight/JPEG path as automatic fallback.

## Host (Share This Mac)

- New `MacVideoEncoder`: VideoToolbox low-latency rate control, constrained baseline profile (as the Open H.264 encoding prescribes), SPS/PPS prepended on IDR frames, Annex-B output.
- Encode-on-demand architecture: captured pixel buffers land in a latest-wins mailbox and one frame is encoded per send slot, so stale frames are dropped before costing encoder time and every encoded frame reaches the client — the H.264 reference chain can never break under backpressure.
- 60 fps capture while H.264 is active (15 fps JPEG otherwise); initial capture cap raised to 2560x1600, H.264 resize up to 4096x2304.
- Idle screens answer update requests with rectangle-free heartbeat updates instead of pixels; a one-shot `SCScreenshotManager` snapshot guarantees keyframes on connect/resize even when nothing changes on screen. The JPEG path also stops resending identical frames (previously ~1.5 MB/s on a static screen).
- Adaptive bitrate: deterministic AIMD controller, 8 Mbit/s start, 1.5-30 Mbit/s range, driven by measured send time.
- Live stream stats in the share sheet (codec, hardware/software, fps, Mbit/s).
- Persisted "View only" toggle enforced host-side; engaging it releases held keys and mouse buttons.
- Failure at any point (session creation, encode, reconfigure) tears down the video path and continues on Tight/JPEG, including a snapshot-refresh of the JPEG store so fallback works on static screens.

## Viewer (vendored RoyalVNCKit fork)

- New `OpenH264Encoding` frame decoder: bounded Annex-B parsing, access-unit splitting (third-party servers may glue several frames into one rectangle), VideoToolbox hardware decode to BGRA, per-geometry decoder contexts with LRU eviction, reset flags, and wait-for-IDR recovery after decode errors.
- Cross-platform-safe: everything VideoToolbox lives behind `canImport(VideoToolbox)`; the encoding is stripped from negotiation elsewhere. Fork delta documented in `UPSTREAM.md`.
- The native viewer now negotiates `[.openH264, .tight, .hextile]`.

## Protocol notes

- Open H.264 rect: u32 length, u32 flags (0x1 reset context, 0x2 reset all), Annex-B payload; full-framebuffer geometry per frame; reset-all sent on session start and after resize.
- Non-incremental `FramebufferUpdateRequest`s always receive real pixels (H.264: forced keyframe; JPEG: dedupe bypassed).

## Proof

- `swift build` clean, zero warnings.
- `swift test --package-path macos/CrabfleetMac`: 102 tests passed (includes a real client-server loopback exercising H.264 negotiation -> encoder failure -> Tight fallback -> clipboard/resize/dedupe).
- Vendor suite: 47 tests passed (Annex-B parsing, access-unit grouping, IDR gate, parameter-set bounds).
- Four structured review rounds (Codex `gpt-5.5`); all accepted findings fixed (multi-frame rectangles, baseline profile, stale JPEG store on fallback, non-incremental refresh), final round clean.
- Live two-Mac hardware validation on the tailnet (clawmac host -> megaclaw viewer) to follow in PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
