### PR TITLE
feat(events): add structured ClawSweeper session events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add an agent-authenticated structured action-event ledger with per-session idempotency keys, conflict detection, atomically enforced count and byte budgets, bounded versioned JSON payloads, and complete API/R2 archive exposure while preserving existing message events and work-state behavior.
+- Add an agent-authenticated structured action-event ledger with per-session idempotency keys, conflict detection, atomically enforced count and byte budgets, bounded versioned JSON payloads, complete API/R2 archive exposure, and a five-minute terminal retry window while preserving existing message events and work-state behavior.
 - Add a VideoToolbox-backed Open H.264 RFB pipeline for Share This Mac with up to 60 fps capture, adaptive 1.5–30 Mbit/s rate control, automatic Tight/JPEG fallback, live stream stats, larger resize limits, and a persisted host-enforced view-only mode.
 - Exchange full UTF-8 clipboard text between the native Mac viewer, Share This Mac hosts, and any Extended Clipboard-capable VNC server by completing the RoyalVNCKit fork's extension stub, keeping Latin-1 cut text as the fallback and dropping malformed extension bodies without tearing down the connection.
 - Add persisted send-only and receive-only clipboard directions to the native viewer's focus toolbar; automatic sync respects the direction while the explicit Send and Get actions keep working.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add an agent-authenticated structured action-event ledger with per-session idempotency keys, conflict detection, versioned JSON payloads, and complete API/R2 archive exposure while preserving existing message events and work-state behavior.
+- Add an agent-authenticated structured action-event ledger with per-session idempotency keys, conflict detection, bounded versioned JSON payloads, and complete API/R2 archive exposure while preserving existing message events and work-state behavior.
 - Add a VideoToolbox-backed Open H.264 RFB pipeline for Share This Mac with up to 60 fps capture, adaptive 1.5–30 Mbit/s rate control, automatic Tight/JPEG fallback, live stream stats, larger resize limits, and a persisted host-enforced view-only mode.
 - Exchange full UTF-8 clipboard text between the native Mac viewer, Share This Mac hosts, and any Extended Clipboard-capable VNC server by completing the RoyalVNCKit fork's extension stub, keeping Latin-1 cut text as the fallback and dropping malformed extension bodies without tearing down the connection.
 - Add persisted send-only and receive-only clipboard directions to the native viewer's focus toolbar; automatic sync respects the direction while the explicit Send and Get actions keep working.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add an agent-authenticated structured action-event ledger with per-session idempotency keys, conflict detection, versioned JSON payloads, and complete API/R2 archive exposure while preserving existing message events and work-state behavior.
 - Add a VideoToolbox-backed Open H.264 RFB pipeline for Share This Mac with up to 60 fps capture, adaptive 1.5–30 Mbit/s rate control, automatic Tight/JPEG fallback, live stream stats, larger resize limits, and a persisted host-enforced view-only mode.
 - Exchange full UTF-8 clipboard text between the native Mac viewer, Share This Mac hosts, and any Extended Clipboard-capable VNC server by completing the RoyalVNCKit fork's extension stub, keeping Latin-1 cut text as the fallback and dropping malformed extension bodies without tearing down the connection.
 - Add persisted send-only and receive-only clipboard directions to the native viewer's focus toolbar; automatic sync respects the direction while the explicit Send and Get actions keep working.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add an agent-authenticated structured action-event ledger with per-session idempotency keys, conflict detection, bounded versioned JSON payloads, and complete API/R2 archive exposure while preserving existing message events and work-state behavior.
+- Add an agent-authenticated structured action-event ledger with per-session idempotency keys, conflict detection, atomically enforced count and byte budgets, bounded versioned JSON payloads, and complete API/R2 archive exposure while preserving existing message events and work-state behavior.
 - Add a VideoToolbox-backed Open H.264 RFB pipeline for Share This Mac with up to 60 fps capture, adaptive 1.5–30 Mbit/s rate control, automatic Tight/JPEG fallback, live stream stats, larger resize limits, and a persisted host-enforced view-only mode.
 - Exchange full UTF-8 clipboard text between the native Mac viewer, Share This Mac hosts, and any Extended Clipboard-capable VNC server by completing the RoyalVNCKit fork's extension stub, keeping Latin-1 cut text as the fallback and dropping malformed extension bodies without tearing down the connection.
 - Add persisted send-only and receive-only clipboard directions to the native viewer's focus toolbar; automatic sync respects the direction while the explicit Send and Get actions keep working.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Add an agent-authenticated structured action-event ledger with per-session idempotency keys, conflict detection, atomically enforced count and byte budgets, bounded versioned JSON payloads, complete API/R2 archive exposure, and a five-minute terminal retry window while preserving existing message events and work-state behavior.
 - Add a VideoToolbox-backed Open H.264 RFB pipeline for Share This Mac with up to 60 fps capture, adaptive 1.5–30 Mbit/s rate control, automatic Tight/JPEG fallback, live stream stats, larger resize limits, and a persisted host-enforced view-only mode.
 - Exchange full UTF-8 clipboard text between the native Mac viewer, Share This Mac hosts, and any Extended Clipboard-capable VNC server by completing the RoyalVNCKit fork's extension stub, keeping Latin-1 cut text as the fallback and dropping malformed extension bodies without tearing down the connection.
 - Add persisted send-only and receive-only clipboard directions to the native viewer's focus toolbar; automatic sync respects the direction while the explicit Send and Get actions keep working.

--- a/docs/api.md
+++ b/docs/api.md
@@ -645,7 +645,9 @@ Agent-authenticated structured event append. Use `Authorization: Bearer <agentTo
 schema filtering. The serialized payload is limited to 64 KiB, 16 levels,
 1,024 aggregate array/object members, and 16 KiB per UTF-8 string or object key.
 Structural-limit violations return `400`; serialized payload overflow returns
-`413`.
+`413`. A session may retain at most 2,048 structured events and 8 MiB of their
+aggregate UTF-8 event data. The database enforces both limits atomically;
+overflow returns `413`, while an exact idempotent replay remains valid.
 
 The first append returns the stored public event with `duplicate: false`.
 Replaying the same key, type, trimmed message, and semantic JSON payload returns

--- a/docs/api.md
+++ b/docs/api.md
@@ -621,6 +621,36 @@ Agent-authenticated heartbeat and state update. Use `Authorization: Bearer <agen
 
 Every call updates `lastHeartbeatAt`. Active states are `registered` and `running`; `phase` keeps active steps distinguishable. Terminal states are `completed`, `blocked`, `failed`, and `canceled`.
 
+### POST /api/agent/interactive-sessions/:id/events
+
+Agent-authenticated structured event append. Use `Authorization: Bearer <agentToken>`.
+
+```json
+{
+  "eventKey": "clawsweeper:run:123:pull:42:update",
+  "type": "clawsweeper.action",
+  "message": "updated pull request 42",
+  "payload": {
+    "version": 1,
+    "action": "pull_request_updated",
+    "repository": "openclaw/crabfleet",
+    "number": 42
+  }
+}
+```
+
+`eventKey` is required, nonempty, and unique within the session. `type` and
+`message` are required. `payload` must be a JSON object with a positive integer
+`version`; additional fields and future positive versions are retained without
+schema filtering.
+
+The first append returns the stored public event with `duplicate: false`.
+Replaying the same key, type, trimmed message, and semantic JSON payload returns
+the original event with `duplicate: true`, including when object keys arrive in
+a different order. Reusing the key with different content returns `409`.
+Structured events do not change work state, `lastEvent`, or the existing
+message-event behavior.
+
 ### POST /api/interactive-sessions
 
 Maintainer+. Creates a standalone Codex CLI workspace request.
@@ -680,7 +710,7 @@ Authenticated viewer. Returns one current decorated session after a bounded life
 
 ### GET /api/interactive-sessions/:id/logs
 
-Visible-session viewer. Returns up to 5,000 recent D1 events, the total event count, truncation state, and current R2 archive snapshot metadata when available. It does not read or return the archived R2 objects.
+Visible-session viewer. Returns up to 5,000 recent D1 events, the total event count, truncation state, and current R2 archive snapshot metadata when available. Event records expose `actor`, `eventKey`, `type`, `message`, `payload`, and `createdAt`. Legacy message events use `eventKey: null`, `type: "message"`, and `payload: null`. This endpoint does not read or return the archived R2 objects.
 
 ### GET /api/interactive-sessions/:id/transcript
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -654,7 +654,8 @@ Replaying the same key, type, trimmed message, and semantic JSON payload returns
 the original event with `duplicate: true`, including when object keys arrive in
 a different order. Reusing the key with different content returns `409`.
 Structured events do not change work state, `lastEvent`, or the existing
-message-event behavior.
+message-event behavior. A terminal session token remains valid for structured
+event append and replay for five minutes after `stoppedAt`, then returns `403`.
 
 ### POST /api/interactive-sessions
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -642,7 +642,10 @@ Agent-authenticated structured event append. Use `Authorization: Bearer <agentTo
 `eventKey` is required, nonempty, and unique within the session. `type` and
 `message` are required. `payload` must be a JSON object with a positive integer
 `version`; additional fields and future positive versions are retained without
-schema filtering.
+schema filtering. The serialized payload is limited to 64 KiB, 16 levels,
+1,024 aggregate array/object members, and 16 KiB per UTF-8 string or object key.
+Structural-limit violations return `400`; serialized payload overflow returns
+`413`.
 
 The first append returns the stored public event with `duplicate: false`.
 Replaying the same key, type, trimmed message, and semantic JSON payload returns

--- a/docs/github-actions-sessions.md
+++ b/docs/github-actions-sessions.md
@@ -249,6 +249,9 @@ returns the original event with `duplicate: true`; changed content under the
 same key returns `409`. This lets retried workflow steps publish once without a
 separate read-before-write race. The endpoint only appends the event ledger: it
 does not update `workState`, `workPhase`, `lastHeartbeatAt`, or `lastEvent`.
+After a terminal work-state update, the same session token can append or replay
+structured events for five minutes. The endpoint rejects that credential after
+the retry window so completed sessions do not retain indefinite write access.
 
 ## Runner PTY
 

--- a/docs/github-actions-sessions.md
+++ b/docs/github-actions-sessions.md
@@ -212,6 +212,41 @@ ClawSweeper include:
 Crabfleet records the state transition as a session event and exposes the
 latest state in Fleet, Sessions, API, CLI, and logs.
 
+## Structured Action Events
+
+The Action runner can append durable machine-readable events without changing
+the work-state heartbeat:
+
+```http
+POST /api/agent/interactive-sessions/:id/events
+Authorization: Bearer <agentToken>
+Content-Type: application/json
+```
+
+```json
+{
+  "eventKey": "clawsweeper:run:123:pull:42:update",
+  "type": "clawsweeper.action",
+  "message": "updated pull request 42",
+  "payload": {
+    "version": 1,
+    "action": "pull_request_updated",
+    "number": 42,
+    "headSha": "0123456789abcdef"
+  }
+}
+```
+
+The payload must be a JSON object with a positive integer `version`. Crabfleet
+keeps all additional fields so ClawSweeper can extend action metadata without a
+coordinated schema migration.
+
+`eventKey` is unique within the session. An exact semantic replay succeeds and
+returns the original event with `duplicate: true`; changed content under the
+same key returns `409`. This lets retried workflow steps publish once without a
+separate read-before-write race. The endpoint only appends the event ledger: it
+does not update `workState`, `workPhase`, `lastHeartbeatAt`, or `lastEvent`.
+
 ## Runner PTY
 
 The Action connects outbound to the returned `runnerPtyUrl`:
@@ -458,11 +493,14 @@ Viewer terminal attaches are also recorded.
 
 When `SESSION_LOGS` is configured, session events periodically refresh:
 
-- NDJSON event archive;
+- NDJSON event archive with `eventKey`, `type`, and structured `payload`;
 - Markdown transcript;
 - JSON summary.
 
-D1 keeps the compact event list and archive pointers used by the app and API. Terminal completion forces a current snapshot before finalization clears.
+D1 keeps the compact event list and archive pointers used by the app and API.
+Legacy message events remain in the same stream with a null key and payload and
+the `message` type. Terminal completion forces a current snapshot before
+finalization clears.
 
 ## Operational Checks
 

--- a/docs/github-actions-sessions.md
+++ b/docs/github-actions-sessions.md
@@ -241,6 +241,8 @@ The payload must be a JSON object with a positive integer `version`. Crabfleet
 keeps all additional fields so ClawSweeper can extend action metadata without a
 coordinated schema migration. Payloads are bounded to 64 KiB serialized, 16
 levels, 1,024 aggregate members, and 16 KiB per UTF-8 string or object key.
+Each session is also capped atomically at 2,048 structured events and 8 MiB of
+aggregate UTF-8 event data, keeping API and archive reads bounded.
 
 `eventKey` is unique within the session. An exact semantic replay succeeds and
 returns the original event with `duplicate: true`; changed content under the

--- a/docs/github-actions-sessions.md
+++ b/docs/github-actions-sessions.md
@@ -239,7 +239,8 @@ Content-Type: application/json
 
 The payload must be a JSON object with a positive integer `version`. Crabfleet
 keeps all additional fields so ClawSweeper can extend action metadata without a
-coordinated schema migration.
+coordinated schema migration. Payloads are bounded to 64 KiB serialized, 16
+levels, 1,024 aggregate members, and 16 KiB per UTF-8 string or object key.
 
 `eventKey` is unique within the session. An exact semantic replay succeeds and
 returns the original event with `duplicate: true`; changed content under the

--- a/migrations/0032_interactive_session_action_events.sql
+++ b/migrations/0032_interactive_session_action_events.sql
@@ -6,3 +6,48 @@ ALTER TABLE interactive_session_events ADD COLUMN payload_json TEXT;
 CREATE UNIQUE INDEX IF NOT EXISTS idx_interactive_session_events_session_event_key
   ON interactive_session_events(session_id, event_key)
   WHERE event_key IS NOT NULL AND event_key <> '';
+
+CREATE TRIGGER IF NOT EXISTS enforce_interactive_session_action_event_budget
+BEFORE INSERT ON interactive_session_events
+WHEN NEW.event_key IS NOT NULL
+  AND NEW.event_key <> ''
+  AND NOT EXISTS (
+    SELECT 1
+    FROM interactive_session_events
+    WHERE session_id = NEW.session_id
+      AND event_key = NEW.event_key
+  )
+  AND (
+    (
+      SELECT COUNT(*)
+      FROM interactive_session_events
+      WHERE session_id = NEW.session_id
+        AND event_key IS NOT NULL
+        AND event_key <> ''
+    ) >= 2048
+    OR (
+      SELECT COALESCE(
+        SUM(
+          length(CAST(actor AS BLOB))
+          + length(CAST(event_key AS BLOB))
+          + length(CAST(event_type AS BLOB))
+          + length(CAST(message AS BLOB))
+          + length(CAST(COALESCE(payload_json, '') AS BLOB))
+        ),
+        0
+      )
+      FROM interactive_session_events
+      WHERE session_id = NEW.session_id
+        AND event_key IS NOT NULL
+        AND event_key <> ''
+    )
+      + length(CAST(NEW.actor AS BLOB))
+      + length(CAST(NEW.event_key AS BLOB))
+      + length(CAST(NEW.event_type AS BLOB))
+      + length(CAST(NEW.message AS BLOB))
+      + length(CAST(COALESCE(NEW.payload_json, '') AS BLOB))
+      > 8388608
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'structured session event budget exceeded');
+END;

--- a/migrations/0032_interactive_session_action_events.sql
+++ b/migrations/0032_interactive_session_action_events.sql
@@ -1,0 +1,8 @@
+ALTER TABLE interactive_session_events ADD COLUMN event_key TEXT;
+ALTER TABLE interactive_session_events
+  ADD COLUMN event_type TEXT NOT NULL DEFAULT 'message';
+ALTER TABLE interactive_session_events ADD COLUMN payload_json TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_interactive_session_events_session_event_key
+  ON interactive_session_events(session_id, event_key)
+  WHERE event_key IS NOT NULL AND event_key <> '';

--- a/src/worker/database.ts
+++ b/src/worker/database.ts
@@ -266,6 +266,9 @@ export type InteractiveSessionEventTable = {
   session_id: string;
   actor: string;
   message: string;
+  event_key: Generated<string | null>;
+  event_type: Generated<string>;
+  payload_json: Generated<string | null>;
   created_at: number;
 };
 

--- a/src/worker/github-actions-application.ts
+++ b/src/worker/github-actions-application.ts
@@ -17,7 +17,7 @@ import {
 import { actor } from "./auth.ts";
 import { sha256 } from "./crypto.ts";
 import type { RuntimeEnv } from "./env.ts";
-import { badRequest, readJson, serviceUnavailable } from "./http.ts";
+import { badRequest, readBoundedJson, readJson, serviceUnavailable } from "./http.ts";
 import type { User } from "./models.ts";
 import {
   AgentSessionAuthenticator,
@@ -42,6 +42,8 @@ const services = {
   authenticator: Symbol("authenticator"),
   repository: Symbol("repository"),
 };
+
+export const structuredEventRequestMaxBytes = 96 * 1024;
 
 export type GitHubActionsApplicationDependencies = {
   audit(user: User, message: string, now: number): Promise<void>;
@@ -116,7 +118,7 @@ export class GitHubActionsApplication {
 
   async appendStructuredEvent(request: Request, id: string) {
     const { user } = await this.authenticate(request, id);
-    const input = await readJson<unknown>(request);
+    const input = await readBoundedJson<unknown>(request, structuredEventRequestMaxBytes);
     if (!input || typeof input !== "object" || Array.isArray(input)) {
       throw badRequest("event body must be a JSON object");
     }

--- a/src/worker/github-actions-application.ts
+++ b/src/worker/github-actions-application.ts
@@ -25,7 +25,10 @@ import {
   type AgentSessionAuthenticationOptions,
   type AgentSessionAuthenticationStore,
 } from "./session-agent-auth.ts";
-import { appendInteractiveSessionEventRecord } from "./session-events.ts";
+import {
+  appendInteractiveSessionEventRecord,
+  appendStructuredInteractiveSessionEventRecord,
+} from "./session-events.ts";
 import { InteractiveSessionGrantRepository } from "./session-grant-repository.ts";
 import { nextInteractiveSessionId } from "./session-id-repository.ts";
 import type { InteractiveSession } from "./session-model.ts";
@@ -82,7 +85,7 @@ export class GitHubActionsApplication {
       updateSession: (id, values) => repository.updateSession(id, values),
       isConstraintError,
       disconnectRunner: (id) => this.disconnectRunner(id),
-      appendEvent: (id, message, now) => this.appendEvent(id, user, message, now),
+      appendEvent: (id, message, now) => this.appendMessageEvent(id, user, message, now),
       audit: (message, now) => this.dependencies.audit(user, message, now),
       readSession: (id) => readInteractiveSessionRecord(this.env, id),
     };
@@ -100,7 +103,8 @@ export class GitHubActionsApplication {
       now: () => Date.now(),
       readRow: (sessionId) => repository.readById(sessionId),
       persist: (sessionId, values) => repository.updateSession(sessionId, values),
-      appendEvent: (sessionId, message, now) => this.appendEvent(sessionId, user, message, now),
+      appendEvent: (sessionId, message, now) =>
+        this.appendMessageEvent(sessionId, user, message, now),
       disconnectRunner: (sessionId) => this.disconnectRunner(sessionId),
       readSession: (sessionId) => readInteractiveSessionRecord(this.env, sessionId),
     };
@@ -108,6 +112,29 @@ export class GitHubActionsApplication {
       session: await new GitHubActionsWorkStateService(store).update(session, body),
       user,
     };
+  }
+
+  async appendStructuredEvent(request: Request, id: string) {
+    const { user } = await this.authenticate(request, id);
+    const input = await readJson<unknown>(request);
+    if (!input || typeof input !== "object" || Array.isArray(input)) {
+      throw badRequest("event body must be a JSON object");
+    }
+    const body = input as {
+      eventKey?: unknown;
+      type?: unknown;
+      message?: unknown;
+      payload?: unknown;
+    };
+    return appendStructuredInteractiveSessionEventRecord(this.env, {
+      sessionId: id,
+      actor: actor(user),
+      eventKey: body.eventKey,
+      type: body.type,
+      message: body.message,
+      payload: body.payload,
+      now: Date.now(),
+    });
   }
 
   async openRunnerPty(request: Request, id: string): Promise<Response> {
@@ -123,7 +150,8 @@ export class GitHubActionsApplication {
     const store: GitHubActionsRunnerConnectionStore = {
       now: () => Date.now(),
       persist: (sessionId, values) => repository.updateSession(sessionId, values),
-      appendEvent: (sessionId, message, now) => this.appendEvent(sessionId, user, message, now),
+      appendEvent: (sessionId, message, now) =>
+        this.appendMessageEvent(sessionId, user, message, now),
     };
     await new GitHubActionsRunnerConnectionService(store).connect(session);
     return stub.fetch("https://crabfleet.internal/api/session-control/github-actions/runner", {
@@ -160,7 +188,7 @@ export class GitHubActionsApplication {
     return this.registry.get(services.repository, () => new GitHubActionsRepository(this.env));
   }
 
-  private appendEvent(id: string, user: User, message: string, now: number): Promise<void> {
+  private appendMessageEvent(id: string, user: User, message: string, now: number): Promise<void> {
     return appendInteractiveSessionEventRecord(this.env, {
       sessionId: id,
       actor: actor(user),

--- a/src/worker/github-actions-application.ts
+++ b/src/worker/github-actions-application.ts
@@ -117,7 +117,7 @@ export class GitHubActionsApplication {
   }
 
   async appendStructuredEvent(request: Request, id: string) {
-    const { user } = await this.authenticate(request, id);
+    const { user } = await this.authenticate(request, id, { allowTerminalEvent: true });
     const input = await readBoundedJson<unknown>(request, structuredEventRequestMaxBytes);
     if (!input || typeof input !== "object" || Array.isArray(input)) {
       throw badRequest("event body must be a JSON object");

--- a/src/worker/github-actions-application.ts
+++ b/src/worker/github-actions-application.ts
@@ -34,7 +34,7 @@ import { nextInteractiveSessionId } from "./session-id-repository.ts";
 import type { InteractiveSession } from "./session-model.ts";
 import { readAgentSessionCredential, readInteractiveSessionRecord } from "./session-repository.ts";
 import { newAgentToken } from "./session-reservation-context.ts";
-import { githubActionsRelayStub } from "./session-control-do.ts";
+import { githubActionsRelayStub } from "./github-actions-relay.ts";
 import { ServiceRegistry } from "./service-registry.ts";
 
 const services = {

--- a/src/worker/github-actions-relay.ts
+++ b/src/worker/github-actions-relay.ts
@@ -1,0 +1,7 @@
+import type { RuntimeEnv } from "./env.ts";
+
+export function githubActionsRelayStub(env: RuntimeEnv, sessionId: string) {
+  if (!env.SESSION_CONTROL) return null;
+  const id = env.SESSION_CONTROL.idFromName(`github-actions:${sessionId}`);
+  return env.SESSION_CONTROL.get(id);
+}

--- a/src/worker/http.ts
+++ b/src/worker/http.ts
@@ -61,6 +61,49 @@ export async function readJson<T>(request: Request): Promise<T> {
   }
 }
 
+export async function readBoundedJson<T>(request: Request, maximumBytes: number): Promise<T> {
+  if (!Number.isSafeInteger(maximumBytes) || maximumBytes < 1) {
+    throw new Error("invalid JSON body limit");
+  }
+  const declaredLength = request.headers.get("content-length");
+  if (/^\d+$/u.test(declaredLength ?? "") && Number(declaredLength) > maximumBytes) {
+    await request.body?.cancel().catch(() => undefined);
+    throw payloadTooLarge(`request body must be at most ${maximumBytes} bytes`);
+  }
+  if (!request.body) throw badRequest("invalid json");
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value?.byteLength) continue;
+      total += value.byteLength;
+      if (total > maximumBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw payloadTooLarge(`request body must be at most ${maximumBytes} bytes`);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as T;
+  } catch {
+    throw badRequest("invalid json");
+  }
+}
+
 export function bearerToken(request: Request): string {
   const authorization = request.headers.get("authorization") ?? "";
   const [scheme, token] = authorization.split(/\s+/, 2);

--- a/src/worker/http.ts
+++ b/src/worker/http.ts
@@ -106,6 +106,10 @@ export function badRequest(message: string): HttpError {
   return httpError(400, message);
 }
 
+export function payloadTooLarge(message: string): HttpError {
+  return httpError(413, message);
+}
+
 export function tooManyRequests(message: string): HttpError {
   return httpError(429, message);
 }

--- a/src/worker/interactive-terminal-service.ts
+++ b/src/worker/interactive-terminal-service.ts
@@ -38,7 +38,7 @@ import {
   delegatedInteractiveSessionControlAvailable,
 } from "./session-access.ts";
 import { InteractiveSessionGrantRepository } from "./session-grant-repository.ts";
-import { githubActionsRelayStub } from "./session-control-do.ts";
+import { githubActionsRelayStub } from "./github-actions-relay.ts";
 import { appendInteractiveSessionEventRecord } from "./session-events.ts";
 import type { InteractiveSession } from "./session-model.ts";
 import { readAuthorizedFreshSession } from "./session-authorized-refresh.ts";

--- a/src/worker/routes/service-sessions.ts
+++ b/src/worker/routes/service-sessions.ts
@@ -13,6 +13,7 @@ export type ServiceSessionRouteDependencies = {
   createSshSession(request: Request): Promise<unknown>;
   createAgentSession(request: Request): Promise<unknown>;
   updateAgentWorkState(request: Request, sessionId: string): Promise<unknown>;
+  appendAgentEvent(request: Request, sessionId: string): Promise<unknown>;
   openAgentRunnerPty(request: Request, sessionId: string): Promise<Response>;
   requireSshViewer(request: Request): Promise<User>;
   requireAgentUser(request: Request): Promise<User>;
@@ -62,6 +63,9 @@ export async function handleServiceSessionRoute(
 
   if (principal === "agent" && request.method === "POST" && resource === "work-state") {
     return json(await dependencies.updateAgentWorkState(request, sessionId));
+  }
+  if (principal === "agent" && request.method === "POST" && resource === "events") {
+    return json(await dependencies.appendAgentEvent(request, sessionId));
   }
   if (principal === "agent" && request.method === "GET" && resource === "runner-pty") {
     return dependencies.openAgentRunnerPty(request, sessionId);

--- a/src/worker/session-agent-auth.ts
+++ b/src/worker/session-agent-auth.ts
@@ -18,6 +18,7 @@ export type AgentSessionAuthenticationStore = {
 
 export type AgentSessionAuthenticationOptions = {
   allowQueryToken?: boolean;
+  allowTerminalEvent?: boolean;
 };
 
 export class AgentSessionAuthenticator {
@@ -46,9 +47,12 @@ export class AgentSessionAuthenticator {
     if (!credential?.tokenHash || credential.tokenHash !== (await this.store.hashToken(token))) {
       throw unauthorized();
     }
+    const terminalEventAllowed =
+      options.allowTerminalEvent &&
+      (credential.session.status === "stopped" || credential.session.status === "failed");
     if (
       credential.session.status === "stopping" ||
-      deadInteractiveSessionStatuses.includes(credential.session.status)
+      (deadInteractiveSessionStatuses.includes(credential.session.status) && !terminalEventAllowed)
     ) {
       throw forbidden("agent session is not active");
     }

--- a/src/worker/session-agent-auth.ts
+++ b/src/worker/session-agent-auth.ts
@@ -21,11 +21,15 @@ export type AgentSessionAuthenticationOptions = {
   allowTerminalEvent?: boolean;
 };
 
+export const terminalAgentEventGraceMs = 5 * 60 * 1000;
+
 export class AgentSessionAuthenticator {
   private readonly store: AgentSessionAuthenticationStore;
+  private readonly now: () => number;
 
-  constructor(store: AgentSessionAuthenticationStore) {
+  constructor(store: AgentSessionAuthenticationStore, now: () => number = Date.now) {
     this.store = store;
+    this.now = now;
   }
 
   async require(
@@ -47,9 +51,15 @@ export class AgentSessionAuthenticator {
     if (!credential?.tokenHash || credential.tokenHash !== (await this.store.hashToken(token))) {
       throw unauthorized();
     }
+    const now = this.now();
+    const stoppedAt = credential.session.stoppedAt;
     const terminalEventAllowed =
       options.allowTerminalEvent &&
-      (credential.session.status === "stopped" || credential.session.status === "failed");
+      (credential.session.status === "stopped" || credential.session.status === "failed") &&
+      typeof stoppedAt === "number" &&
+      Number.isFinite(stoppedAt) &&
+      stoppedAt <= now &&
+      now - stoppedAt <= terminalAgentEventGraceMs;
     if (
       credential.session.status === "stopping" ||
       (deadInteractiveSessionStatuses.includes(credential.session.status) && !terminalEventAllowed)

--- a/src/worker/session-control-do.ts
+++ b/src/worker/session-control-do.ts
@@ -249,15 +249,6 @@ export function sandboxControlStub(env: RuntimeEnv): DurableObjectStub<SessionCo
   return env.SESSION_CONTROL.get(id);
 }
 
-export function githubActionsRelayStub(
-  env: RuntimeEnv,
-  sessionId: string,
-): DurableObjectStub<SessionControlDO> | null {
-  if (!env.SESSION_CONTROL) return null;
-  const id = env.SESSION_CONTROL.idFromName(`github-actions:${sessionId}`);
-  return env.SESSION_CONTROL.get(id);
-}
-
 export async function readSandboxFleetPolicies(env: RuntimeEnv): Promise<{
   available: boolean;
   policies: FleetSandboxPolicySummary[];

--- a/src/worker/session-events.ts
+++ b/src/worker/session-events.ts
@@ -1,6 +1,6 @@
 import { database, executeBatch } from "./database.ts";
 import type { RuntimeEnv } from "./env.ts";
-import { badRequest, conflict } from "./http.ts";
+import { badRequest, conflict, payloadTooLarge } from "./http.ts";
 import { archiveInteractiveSessionLogs } from "./session-log-archive.ts";
 import {
   interactiveSessionEvent,
@@ -10,6 +10,13 @@ import {
   type InteractiveSessionEventRow,
 } from "./session-model.ts";
 import { terminalFinalizationPendingQuery } from "./session-terminal-finalization.ts";
+
+const encoder = new TextEncoder();
+
+export const structuredEventPayloadMaxBytes = 64 * 1024;
+export const structuredEventPayloadMaxDepth = 16;
+export const structuredEventPayloadMaxMembers = 1024;
+export const structuredEventPayloadMaxStringBytes = 16 * 1024;
 
 export type AppendInteractiveSessionEventInput = {
   sessionId: string;
@@ -143,14 +150,14 @@ function normalizeStructuredEvent(
   const eventKey = requiredString(input.eventKey, "eventKey", 240);
   const type = requiredString(input.type, "type", 120);
   const message = requiredString(input.message, "message", 1000);
-  const payload = structuredPayload(input.payload);
+  const payloadJson = structuredPayloadJson(input.payload);
   return {
     sessionId: input.sessionId,
     actor: input.actor,
     eventKey,
     type,
     message,
-    payloadJson: JSON.stringify(payload),
+    payloadJson,
     now: input.now,
   };
 }
@@ -168,7 +175,7 @@ function sameStructuredEvent(
   );
 }
 
-function structuredPayload(value: unknown): InteractiveSessionEventPayload {
+function structuredPayloadJson(value: unknown): string {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw badRequest("payload must be a JSON object");
   }
@@ -182,14 +189,30 @@ function structuredPayload(value: unknown): InteractiveSessionEventPayload {
   ) {
     throw badRequest("payload.version must be a positive integer");
   }
-  return canonicalJsonValue(record, new Set()) as InteractiveSessionEventPayload;
+  const payload = canonicalJsonValue(record, new Set(), 0, { members: 0 });
+  const payloadJson = JSON.stringify(payload);
+  if (encoder.encode(payloadJson).byteLength > structuredEventPayloadMaxBytes) {
+    throw payloadTooLarge(
+      `payload must be at most ${structuredEventPayloadMaxBytes} serialized bytes`,
+    );
+  }
+  return payloadJson;
 }
 
 function canonicalJsonValue(
   value: unknown,
   parents: Set<object>,
+  depth: number,
+  budget: { members: number },
 ): InteractiveSessionEventPayloadValue {
-  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (depth > structuredEventPayloadMaxDepth) {
+    throw badRequest(`payload depth must be at most ${structuredEventPayloadMaxDepth}`);
+  }
+  if (value === null || typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    assertPayloadStringSize(value);
+    return value;
+  }
   if (typeof value === "number") {
     if (!Number.isFinite(value)) throw badRequest("payload must contain valid JSON values");
     return value;
@@ -201,15 +224,35 @@ function canonicalJsonValue(
   parents.add(value);
   try {
     if (Array.isArray(value)) {
-      return value.map((item) => canonicalJsonValue(item, parents));
+      consumePayloadMembers(budget, value.length);
+      return value.map((item) => canonicalJsonValue(item, parents, depth + 1, budget));
     }
+    const keys = Object.keys(value).sort();
+    consumePayloadMembers(budget, keys.length);
+    for (const key of keys) assertPayloadStringSize(key);
     return Object.fromEntries(
-      Object.keys(value)
-        .sort()
-        .map((key) => [key, canonicalJsonValue((value as Record<string, unknown>)[key], parents)]),
+      keys.map((key) => [
+        key,
+        canonicalJsonValue((value as Record<string, unknown>)[key], parents, depth + 1, budget),
+      ]),
     ) as InteractiveSessionEventPayload;
   } finally {
     parents.delete(value);
+  }
+}
+
+function consumePayloadMembers(budget: { members: number }, count: number): void {
+  budget.members += count;
+  if (budget.members > structuredEventPayloadMaxMembers) {
+    throw badRequest(`payload must contain at most ${structuredEventPayloadMaxMembers} members`);
+  }
+}
+
+function assertPayloadStringSize(value: string): void {
+  if (encoder.encode(value).byteLength > structuredEventPayloadMaxStringBytes) {
+    throw badRequest(
+      `payload strings must be at most ${structuredEventPayloadMaxStringBytes} UTF-8 bytes`,
+    );
   }
 }
 

--- a/src/worker/session-events.ts
+++ b/src/worker/session-events.ts
@@ -1,6 +1,9 @@
+import { sql } from "kysely";
+
 import { database, executeBatch } from "./database.ts";
 import type { RuntimeEnv } from "./env.ts";
 import { badRequest, conflict, payloadTooLarge } from "./http.ts";
+import { deadInteractiveSessionStatuses } from "./models.ts";
 import { archiveInteractiveSessionLogs } from "./session-log-archive.ts";
 import {
   interactiveSessionEvent,
@@ -48,10 +51,9 @@ type PersistedStructuredInteractiveSessionEvent = {
 };
 
 export type InteractiveSessionEventLedgerStore = {
-  persist(
+  persistAndInvalidate(
     event: PersistedStructuredInteractiveSessionEvent,
   ): Promise<{ row: InteractiveSessionEventRow; inserted: boolean }>;
-  invalidateTerminalFinalization(sessionId: string): Promise<void>;
   archive(sessionId: string, now: number): Promise<void>;
 };
 
@@ -71,11 +73,10 @@ export class InteractiveSessionEventLedgerService {
     input: AppendStructuredInteractiveSessionEventInput,
   ): Promise<AppendStructuredInteractiveSessionEventResult> {
     const event = normalizeStructuredEvent(input);
-    const persisted = await this.store.persist(event);
+    const persisted = await this.store.persistAndInvalidate(event);
     if (!sameStructuredEvent(persisted.row, event)) {
       throw conflict("event key already belongs to a different session event");
     }
-    await this.store.invalidateTerminalFinalization(event.sessionId);
     await this.store.archive(event.sessionId, event.now).catch(() => undefined);
     return {
       event: interactiveSessionEvent(persisted.row),
@@ -111,8 +112,8 @@ export async function appendStructuredInteractiveSessionEventRecord(
 ): Promise<AppendStructuredInteractiveSessionEventResult> {
   const db = database(env);
   return new InteractiveSessionEventLedgerService({
-    async persist(event) {
-      const inserted = await db
+    async persistAndInvalidate(event) {
+      const insert = db
         .insertInto("interactive_session_events")
         .values({
           session_id: event.sessionId,
@@ -124,8 +125,30 @@ export async function appendStructuredInteractiveSessionEventRecord(
           created_at: event.now,
         })
         .onConflict((constraint) => constraint.doNothing())
-        .returningAll()
-        .executeTakeFirst();
+        .returningAll();
+      const invalidate = db
+        .updateTable("interactive_sessions")
+        .set({ terminal_finalize_pending: 1 })
+        .where("id", "=", event.sessionId)
+        .where("status", "in", deadInteractiveSessionStatuses)
+        .where(
+          sql<boolean>`EXISTS (
+            SELECT 1
+            FROM interactive_session_events
+            WHERE session_id = ${event.sessionId}
+              AND event_key = ${event.eventKey}
+              AND event_type = ${event.type}
+              AND message = ${event.message}
+              AND payload_json = ${event.payloadJson}
+          )`,
+        );
+      const results = await env.DB.batch<InteractiveSessionEventRow>(
+        [insert, invalidate].map((query) => {
+          const compiled = query.compile();
+          return env.DB.prepare(compiled.sql).bind(...compiled.parameters);
+        }),
+      );
+      const inserted = results[0]?.results?.[0];
       const row =
         inserted ??
         (await db
@@ -136,9 +159,6 @@ export async function appendStructuredInteractiveSessionEventRecord(
           .executeTakeFirst());
       if (!row) throw new Error("structured session event was not persisted");
       return { row, inserted: Boolean(inserted) };
-    },
-    async invalidateTerminalFinalization(sessionId) {
-      await executeBatch(env, [terminalFinalizationPendingQuery(db, sessionId)]);
     },
     archive,
   }).append(input);

--- a/src/worker/session-events.ts
+++ b/src/worker/session-events.ts
@@ -1,6 +1,14 @@
 import { database, executeBatch } from "./database.ts";
 import type { RuntimeEnv } from "./env.ts";
+import { badRequest, conflict } from "./http.ts";
 import { archiveInteractiveSessionLogs } from "./session-log-archive.ts";
+import {
+  interactiveSessionEvent,
+  type InteractiveSessionEvent,
+  type InteractiveSessionEventPayload,
+  type InteractiveSessionEventPayloadValue,
+  type InteractiveSessionEventRow,
+} from "./session-model.ts";
 import { terminalFinalizationPendingQuery } from "./session-terminal-finalization.ts";
 
 export type AppendInteractiveSessionEventInput = {
@@ -11,6 +19,63 @@ export type AppendInteractiveSessionEventInput = {
 };
 
 export type InteractiveSessionEventArchive = (sessionId: string, now: number) => Promise<void>;
+
+export type AppendStructuredInteractiveSessionEventInput = {
+  sessionId: string;
+  actor: string;
+  eventKey: unknown;
+  type: unknown;
+  message: unknown;
+  payload: unknown;
+  now: number;
+};
+
+type PersistedStructuredInteractiveSessionEvent = {
+  sessionId: string;
+  actor: string;
+  eventKey: string;
+  type: string;
+  message: string;
+  payloadJson: string;
+  now: number;
+};
+
+export type InteractiveSessionEventLedgerStore = {
+  persist(
+    event: PersistedStructuredInteractiveSessionEvent,
+  ): Promise<{ row: InteractiveSessionEventRow; inserted: boolean }>;
+  invalidateTerminalFinalization(sessionId: string): Promise<void>;
+  archive(sessionId: string, now: number): Promise<void>;
+};
+
+export type AppendStructuredInteractiveSessionEventResult = {
+  event: InteractiveSessionEvent;
+  duplicate: boolean;
+};
+
+export class InteractiveSessionEventLedgerService {
+  private readonly store: InteractiveSessionEventLedgerStore;
+
+  constructor(store: InteractiveSessionEventLedgerStore) {
+    this.store = store;
+  }
+
+  async append(
+    input: AppendStructuredInteractiveSessionEventInput,
+  ): Promise<AppendStructuredInteractiveSessionEventResult> {
+    const event = normalizeStructuredEvent(input);
+    const persisted = await this.store.persist(event);
+    if (!sameStructuredEvent(persisted.row, event)) {
+      throw conflict("event key already belongs to a different session event");
+    }
+    await this.store.invalidateTerminalFinalization(event.sessionId);
+    await this.store.archive(event.sessionId, event.now).catch(() => undefined);
+    return {
+      event: interactiveSessionEvent(persisted.row),
+      duplicate: !persisted.inserted,
+    };
+  }
+}
 
 export async function appendInteractiveSessionEventRecord(
   env: RuntimeEnv,
@@ -29,6 +94,133 @@ export async function appendInteractiveSessionEventRecord(
     terminalFinalizationPendingQuery(db, input.sessionId),
   ]);
   await archive(input.sessionId, input.now).catch(() => undefined);
+}
+
+export async function appendStructuredInteractiveSessionEventRecord(
+  env: RuntimeEnv,
+  input: AppendStructuredInteractiveSessionEventInput,
+  archive: InteractiveSessionEventArchive = (sessionId, now) =>
+    archiveInteractiveSessionLogs(env, sessionId, now),
+): Promise<AppendStructuredInteractiveSessionEventResult> {
+  const db = database(env);
+  return new InteractiveSessionEventLedgerService({
+    async persist(event) {
+      const inserted = await db
+        .insertInto("interactive_session_events")
+        .values({
+          session_id: event.sessionId,
+          actor: event.actor,
+          event_key: event.eventKey,
+          event_type: event.type,
+          message: event.message,
+          payload_json: event.payloadJson,
+          created_at: event.now,
+        })
+        .onConflict((constraint) => constraint.doNothing())
+        .returningAll()
+        .executeTakeFirst();
+      const row =
+        inserted ??
+        (await db
+          .selectFrom("interactive_session_events")
+          .selectAll()
+          .where("session_id", "=", event.sessionId)
+          .where("event_key", "=", event.eventKey)
+          .executeTakeFirst());
+      if (!row) throw new Error("structured session event was not persisted");
+      return { row, inserted: Boolean(inserted) };
+    },
+    async invalidateTerminalFinalization(sessionId) {
+      await executeBatch(env, [terminalFinalizationPendingQuery(db, sessionId)]);
+    },
+    archive,
+  }).append(input);
+}
+
+function normalizeStructuredEvent(
+  input: AppendStructuredInteractiveSessionEventInput,
+): PersistedStructuredInteractiveSessionEvent {
+  const eventKey = requiredString(input.eventKey, "eventKey", 240);
+  const type = requiredString(input.type, "type", 120);
+  const message = requiredString(input.message, "message", 1000);
+  const payload = structuredPayload(input.payload);
+  return {
+    sessionId: input.sessionId,
+    actor: input.actor,
+    eventKey,
+    type,
+    message,
+    payloadJson: JSON.stringify(payload),
+    now: input.now,
+  };
+}
+
+function sameStructuredEvent(
+  row: InteractiveSessionEventRow,
+  event: PersistedStructuredInteractiveSessionEvent,
+): boolean {
+  return (
+    row.session_id === event.sessionId &&
+    row.event_key === event.eventKey &&
+    row.event_type === event.type &&
+    row.message === event.message &&
+    row.payload_json === event.payloadJson
+  );
+}
+
+function structuredPayload(value: unknown): InteractiveSessionEventPayload {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw badRequest("payload must be a JSON object");
+  }
+  const record = value as Record<string, unknown>;
+  const version = record.version;
+  if (
+    !Object.hasOwn(record, "version") ||
+    typeof version !== "number" ||
+    !Number.isInteger(version) ||
+    version < 1
+  ) {
+    throw badRequest("payload.version must be a positive integer");
+  }
+  return canonicalJsonValue(record, new Set()) as InteractiveSessionEventPayload;
+}
+
+function canonicalJsonValue(
+  value: unknown,
+  parents: Set<object>,
+): InteractiveSessionEventPayloadValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw badRequest("payload must contain valid JSON values");
+    return value;
+  }
+  if (typeof value !== "object") {
+    throw badRequest("payload must contain valid JSON values");
+  }
+  if (parents.has(value)) throw badRequest("payload must contain valid JSON values");
+  parents.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item) => canonicalJsonValue(item, parents));
+    }
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalJsonValue((value as Record<string, unknown>)[key], parents)]),
+    ) as InteractiveSessionEventPayload;
+  } finally {
+    parents.delete(value);
+  }
+}
+
+function requiredString(value: unknown, name: string, maximum: number): string {
+  if (typeof value !== "string") throw badRequest(`${name} must be a string`);
+  const normalized = value.trim();
+  if (!normalized) throw badRequest(`${name} is required`);
+  if (normalized.length > maximum) {
+    throw badRequest(`${name} must be at most ${maximum} characters`);
+  }
+  return normalized;
 }
 
 function clean(value: unknown, maximum: number): string {

--- a/src/worker/session-events.ts
+++ b/src/worker/session-events.ts
@@ -20,6 +20,10 @@ export const structuredEventPayloadMaxBytes = 64 * 1024;
 export const structuredEventPayloadMaxDepth = 16;
 export const structuredEventPayloadMaxMembers = 1024;
 export const structuredEventPayloadMaxStringBytes = 16 * 1024;
+export const structuredEventLedgerMaxCount = 2048;
+export const structuredEventLedgerMaxBytes = 8 * 1024 * 1024;
+
+const structuredEventLedgerBudgetError = "structured session event budget exceeded";
 
 export type AppendInteractiveSessionEventInput = {
   sessionId: string;
@@ -111,57 +115,66 @@ export async function appendStructuredInteractiveSessionEventRecord(
     archiveInteractiveSessionLogs(env, sessionId, now),
 ): Promise<AppendStructuredInteractiveSessionEventResult> {
   const db = database(env);
-  return new InteractiveSessionEventLedgerService({
-    async persistAndInvalidate(event) {
-      const insert = db
-        .insertInto("interactive_session_events")
-        .values({
-          session_id: event.sessionId,
-          actor: event.actor,
-          event_key: event.eventKey,
-          event_type: event.type,
-          message: event.message,
-          payload_json: event.payloadJson,
-          created_at: event.now,
-        })
-        .onConflict((constraint) => constraint.doNothing())
-        .returningAll();
-      const invalidate = db
-        .updateTable("interactive_sessions")
-        .set({ terminal_finalize_pending: 1 })
-        .where("id", "=", event.sessionId)
-        .where("status", "in", deadInteractiveSessionStatuses)
-        .where(
-          sql<boolean>`EXISTS (
-            SELECT 1
-            FROM interactive_session_events
-            WHERE session_id = ${event.sessionId}
-              AND event_key = ${event.eventKey}
-              AND event_type = ${event.type}
-              AND message = ${event.message}
-              AND payload_json = ${event.payloadJson}
-          )`,
+  try {
+    return await new InteractiveSessionEventLedgerService({
+      async persistAndInvalidate(event) {
+        const insert = db
+          .insertInto("interactive_session_events")
+          .values({
+            session_id: event.sessionId,
+            actor: event.actor,
+            event_key: event.eventKey,
+            event_type: event.type,
+            message: event.message,
+            payload_json: event.payloadJson,
+            created_at: event.now,
+          })
+          .onConflict((constraint) => constraint.doNothing())
+          .returningAll();
+        const invalidate = db
+          .updateTable("interactive_sessions")
+          .set({ terminal_finalize_pending: 1 })
+          .where("id", "=", event.sessionId)
+          .where("status", "in", deadInteractiveSessionStatuses)
+          .where(
+            sql<boolean>`EXISTS (
+              SELECT 1
+              FROM interactive_session_events
+              WHERE session_id = ${event.sessionId}
+                AND event_key = ${event.eventKey}
+                AND event_type = ${event.type}
+                AND message = ${event.message}
+                AND payload_json = ${event.payloadJson}
+            )`,
+          );
+        const results = await env.DB.batch<InteractiveSessionEventRow>(
+          [insert, invalidate].map((query) => {
+            const compiled = query.compile();
+            return env.DB.prepare(compiled.sql).bind(...compiled.parameters);
+          }),
         );
-      const results = await env.DB.batch<InteractiveSessionEventRow>(
-        [insert, invalidate].map((query) => {
-          const compiled = query.compile();
-          return env.DB.prepare(compiled.sql).bind(...compiled.parameters);
-        }),
+        const inserted = results[0]?.results?.[0];
+        const row =
+          inserted ??
+          (await db
+            .selectFrom("interactive_session_events")
+            .selectAll()
+            .where("session_id", "=", event.sessionId)
+            .where("event_key", "=", event.eventKey)
+            .executeTakeFirst());
+        if (!row) throw new Error("structured session event was not persisted");
+        return { row, inserted: Boolean(inserted) };
+      },
+      archive,
+    }).append(input);
+  } catch (error) {
+    if (String(error).toLowerCase().includes(structuredEventLedgerBudgetError)) {
+      throw payloadTooLarge(
+        `structured events must stay within ${structuredEventLedgerMaxCount} events and ${structuredEventLedgerMaxBytes} UTF-8 bytes per session`,
       );
-      const inserted = results[0]?.results?.[0];
-      const row =
-        inserted ??
-        (await db
-          .selectFrom("interactive_session_events")
-          .selectAll()
-          .where("session_id", "=", event.sessionId)
-          .where("event_key", "=", event.eventKey)
-          .executeTakeFirst());
-      if (!row) throw new Error("structured session event was not persisted");
-      return { row, inserted: Boolean(inserted) };
-    },
-    archive,
-  }).append(input);
+    }
+    throw error;
+  }
 }
 
 function normalizeStructuredEvent(

--- a/src/worker/session-log-archive.ts
+++ b/src/worker/session-log-archive.ts
@@ -52,11 +52,9 @@ export async function archiveInteractiveSessionLogs(
   const summaryKey = attemptedArchive.summary_key;
   if (env.SESSION_LOGS) {
     await Promise.all([
-      env.SESSION_LOGS.put(
-        eventsKey,
-        events.map((row) => JSON.stringify(interactiveSessionEvent(row))).join("\n") + "\n",
-        { httpMetadata: { contentType: "application/x-ndjson; charset=utf-8" } },
-      ),
+      env.SESSION_LOGS.put(eventsKey, sessionLogEventsNdjson(events), {
+        httpMetadata: { contentType: "application/x-ndjson; charset=utf-8" },
+      }),
       env.SESSION_LOGS.put(transcriptKey, sessionLogTranscript(sessionRow, events), {
         httpMetadata: { contentType: "text/markdown; charset=utf-8" },
       }),
@@ -160,6 +158,10 @@ export async function cleanupSessionLogArchiveObjects(
 
 export function sessionLogArchiveBase(id: string): string {
   return `orgs/openclaw/interactive-sessions/${id.replace(/[^A-Za-z0-9_.-]/g, "_")}`;
+}
+
+export function sessionLogEventsNdjson(events: InteractiveSessionEventRow[]): string {
+  return events.map((row) => JSON.stringify(interactiveSessionEvent(row))).join("\n") + "\n";
 }
 
 export function sessionLogTranscript(

--- a/src/worker/session-model.ts
+++ b/src/worker/session-model.ts
@@ -122,8 +122,23 @@ export type InteractiveSessionLogArchive = {
 
 export type InteractiveSessionEvent = {
   actor: string;
+  eventKey: string | null;
+  type: string;
   message: string;
+  payload: InteractiveSessionEventPayload | null;
   createdAt: number;
+};
+
+export type InteractiveSessionEventPayloadValue =
+  | null
+  | boolean
+  | number
+  | string
+  | InteractiveSessionEventPayloadValue[]
+  | { [key: string]: InteractiveSessionEventPayloadValue };
+
+export type InteractiveSessionEventPayload = {
+  [key: string]: InteractiveSessionEventPayloadValue;
 };
 
 export type InteractiveSessionEventRow = {
@@ -131,6 +146,9 @@ export type InteractiveSessionEventRow = {
   session_id: string;
   actor: string;
   message: string;
+  event_key: string | null;
+  event_type: string;
+  payload_json: string | null;
   created_at: number;
 };
 
@@ -201,7 +219,10 @@ export function interactiveSession(
 export function interactiveSessionEvent(row: InteractiveSessionEventRow): InteractiveSessionEvent {
   return {
     actor: row.actor,
+    eventKey: row.event_key,
+    type: row.event_type || "message",
     message: row.message,
+    payload: parseEventPayload(row.payload_json),
     createdAt: row.created_at,
   };
 }
@@ -249,4 +270,12 @@ function parseJson<T>(value: string, fallback: T): T {
   } catch {
     return fallback;
   }
+}
+
+function parseEventPayload(value: string | null): InteractiveSessionEventPayload | null {
+  if (!value) return null;
+  const parsed = parseJson<unknown>(value, null);
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? (parsed as InteractiveSessionEventPayload)
+    : null;
 }

--- a/src/worker/worker-application.ts
+++ b/src/worker/worker-application.ts
@@ -275,6 +275,8 @@ export class WorkerApplication {
           session: this.sessions.present(result.session, result.user),
         };
       },
+      appendAgentEvent: (request, sessionId) =>
+        this.githubActions.appendStructuredEvent(request, sessionId),
       openAgentRunnerPty: (request, sessionId) =>
         this.githubActions.openRunnerPty(request, sessionId),
       requireSshViewer: async (request) => {

--- a/tests/github-actions-event-auth.test.ts
+++ b/tests/github-actions-event-auth.test.ts
@@ -3,7 +3,10 @@ import test from "node:test";
 
 import { sha256 } from "../src/worker/crypto.ts";
 import type { RuntimeEnv } from "../src/worker/env.ts";
-import { GitHubActionsApplication } from "../src/worker/github-actions-application.ts";
+import {
+  GitHubActionsApplication,
+  structuredEventRequestMaxBytes,
+} from "../src/worker/github-actions-application.ts";
 import {
   handleServiceSessionRoute,
   type ServiceSessionRouteDependencies,
@@ -143,6 +146,34 @@ test("agent event endpoint rejects a wrong-session token before persistence", as
     handleServiceSessionRoute(request, new URL(request.url), routeDependencies(application)),
     hasStatus(401),
   );
+  assert.deepEqual(subject.credentialReads, ["IS-target"]);
+  assert.equal(subject.mutationCount(), 0);
+});
+
+test("authenticated event ingress rejects oversized chunked bodies before persistence", async () => {
+  const subject = await authEnvironment();
+  const application = new GitHubActionsApplication(subject.env, { audit: async () => undefined });
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array(structuredEventRequestMaxBytes));
+      controller.enqueue(new Uint8Array([123]));
+      controller.close();
+    },
+  });
+  const request = new Request(
+    "https://fleet.example/api/agent/interactive-sessions/IS-target/events",
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer target-token",
+        "content-type": "application/json",
+      },
+      body,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" },
+  );
+
+  await assert.rejects(application.appendStructuredEvent(request, "IS-target"), hasStatus(413));
   assert.deepEqual(subject.credentialReads, ["IS-target"]);
   assert.equal(subject.mutationCount(), 0);
 });

--- a/tests/github-actions-event-auth.test.ts
+++ b/tests/github-actions-event-auth.test.ts
@@ -7,6 +7,7 @@ import {
   GitHubActionsApplication,
   structuredEventRequestMaxBytes,
 } from "../src/worker/github-actions-application.ts";
+import { terminalAgentEventGraceMs } from "../src/worker/session-agent-auth.ts";
 import {
   handleServiceSessionRoute,
   type ServiceSessionRouteDependencies,
@@ -29,7 +30,10 @@ function eventRequest(sessionId: string, token: string): Request {
   });
 }
 
-async function authEnvironment(targetStatus: "ready" | "stopped" | "failed" = "ready") {
+async function authEnvironment(
+  targetStatus: "ready" | "stopped" | "failed" = "ready",
+  stoppedAt: number | null = targetStatus === "ready" ? null : Date.now(),
+) {
   const rows = new Map([
     [
       "IS-source",
@@ -48,6 +52,7 @@ async function authEnvironment(targetStatus: "ready" | "stopped" | "failed" = "r
         work_key: "target",
         agent_token_hash: await sha256("target-token"),
         status: targetStatus,
+        stopped_at: stoppedAt,
       }),
     ],
   ]);
@@ -173,6 +178,20 @@ test("agent event endpoint retains exact-token authentication after terminal wor
     assert.deepEqual(subject.credentialReads, ["IS-target"]);
     assert.equal(subject.mutationCount(), 0);
   }
+});
+
+test("agent event endpoint rejects terminal credentials after the retry window", async () => {
+  const subject = await authEnvironment("stopped", Date.now() - terminalAgentEventGraceMs - 60_000);
+  const application = new GitHubActionsApplication(subject.env, {
+    audit: async () => undefined,
+  });
+
+  await assert.rejects(
+    application.appendStructuredEvent(eventRequest("IS-target", "target-token"), "IS-target"),
+    hasStatus(403),
+  );
+  assert.deepEqual(subject.credentialReads, ["IS-target"]);
+  assert.equal(subject.mutationCount(), 0);
 });
 
 test("authenticated event ingress rejects oversized chunked bodies before persistence", async () => {

--- a/tests/github-actions-event-auth.test.ts
+++ b/tests/github-actions-event-auth.test.ts
@@ -29,7 +29,7 @@ function eventRequest(sessionId: string, token: string): Request {
   });
 }
 
-async function authEnvironment() {
+async function authEnvironment(targetStatus: "ready" | "stopped" | "failed" = "ready") {
   const rows = new Map([
     [
       "IS-source",
@@ -47,6 +47,7 @@ async function authEnvironment() {
         runtime: "github_actions",
         work_key: "target",
         agent_token_hash: await sha256("target-token"),
+        status: targetStatus,
       }),
     ],
   ]);
@@ -148,6 +149,30 @@ test("agent event endpoint rejects a wrong-session token before persistence", as
   );
   assert.deepEqual(subject.credentialReads, ["IS-target"]);
   assert.equal(subject.mutationCount(), 0);
+});
+
+test("agent event endpoint retains exact-token authentication after terminal work state", async () => {
+  for (const status of ["stopped", "failed"] as const) {
+    const subject = await authEnvironment(status);
+    const application = new GitHubActionsApplication(subject.env, {
+      audit: async () => undefined,
+    });
+    const request = new Request(
+      "https://fleet.example/api/agent/interactive-sessions/IS-target/events",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer target-token",
+          "content-type": "application/json",
+        },
+        body: "[]",
+      },
+    );
+
+    await assert.rejects(application.appendStructuredEvent(request, "IS-target"), hasStatus(400));
+    assert.deepEqual(subject.credentialReads, ["IS-target"]);
+    assert.equal(subject.mutationCount(), 0);
+  }
 });
 
 test("authenticated event ingress rejects oversized chunked bodies before persistence", async () => {

--- a/tests/github-actions-event-auth.test.ts
+++ b/tests/github-actions-event-auth.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sha256 } from "../src/worker/crypto.ts";
+import type { RuntimeEnv } from "../src/worker/env.ts";
+import { GitHubActionsApplication } from "../src/worker/github-actions-application.ts";
+import {
+  handleServiceSessionRoute,
+  type ServiceSessionRouteDependencies,
+} from "../src/worker/routes/service-sessions.ts";
+import { sessionRow } from "./helpers/session-row.ts";
+
+function eventRequest(sessionId: string, token: string): Request {
+  return new Request(`https://fleet.example/api/agent/interactive-sessions/${sessionId}/events`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      eventKey: "run:1",
+      type: "clawsweeper.action",
+      message: "updated pull request",
+      payload: { version: 1, number: 42 },
+    }),
+  });
+}
+
+async function authEnvironment() {
+  const rows = new Map([
+    [
+      "IS-source",
+      sessionRow({
+        id: "IS-source",
+        runtime: "github_actions",
+        work_key: "source",
+        agent_token_hash: await sha256("source-token"),
+      }),
+    ],
+    [
+      "IS-target",
+      sessionRow({
+        id: "IS-target",
+        runtime: "github_actions",
+        work_key: "target",
+        agent_token_hash: await sha256("target-token"),
+      }),
+    ],
+  ]);
+  const credentialReads: string[] = [];
+  let mutations = 0;
+  const env = {
+    DB: {
+      prepare(sql: string) {
+        return {
+          bind(...parameters: unknown[]) {
+            return {
+              async all() {
+                if (!/from "interactive_sessions"/i.test(sql)) {
+                  mutations += 1;
+                  throw new Error(`unexpected query: ${sql}`);
+                }
+                const id = parameters.find(
+                  (parameter): parameter is string =>
+                    typeof parameter === "string" && rows.has(parameter),
+                );
+                if (!id) throw new Error("credential lookup did not bind a session id");
+                credentialReads.push(id);
+                return { results: [rows.get(id)], meta: { changes: 0 } };
+              },
+              async run() {
+                mutations += 1;
+                throw new Error(`unexpected mutation: ${sql}`);
+              },
+            };
+          },
+        };
+      },
+      async batch() {
+        mutations += 1;
+        throw new Error("unexpected event persistence");
+      },
+    } as unknown as D1Database,
+  } as RuntimeEnv;
+  return { env, credentialReads, mutationCount: () => mutations };
+}
+
+function hasStatus(expected: number) {
+  return (error: unknown) => {
+    assert.equal(
+      typeof error === "object" && error && "status" in error ? error.status : undefined,
+      expected,
+    );
+    return true;
+  };
+}
+
+function routeDependencies(application: GitHubActionsApplication): ServiceSessionRouteDependencies {
+  const unused = async (): Promise<never> => {
+    throw new Error("unexpected route dependency");
+  };
+  return {
+    sshAuth: unused,
+    sshState: unused,
+    agentState: unused,
+    createSshSession: unused,
+    createAgentSession: unused,
+    updateAgentWorkState: unused,
+    appendAgentEvent: (request, sessionId) => application.appendStructuredEvent(request, sessionId),
+    openAgentRunnerPty: unused,
+    requireSshViewer: unused,
+    requireAgentUser: unused,
+    readFreshSession: unused,
+    presentSession: unused,
+    mutateSession: unused,
+    listCheckpoints: unused,
+    createCheckpoint: unused,
+    restoreCheckpoint: unused,
+    readLogs: unused,
+    readTranscript: unused,
+    updateSummary: unused,
+  };
+}
+
+test("GitHub Actions application rejects an event token issued to another session", async () => {
+  const subject = await authEnvironment();
+  const application = new GitHubActionsApplication(subject.env, { audit: async () => undefined });
+
+  await assert.rejects(
+    application.appendStructuredEvent(eventRequest("IS-target", "source-token"), "IS-target"),
+    hasStatus(401),
+  );
+  assert.deepEqual(subject.credentialReads, ["IS-target"]);
+  assert.equal(subject.mutationCount(), 0);
+});
+
+test("agent event endpoint rejects a wrong-session token before persistence", async () => {
+  const subject = await authEnvironment();
+  const application = new GitHubActionsApplication(subject.env, { audit: async () => undefined });
+  const request = eventRequest("IS-target", "source-token");
+
+  await assert.rejects(
+    handleServiceSessionRoute(request, new URL(request.url), routeDependencies(application)),
+    hasStatus(401),
+  );
+  assert.deepEqual(subject.credentialReads, ["IS-target"]);
+  assert.equal(subject.mutationCount(), 0);
+});

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -11,6 +11,7 @@ import {
   forbidden,
   json,
   notFound,
+  readBoundedJson,
   readJson,
   redirect,
   serviceUnavailable,
@@ -78,6 +79,37 @@ test("JSON parsing and status errors retain stable messages and status codes", a
   ] as const) {
     assert.equal(error.status, status);
     assert.equal(error.message, message);
+  }
+});
+
+test("bounded JSON parsing rejects declared and streamed bodies before unbounded parsing", async () => {
+  const limit = 16;
+  assert.deepEqual(
+    await readBoundedJson<{ value: number }>(
+      new Request("https://fleet.example", { method: "POST", body: '{"value":42}' }),
+      limit,
+    ),
+    { value: 42 },
+  );
+
+  for (const request of [
+    new Request("https://fleet.example", {
+      method: "POST",
+      headers: { "content-length": "17" },
+      body: "{}",
+    }),
+    new Request("https://fleet.example", {
+      method: "POST",
+      body: JSON.stringify({ value: "oversized" }),
+    }),
+  ]) {
+    await assert.rejects(readBoundedJson(request, limit), (error: unknown) => {
+      assert.equal(
+        typeof error === "object" && error && "status" in error ? error.status : undefined,
+        413,
+      );
+      return true;
+    });
   }
 });
 

--- a/tests/interactive-session-action-event-migration.test.ts
+++ b/tests/interactive-session-action-event-migration.test.ts
@@ -3,6 +3,11 @@ import { readFileSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 
+import {
+  structuredEventLedgerMaxBytes,
+  structuredEventLedgerMaxCount,
+} from "../src/worker/session-events.ts";
+
 test("action event migration preserves messages and keys structured events per session", () => {
   const database = new DatabaseSync(":memory:");
   database.exec(`
@@ -51,4 +56,46 @@ test("action event migration preserves messages and keys structured events per s
       ('IS-1', 'agent', 'unkeyed one', 3),
       ('IS-1', 'agent', 'unkeyed two', 4);
   `);
+
+  const budgetInsert = database.prepare(`
+    INSERT INTO interactive_session_events
+      (session_id, actor, event_key, event_type, message, payload_json, created_at)
+    VALUES (?, 'agent', ?, 'clawsweeper.action', 'm', '{"version":1}', 5)
+  `);
+  database.exec("BEGIN");
+  for (let index = 0; index < structuredEventLedgerMaxCount; index += 1) {
+    budgetInsert.run("IS-count-budget", `event:${index}`);
+  }
+  database.exec("COMMIT");
+  assert.throws(
+    () => budgetInsert.run("IS-count-budget", "event:overflow"),
+    /structured session event budget exceeded/i,
+  );
+  database
+    .prepare(`
+      INSERT OR IGNORE INTO interactive_session_events
+        (session_id, actor, event_key, event_type, message, payload_json, created_at)
+      VALUES ('IS-count-budget', 'agent', 'event:0', 'clawsweeper.action', 'replay', '{"version":2}', 6)
+    `)
+    .run();
+
+  const byteFiller = "x".repeat(structuredEventLedgerMaxBytes - 1024);
+  database
+    .prepare(`
+      INSERT INTO interactive_session_events
+        (session_id, actor, event_key, event_type, message, payload_json, created_at)
+      VALUES ('IS-byte-budget', 'agent', 'filler', 'clawsweeper.action', 'm', ?, 7)
+    `)
+    .run(byteFiller);
+  assert.throws(
+    () =>
+      database
+        .prepare(`
+          INSERT INTO interactive_session_events
+            (session_id, actor, event_key, event_type, message, payload_json, created_at)
+          VALUES ('IS-byte-budget', 'agent', 'overflow', 'clawsweeper.action', 'm', ?, 8)
+        `)
+        .run("x".repeat(2048)),
+    /structured session event budget exceeded/i,
+  );
 });

--- a/tests/interactive-session-action-event-migration.test.ts
+++ b/tests/interactive-session-action-event-migration.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+
+test("action event migration preserves messages and keys structured events per session", () => {
+  const database = new DatabaseSync(":memory:");
+  database.exec(`
+    CREATE TABLE interactive_session_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      actor TEXT NOT NULL,
+      message TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+    INSERT INTO interactive_session_events (session_id, actor, message, created_at)
+    VALUES ('IS-1', 'operator', 'legacy message', 1);
+  `);
+  database.exec(
+    readFileSync(
+      new URL("../migrations/0032_interactive_session_action_events.sql", import.meta.url),
+      "utf8",
+    ),
+  );
+
+  assert.deepEqual(
+    {
+      ...database
+        .prepare(
+          "SELECT event_key, event_type, payload_json FROM interactive_session_events WHERE id = 1",
+        )
+        .get(),
+    },
+    { event_key: null, event_type: "message", payload_json: null },
+  );
+
+  const insert = database.prepare(`
+    INSERT INTO interactive_session_events
+      (session_id, actor, event_key, event_type, message, payload_json, created_at)
+    VALUES (?, 'agent', ?, 'clawsweeper.action', 'updated pull request', '{"version":1}', 2)
+  `);
+  insert.run("IS-1", "run:1");
+  insert.run("IS-2", "run:1");
+  assert.throws(() => insert.run("IS-1", "run:1"), /unique constraint/i);
+
+  insert.run("IS-1", "");
+  insert.run("IS-1", "");
+  database.exec(`
+    INSERT INTO interactive_session_events (session_id, actor, message, created_at)
+    VALUES
+      ('IS-1', 'agent', 'unkeyed one', 3),
+      ('IS-1', 'agent', 'unkeyed two', 4);
+  `);
+});

--- a/tests/interactive-session-action-event-migration.test.ts
+++ b/tests/interactive-session-action-event-migration.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 
@@ -7,6 +7,32 @@ import {
   structuredEventLedgerMaxBytes,
   structuredEventLedgerMaxCount,
 } from "../src/worker/session-events.ts";
+
+test("fresh migration chain creates the structured action event schema", () => {
+  const database = new DatabaseSync(":memory:");
+  const migrations = readdirSync(new URL("../migrations/", import.meta.url))
+    .filter((name) => name.endsWith(".sql"))
+    .sort();
+  for (const migration of migrations) {
+    database.exec(readFileSync(new URL(`../migrations/${migration}`, import.meta.url), "utf8"));
+  }
+
+  const columns = database
+    .prepare("PRAGMA table_info(interactive_session_events)")
+    .all()
+    .map((column) => String(column.name));
+  assert.ok(columns.includes("event_key"));
+  assert.ok(columns.includes("event_type"));
+  assert.ok(columns.includes("payload_json"));
+  assert.equal(
+    database
+      .prepare(
+        "SELECT count(*) AS count FROM sqlite_master WHERE type = 'trigger' AND name = 'enforce_interactive_session_action_event_budget'",
+      )
+      .get()?.count,
+    1,
+  );
+});
 
 test("action event migration preserves messages and keys structured events per session", () => {
   const database = new DatabaseSync(":memory:");

--- a/tests/service-session-routes.test.ts
+++ b/tests/service-session-routes.test.ts
@@ -56,6 +56,10 @@ function dependencies(calls: string[]): ServiceSessionRouteDependencies {
       calls.push(`work-state:${sessionId}`);
       return { handler: "work-state" };
     },
+    async appendAgentEvent(_request: Request, sessionId: string) {
+      calls.push(`event:${sessionId}`);
+      return { handler: "event" };
+    },
     async openAgentRunnerPty(_request: Request, sessionId: string) {
       calls.push(`runner-pty:${sessionId}`);
       return response("runner-pty");
@@ -130,6 +134,16 @@ test("service-session routes dispatch collection and agent-specialized endpoints
       request("POST", "/api/agent/interactive-sessions/IS%2F2/work-state", {}),
       200,
       ["work-state:IS/2"],
+    ],
+    [
+      request("POST", "/api/agent/interactive-sessions/IS%2F2/events", {
+        eventKey: "run:1",
+        type: "clawsweeper.action",
+        message: "updated pull request",
+        payload: { version: 1 },
+      }),
+      200,
+      ["event:IS/2"],
     ],
   ];
 
@@ -235,6 +249,18 @@ test("service-session routes keep actions and checkpoints SSH-only", async () =>
   assert.equal(
     await dispatch(
       request("POST", "/api/agent/interactive-sessions/IS-2/actions", { action: "stop" }),
+      calls,
+    ),
+    null,
+  );
+  assert.equal(
+    await dispatch(
+      request("POST", "/api/ssh/interactive-sessions/IS-2/events", {
+        eventKey: "run:1",
+        type: "clawsweeper.action",
+        message: "updated pull request",
+        payload: { version: 1 },
+      }),
       calls,
     ),
     null,

--- a/tests/session-agent-auth.test.ts
+++ b/tests/session-agent-auth.test.ts
@@ -7,11 +7,15 @@ import {
   AgentSessionAuthenticator,
   agentSessionId,
   agentSessionToken,
+  terminalAgentEventGraceMs,
 } from "../src/worker/session-agent-auth.ts";
 import { interactiveSession } from "../src/worker/session-model.ts";
 import { sessionRow } from "./helpers/session-row.ts";
 
-function authenticator(values: Parameters<typeof sessionRow>[0] = {}): AgentSessionAuthenticator {
+function authenticator(
+  values: Parameters<typeof sessionRow>[0] = {},
+  now: () => number = () => 10_000,
+): AgentSessionAuthenticator {
   const session = interactiveSession(
     sessionRow({
       id: "IS-agent",
@@ -21,11 +25,14 @@ function authenticator(values: Parameters<typeof sessionRow>[0] = {}): AgentSess
     }),
     [],
   );
-  return new AgentSessionAuthenticator({
-    readCredential: async (id) =>
-      id === session.id ? { session, tokenHash: "agent-token-hash" } : null,
-    hashToken: async (token) => (token === "agent-token" ? "agent-token-hash" : sha256(token)),
-  });
+  return new AgentSessionAuthenticator(
+    {
+      readCredential: async (id) =>
+        id === session.id ? { session, tokenHash: "agent-token-hash" } : null,
+      hashToken: async (token) => (token === "agent-token" ? "agent-token-hash" : sha256(token)),
+    },
+    now,
+  );
 }
 
 test("agent session credentials use the canonical Crabfleet protocol", () => {
@@ -148,27 +155,43 @@ test("agent authentication rejects missing, invalid, and inactive credentials", 
   });
 });
 
-test("terminal event authentication permits only stopped and failed sessions", async () => {
+test("terminal event authentication is limited to the stopped-at retry window", async () => {
   const request = new Request("https://fleet.example/api/agent/state", {
     headers: {
       authorization: "Bearer agent-token",
       "x-crabfleet-session-id": "IS-agent",
     },
   });
+  const now = 1_000_000;
 
   for (const status of ["stopped", "failed"] as const) {
     await assert.doesNotReject(() =>
-      authenticator({ status }).require(request, "IS-agent", {
-        allowTerminalEvent: true,
-      }),
+      authenticator({ status, stopped_at: now - terminalAgentEventGraceMs }, () => now).require(
+        request,
+        "IS-agent",
+        {
+          allowTerminalEvent: true,
+        },
+      ),
     );
   }
   for (const status of ["stopping", "expired"] as const) {
     await assert.rejects(
       () =>
-        authenticator({ status }).require(request, "IS-agent", {
+        authenticator({ status, stopped_at: now }, () => now).require(request, "IS-agent", {
           allowTerminalEvent: true,
         }),
+      { message: "agent session is not active" },
+    );
+  }
+  for (const stoppedAt of [null, now + 1, now - terminalAgentEventGraceMs - 1]) {
+    await assert.rejects(
+      () =>
+        authenticator({ status: "stopped", stopped_at: stoppedAt }, () => now).require(
+          request,
+          "IS-agent",
+          { allowTerminalEvent: true },
+        ),
       { message: "agent session is not active" },
     );
   }

--- a/tests/session-agent-auth.test.ts
+++ b/tests/session-agent-auth.test.ts
@@ -147,3 +147,29 @@ test("agent authentication rejects missing, invalid, and inactive credentials", 
     message: "agent session is not active",
   });
 });
+
+test("terminal event authentication permits only stopped and failed sessions", async () => {
+  const request = new Request("https://fleet.example/api/agent/state", {
+    headers: {
+      authorization: "Bearer agent-token",
+      "x-crabfleet-session-id": "IS-agent",
+    },
+  });
+
+  for (const status of ["stopped", "failed"] as const) {
+    await assert.doesNotReject(() =>
+      authenticator({ status }).require(request, "IS-agent", {
+        allowTerminalEvent: true,
+      }),
+    );
+  }
+  for (const status of ["stopping", "expired"] as const) {
+    await assert.rejects(
+      () =>
+        authenticator({ status }).require(request, "IS-agent", {
+          allowTerminalEvent: true,
+        }),
+      { message: "agent session is not active" },
+    );
+  }
+});

--- a/tests/session-event-ledger-persistence.test.ts
+++ b/tests/session-event-ledger-persistence.test.ts
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+
+import { appendStructuredInteractiveSessionEventRecord } from "../src/worker/session-events.ts";
+import type { RuntimeEnv } from "../src/worker/env.ts";
+
+type SqliteStatement = {
+  all(...parameters: unknown[]): Record<string, unknown>[];
+  run(...parameters: unknown[]): { changes: number | bigint; lastInsertRowid: number | bigint };
+};
+
+type BoundStatement = {
+  execute(): {
+    results: Record<string, unknown>[];
+    success: true;
+    meta: { changes: number; last_row_id?: number };
+  };
+};
+
+function eventDatabase(): DatabaseSync {
+  const database = new DatabaseSync(":memory:");
+  database.exec(`
+    CREATE TABLE interactive_sessions (
+      id TEXT PRIMARY KEY,
+      status TEXT NOT NULL,
+      terminal_finalize_pending INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE interactive_session_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      actor TEXT NOT NULL,
+      message TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      event_key TEXT,
+      event_type TEXT NOT NULL DEFAULT 'message',
+      payload_json TEXT
+    );
+    CREATE UNIQUE INDEX idx_interactive_session_events_session_event_key
+      ON interactive_session_events(session_id, event_key)
+      WHERE event_key IS NOT NULL AND event_key <> '';
+    INSERT INTO interactive_sessions (id, status) VALUES ('IS-1', 'stopped');
+  `);
+  return database;
+}
+
+function runtimeEnv(
+  database: DatabaseSync,
+  options: { interruptAfterStatement?: number } = {},
+): RuntimeEnv {
+  function execute(sql: string, parameters: unknown[]) {
+    const statement = database.prepare(sql) as unknown as SqliteStatement;
+    if (/^\s*(?:select|pragma|with)\b|\breturning\b/i.test(sql)) {
+      const results = statement.all(...parameters).map((row) => ({ ...row }));
+      const changes = Number(database.prepare("SELECT changes() AS changes").get()?.changes ?? 0);
+      return { results, success: true as const, meta: { changes } };
+    }
+    const result = statement.run(...parameters);
+    return {
+      results: [],
+      success: true as const,
+      meta: {
+        changes: Number(result.changes),
+        last_row_id: Number(result.lastInsertRowid),
+      },
+    };
+  }
+
+  return {
+    DB: {
+      prepare(sql: string) {
+        return {
+          bind(...parameters: unknown[]) {
+            const bound: BoundStatement = {
+              execute: () => execute(sql, parameters),
+            };
+            return {
+              ...bound,
+              async all() {
+                return bound.execute();
+              },
+              async run() {
+                return bound.execute();
+              },
+            };
+          },
+        };
+      },
+      async batch(statements: D1PreparedStatement[]) {
+        database.exec("BEGIN IMMEDIATE");
+        try {
+          const results = [];
+          for (const [index, statement] of statements.entries()) {
+            results.push((statement as unknown as BoundStatement).execute());
+            if (options.interruptAfterStatement === index + 1) {
+              throw new Error("simulated batch interruption");
+            }
+          }
+          database.exec("COMMIT");
+          return results;
+        } catch (error) {
+          database.exec("ROLLBACK");
+          throw error;
+        }
+      },
+    } as unknown as D1Database,
+  } as RuntimeEnv;
+}
+
+function eventInput(message = "updated pull request", now = 123) {
+  return {
+    sessionId: "IS-1",
+    actor: "operator",
+    eventKey: "run:1",
+    type: "clawsweeper.action",
+    message,
+    payload: { version: 1, number: 42 },
+    now,
+  };
+}
+
+test("structured event batch interruption rolls back insert and terminal invalidation", async () => {
+  const database = eventDatabase();
+  let archived = false;
+  await assert.rejects(
+    appendStructuredInteractiveSessionEventRecord(
+      runtimeEnv(database, { interruptAfterStatement: 1 }),
+      eventInput(),
+      async () => {
+        archived = true;
+      },
+    ),
+    /simulated batch interruption/,
+  );
+
+  assert.equal(
+    database.prepare("SELECT count(*) AS count FROM interactive_session_events").get()?.count,
+    0,
+  );
+  assert.equal(
+    database
+      .prepare("SELECT terminal_finalize_pending FROM interactive_sessions WHERE id = 'IS-1'")
+      .get()?.terminal_finalize_pending,
+    0,
+  );
+  assert.equal(archived, false);
+});
+
+test("structured event races deduplicate and invalidate only exact replays", async () => {
+  const database = eventDatabase();
+  const env = runtimeEnv(database);
+  const append = (input: ReturnType<typeof eventInput>) =>
+    appendStructuredInteractiveSessionEventRecord(env, input, async () => undefined);
+  const results = await Promise.all([
+    append(eventInput("updated pull request", 100)),
+    append(eventInput("updated pull request", 200)),
+  ]);
+
+  assert.deepEqual(results.map((result) => result.duplicate).sort(), [false, true]);
+  assert.equal(
+    database.prepare("SELECT count(*) AS count FROM interactive_session_events").get()?.count,
+    1,
+  );
+  assert.equal(
+    database
+      .prepare("SELECT terminal_finalize_pending FROM interactive_sessions WHERE id = 'IS-1'")
+      .get()?.terminal_finalize_pending,
+    1,
+  );
+
+  database.exec("UPDATE interactive_sessions SET terminal_finalize_pending = 0 WHERE id = 'IS-1'");
+  const replay = await append(eventInput("updated pull request", 300));
+  assert.equal(replay.duplicate, true);
+  assert.equal(
+    database
+      .prepare("SELECT terminal_finalize_pending FROM interactive_sessions WHERE id = 'IS-1'")
+      .get()?.terminal_finalize_pending,
+    1,
+  );
+
+  database.exec("UPDATE interactive_sessions SET terminal_finalize_pending = 0 WHERE id = 'IS-1'");
+  await assert.rejects(append(eventInput("changed content", 400)), (error) => {
+    assert.equal(
+      typeof error === "object" && error && "status" in error ? error.status : undefined,
+      409,
+    );
+    return true;
+  });
+  assert.equal(
+    database
+      .prepare("SELECT terminal_finalize_pending FROM interactive_sessions WHERE id = 'IS-1'")
+      .get()?.terminal_finalize_pending,
+    0,
+  );
+});

--- a/tests/session-events.test.ts
+++ b/tests/session-events.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { RuntimeEnv } from "../src/worker/env.ts";
-import { appendInteractiveSessionEventRecord } from "../src/worker/session-events.ts";
+import {
+  appendInteractiveSessionEventRecord,
+  InteractiveSessionEventLedgerService,
+  type InteractiveSessionEventLedgerStore,
+} from "../src/worker/session-events.ts";
+import type { InteractiveSessionEventRow } from "../src/worker/session-model.ts";
 
 type PreparedStatement = {
   sql: string;
@@ -79,4 +84,170 @@ test("session event archive refresh remains best effort after durable persistenc
   );
 
   assert.equal(persisted, true);
+});
+
+test("structured session events canonicalize additive payloads and replay idempotently", async () => {
+  let row: InteractiveSessionEventRow | undefined;
+  const persistedPayloads: string[] = [];
+  const invalidations: string[] = [];
+  const archives: string[] = [];
+  const store: InteractiveSessionEventLedgerStore = {
+    async persist(event) {
+      persistedPayloads.push(event.payloadJson);
+      if (!row) {
+        row = {
+          id: 1,
+          session_id: event.sessionId,
+          actor: event.actor,
+          event_key: event.eventKey,
+          event_type: event.type,
+          message: event.message,
+          payload_json: event.payloadJson,
+          created_at: event.now,
+        };
+        return { row, inserted: true };
+      }
+      return { row, inserted: false };
+    },
+    async invalidateTerminalFinalization(sessionId) {
+      invalidations.push(sessionId);
+    },
+    async archive(sessionId) {
+      archives.push(sessionId);
+    },
+  };
+  const service = new InteractiveSessionEventLedgerService(store);
+  const first = await service.append({
+    sessionId: "IS-1",
+    actor: "operator",
+    eventKey: " run:1 ",
+    type: " clawsweeper.action ",
+    message: " updated pull request ",
+    payload: {
+      version: 2,
+      target: { z: true, a: 1 },
+      additiveField: ["kept"],
+    },
+    now: 123,
+  });
+  const replay = await service.append({
+    sessionId: "IS-1",
+    actor: "operator",
+    eventKey: "run:1",
+    type: "clawsweeper.action",
+    message: "updated pull request",
+    payload: {
+      additiveField: ["kept"],
+      target: { a: 1, z: true },
+      version: 2,
+    },
+    now: 456,
+  });
+
+  assert.equal(first.duplicate, false);
+  assert.equal(replay.duplicate, true);
+  assert.deepEqual(replay.event, {
+    actor: "operator",
+    eventKey: "run:1",
+    type: "clawsweeper.action",
+    message: "updated pull request",
+    payload: {
+      additiveField: ["kept"],
+      target: { a: 1, z: true },
+      version: 2,
+    },
+    createdAt: 123,
+  });
+  assert.deepEqual(persistedPayloads, [
+    '{"additiveField":["kept"],"target":{"a":1,"z":true},"version":2}',
+    '{"additiveField":["kept"],"target":{"a":1,"z":true},"version":2}',
+  ]);
+  assert.deepEqual(invalidations, ["IS-1", "IS-1"]);
+  assert.deepEqual(archives, ["IS-1", "IS-1"]);
+});
+
+test("structured session event key conflicts reject changed content before side effects", async () => {
+  const existing: InteractiveSessionEventRow = {
+    id: 1,
+    session_id: "IS-1",
+    actor: "operator",
+    event_key: "run:1",
+    event_type: "clawsweeper.action",
+    message: "original",
+    payload_json: '{"version":1}',
+    created_at: 123,
+  };
+  let invalidated = false;
+  let archived = false;
+  const service = new InteractiveSessionEventLedgerService({
+    async persist() {
+      return { row: existing, inserted: false };
+    },
+    async invalidateTerminalFinalization() {
+      invalidated = true;
+    },
+    async archive() {
+      archived = true;
+    },
+  });
+
+  await assert.rejects(
+    service.append({
+      sessionId: "IS-1",
+      actor: "operator",
+      eventKey: "run:1",
+      type: "clawsweeper.action",
+      message: "changed",
+      payload: { version: 1 },
+      now: 456,
+    }),
+    (error) => {
+      assert.equal(
+        typeof error === "object" && error && "status" in error ? error.status : undefined,
+        409,
+      );
+      return true;
+    },
+  );
+  assert.equal(invalidated, false);
+  assert.equal(archived, false);
+});
+
+test("structured session events require bounded identifiers and a versioned object payload", async () => {
+  let persisted = false;
+  const service = new InteractiveSessionEventLedgerService({
+    async persist() {
+      persisted = true;
+      throw new Error("unexpected persistence");
+    },
+    async invalidateTerminalFinalization() {},
+    async archive() {},
+  });
+  const cases = [
+    { eventKey: "", type: "action", message: "message", payload: { version: 1 } },
+    { eventKey: "key", type: "", message: "message", payload: { version: 1 } },
+    { eventKey: "key", type: "action", message: "", payload: { version: 1 } },
+    { eventKey: "key", type: "action", message: "message", payload: null },
+    { eventKey: "key", type: "action", message: "message", payload: [] },
+    { eventKey: "key", type: "action", message: "message", payload: {} },
+    { eventKey: "key", type: "action", message: "message", payload: { version: 0 } },
+  ];
+  for (const input of cases) {
+    await assert.rejects(
+      service.append({
+        sessionId: "IS-1",
+        actor: "operator",
+        ...input,
+        now: 123,
+      }),
+      (error) => {
+        assert.equal(
+          typeof error === "object" && error && "status" in error ? error.status : undefined,
+          400,
+        );
+        return true;
+      },
+    );
+  }
+  assert.equal(persisted, false);
 });

--- a/tests/session-events.test.ts
+++ b/tests/session-events.test.ts
@@ -5,6 +5,10 @@ import type { RuntimeEnv } from "../src/worker/env.ts";
 import {
   appendInteractiveSessionEventRecord,
   InteractiveSessionEventLedgerService,
+  structuredEventPayloadMaxBytes,
+  structuredEventPayloadMaxDepth,
+  structuredEventPayloadMaxMembers,
+  structuredEventPayloadMaxStringBytes,
   type InteractiveSessionEventLedgerStore,
 } from "../src/worker/session-events.ts";
 import type { InteractiveSessionEventRow } from "../src/worker/session-model.ts";
@@ -244,6 +248,72 @@ test("structured session events require bounded identifiers and a versioned obje
         assert.equal(
           typeof error === "object" && error && "status" in error ? error.status : undefined,
           400,
+        );
+        return true;
+      },
+    );
+  }
+  assert.equal(persisted, false);
+});
+
+test("structured session event payload budgets fail with controlled client errors", async () => {
+  let persisted = false;
+  const service = new InteractiveSessionEventLedgerService({
+    async persist() {
+      persisted = true;
+      throw new Error("unexpected persistence");
+    },
+    async invalidateTerminalFinalization() {},
+    async archive() {},
+  });
+  let nested: Record<string, unknown> = {};
+  const deepPayload: Record<string, unknown> = { version: 1, nested };
+  for (let depth = 0; depth < structuredEventPayloadMaxDepth + 1; depth += 1) {
+    const child: Record<string, unknown> = {};
+    nested.child = child;
+    nested = child;
+  }
+  const cases: Array<{ payload: Record<string, unknown>; status: number }> = [
+    { payload: deepPayload, status: 400 },
+    {
+      payload: {
+        version: 1,
+        values: Array.from({ length: structuredEventPayloadMaxMembers }, () => null),
+      },
+      status: 400,
+    },
+    {
+      payload: {
+        version: 1,
+        value: "x".repeat(structuredEventPayloadMaxStringBytes + 1),
+      },
+      status: 400,
+    },
+    {
+      payload: {
+        version: 1,
+        values: Array.from({ length: 5 }, () =>
+          "x".repeat(Math.floor(structuredEventPayloadMaxBytes / 4)),
+        ),
+      },
+      status: 413,
+    },
+  ];
+  for (const { payload, status } of cases) {
+    await assert.rejects(
+      service.append({
+        sessionId: "IS-1",
+        actor: "operator",
+        eventKey: "run:1",
+        type: "clawsweeper.action",
+        message: "updated pull request",
+        payload,
+        now: 123,
+      }),
+      (error) => {
+        assert.equal(
+          typeof error === "object" && error && "status" in error ? error.status : undefined,
+          status,
         );
         return true;
       },

--- a/tests/session-events.test.ts
+++ b/tests/session-events.test.ts
@@ -4,7 +4,10 @@ import test from "node:test";
 import type { RuntimeEnv } from "../src/worker/env.ts";
 import {
   appendInteractiveSessionEventRecord,
+  appendStructuredInteractiveSessionEventRecord,
   InteractiveSessionEventLedgerService,
+  structuredEventLedgerMaxBytes,
+  structuredEventLedgerMaxCount,
   structuredEventPayloadMaxBytes,
   structuredEventPayloadMaxDepth,
   structuredEventPayloadMaxMembers,
@@ -311,4 +314,52 @@ test("structured session event payload budgets fail with controlled client error
     );
   }
   assert.equal(persisted, false);
+});
+
+test("structured session aggregate budget failures return a controlled client error", async () => {
+  let archived = false;
+  const env = {
+    DB: {
+      prepare(sql: string) {
+        return {
+          bind(...parameters: unknown[]) {
+            return { sql, parameters };
+          },
+        };
+      },
+      async batch() {
+        throw new Error("D1_ERROR: structured session event budget exceeded");
+      },
+    } as unknown as D1Database,
+  } as RuntimeEnv;
+
+  await assert.rejects(
+    appendStructuredInteractiveSessionEventRecord(
+      env,
+      {
+        sessionId: "IS-1",
+        actor: "agent",
+        eventKey: "run:1",
+        type: "clawsweeper.action",
+        message: "updated pull request",
+        payload: { version: 1 },
+        now: 123,
+      },
+      async () => {
+        archived = true;
+      },
+    ),
+    (error) => {
+      assert.equal(
+        typeof error === "object" && error && "status" in error ? error.status : undefined,
+        413,
+      );
+      assert.match(
+        error instanceof Error ? error.message : "",
+        new RegExp(`${structuredEventLedgerMaxCount} events.*${structuredEventLedgerMaxBytes}`),
+      );
+      return true;
+    },
+  );
+  assert.equal(archived, false);
 });

--- a/tests/session-events.test.ts
+++ b/tests/session-events.test.ts
@@ -96,8 +96,9 @@ test("structured session events canonicalize additive payloads and replay idempo
   const invalidations: string[] = [];
   const archives: string[] = [];
   const store: InteractiveSessionEventLedgerStore = {
-    async persist(event) {
+    async persistAndInvalidate(event) {
       persistedPayloads.push(event.payloadJson);
+      invalidations.push(event.sessionId);
       if (!row) {
         row = {
           id: 1,
@@ -112,9 +113,6 @@ test("structured session events canonicalize additive payloads and replay idempo
         return { row, inserted: true };
       }
       return { row, inserted: false };
-    },
-    async invalidateTerminalFinalization(sessionId) {
-      invalidations.push(sessionId);
     },
     async archive(sessionId) {
       archives.push(sessionId);
@@ -181,14 +179,10 @@ test("structured session event key conflicts reject changed content before side 
     payload_json: '{"version":1}',
     created_at: 123,
   };
-  let invalidated = false;
   let archived = false;
   const service = new InteractiveSessionEventLedgerService({
-    async persist() {
+    async persistAndInvalidate() {
       return { row: existing, inserted: false };
-    },
-    async invalidateTerminalFinalization() {
-      invalidated = true;
     },
     async archive() {
       archived = true;
@@ -213,18 +207,16 @@ test("structured session event key conflicts reject changed content before side 
       return true;
     },
   );
-  assert.equal(invalidated, false);
   assert.equal(archived, false);
 });
 
 test("structured session events require bounded identifiers and a versioned object payload", async () => {
   let persisted = false;
   const service = new InteractiveSessionEventLedgerService({
-    async persist() {
+    async persistAndInvalidate() {
       persisted = true;
       throw new Error("unexpected persistence");
     },
-    async invalidateTerminalFinalization() {},
     async archive() {},
   });
   const cases = [
@@ -259,11 +251,10 @@ test("structured session events require bounded identifiers and a versioned obje
 test("structured session event payload budgets fail with controlled client errors", async () => {
   let persisted = false;
   const service = new InteractiveSessionEventLedgerService({
-    async persist() {
+    async persistAndInvalidate() {
       persisted = true;
       throw new Error("unexpected persistence");
     },
-    async invalidateTerminalFinalization() {},
     async archive() {},
   });
   let nested: Record<string, unknown> = {};

--- a/tests/session-log-archive.test.ts
+++ b/tests/session-log-archive.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   sessionLogArchiveBase,
+  sessionLogEventsNdjson,
   sessionLogSummary,
   sessionLogTranscript,
   shouldArchiveInteractiveSessionLogs,
@@ -52,7 +53,10 @@ test("transcripts render row metadata and ordered events", () => {
         id: 1,
         session_id: "IS-1",
         actor: "operator",
+        event_key: null,
+        event_type: "message",
         message: "started",
+        payload_json: null,
         created_at: 0,
       },
     ],
@@ -77,8 +81,26 @@ test("transcripts accept domain sessions and summaries keep event anchors", () =
   assert.match(sessionLogTranscript(session, []), /root: IS-1/);
 
   const summary = sessionLogSummary(row, [
-    { id: 1, session_id: "IS-1", actor: "a", message: "first", created_at: 10 },
-    { id: 2, session_id: "IS-1", actor: "b", message: "last", created_at: 20 },
+    {
+      id: 1,
+      session_id: "IS-1",
+      actor: "a",
+      event_key: null,
+      event_type: "message",
+      message: "first",
+      payload_json: null,
+      created_at: 10,
+    },
+    {
+      id: 2,
+      session_id: "IS-1",
+      actor: "b",
+      event_key: "run:2",
+      event_type: "clawsweeper.action",
+      message: "last",
+      payload_json: '{"version":1}',
+      created_at: 20,
+    },
   ]);
   assert.equal(summary.workState, "completed");
   assert.equal(summary.eventCount, 2);
@@ -86,4 +108,53 @@ test("transcripts accept domain sessions and summaries keep event anchors", () =
   assert.equal(summary.lastEventAt, 20);
   assert.equal(summary.lastEvent, "last");
   assert.equal(summary.updatedAt, 120);
+});
+
+test("event archives expose structured fields while preserving legacy messages", () => {
+  const ndjson = sessionLogEventsNdjson([
+    {
+      id: 1,
+      session_id: "IS-1",
+      actor: "system",
+      event_key: null,
+      event_type: "message",
+      message: "registered",
+      payload_json: null,
+      created_at: 10,
+    },
+    {
+      id: 2,
+      session_id: "IS-1",
+      actor: "operator",
+      event_key: "run:2",
+      event_type: "clawsweeper.action",
+      message: "updated pull request",
+      payload_json: '{"action":"update","version":1}',
+      created_at: 20,
+    },
+  ]);
+  assert.deepEqual(
+    ndjson
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line)),
+    [
+      {
+        actor: "system",
+        eventKey: null,
+        type: "message",
+        message: "registered",
+        payload: null,
+        createdAt: 10,
+      },
+      {
+        actor: "operator",
+        eventKey: "run:2",
+        type: "clawsweeper.action",
+        message: "updated pull request",
+        payload: { action: "update", version: 1 },
+        createdAt: 20,
+      },
+    ],
+  );
 });

--- a/tests/session-model.test.ts
+++ b/tests/session-model.test.ts
@@ -77,10 +77,20 @@ test("event and archive rows map to public session records", () => {
       id: 1,
       session_id: "IS-42",
       actor: "owner",
+      event_key: "run:42",
+      event_type: "clawsweeper.action",
       message: "ready",
+      payload_json: '{"details":{"count":2},"version":1}',
       created_at: 10,
     }),
-    { actor: "owner", message: "ready", createdAt: 10 },
+    {
+      actor: "owner",
+      eventKey: "run:42",
+      type: "clawsweeper.action",
+      message: "ready",
+      payload: { details: { count: 2 }, version: 1 },
+      createdAt: 10,
+    },
   );
 
   const row: InteractiveSessionLogArchiveTable = {


### PR DESCRIPTION
## Summary

- add authenticated, session-bound structured action-event ingestion
- persist idempotent bounded events in D1 and expose them through session logs/R2 archives
- document the API and migration contract for ClawSweeper review, apply, and repair telemetry

## Validation

- full test suite: 743 passed
- changed checks passed
- local ClawSweeper range review found no correctness or security findings

## Risk

This adds an additive D1 migration. The branch includes migration, persistence, authentication, replay/conflict, and archive tests; GitHub checks remain the final hosted validation gate.