### PR TITLE
fix(vnc): reject native-VNC grants for sessions that are not live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reject native-VNC grant issuance unless the session remains live and controllable before and after minting, preventing teardown races from returning stale workspace credentials, thanks @anagnorisis2peripeteia.
 - Fix the QUIC host identity leaking a new self-signed "Crabfleet QUIC" certificate into the login keychain on every launch: reuse the stored certificate by matching the stable host public key instead of a label macOS never persists, and collapse any already-accumulated duplicates back to one, restoring fast system-CA trust evaluation.
 - Extend the deck design language to the Quick Connect and desktop connection sheets: card-based fields and switches, gradient headers, pinned dark scheme, and a shared height-capped scrolling sheet container.
 - Redesign the Share This Mac sheet in the app's dark deck design language: pulsing readiness beacons with two-line status rows, custom capsule switches with icon tiles and captions, an animated segmented quality control, a live phase badge, and a restyled connect card — no behavior changes.

--- a/src/worker/native-vnc-service.ts
+++ b/src/worker/native-vnc-service.ts
@@ -1,0 +1,80 @@
+import { conflict, forbidden, notFound } from "./http.ts";
+import type { User } from "./models.ts";
+import type { AdapterNativeVNCGrant } from "../runtime-adapter.ts";
+import { interactiveSessionAdapterControlPlane, type InteractiveSession } from "./session-model.ts";
+
+// A session must be in one of these live states to mint a native-VNC grant. This mirrors the
+// browser-VNC path (InteractiveDesktopService.open), which rejects stopping/stopped/expired/failed
+// before minting and re-validates after the round trip. Without the same guard the native path
+// hands the caller usable desktop credentials for a workspace that is already being torn down.
+const NATIVE_VNC_LIVE_STATUSES = ["ready", "attached", "detached"];
+
+export interface NativeVNCServiceDependencies {
+  readSession: (user: User, sessionId: string) => Promise<InteractiveSession | null>;
+  mintGrant: (
+    profile: string,
+    controlPlane: string,
+    adapterWorkspaceId: string,
+  ) => Promise<AdapterNativeVNCGrant>;
+}
+
+/** Mints a native-VNC grant for a live runtime-adapter session, with the same pre-mint status guard
+ * and post-mint re-validation as the browser-VNC path. Injected deps keep it unit-testable. */
+export class NativeVNCService {
+  private readonly dependencies: NativeVNCServiceDependencies;
+
+  constructor(dependencies: NativeVNCServiceDependencies) {
+    this.dependencies = dependencies;
+  }
+
+  async createGrant(user: User, sessionId: string): Promise<AdapterNativeVNCGrant> {
+    const session = await this.dependencies.readSession(user, sessionId);
+    if (!session) throw notFound("session not found");
+    if (session.canControl !== true) throw forbidden("session control required");
+    const controlPlane = session[interactiveSessionAdapterControlPlane];
+    if (
+      session.runtime !== "crabbox" ||
+      session.adapter !== "runtime-v1" ||
+      session.capabilities.nativeVnc !== true ||
+      !session.adapterWorkspaceId ||
+      !controlPlane
+    ) {
+      throw conflict("native VNC is unavailable for this session");
+    }
+    // Pre-mint: never mint for a session that is not live (stopping/stopped/expired/failed/…).
+    if (!NATIVE_VNC_LIVE_STATUSES.includes(session.status)) {
+      throw conflict(`native VNC is unavailable while the session is ${session.status}`);
+    }
+    const grant = await this.dependencies.mintGrant(
+      session.profile,
+      controlPlane,
+      session.adapterWorkspaceId,
+    );
+    // Post-mint: re-read and re-validate access the way the browser-VNC sibling's hasCurrentAccess
+    // does — control authorization, native-VNC eligibility, and the workspace identity (control-plane,
+    // workspace id, provider resource, profile) plus live status — not just status. A concurrent stop,
+    // a control revocation, or a re-bind of the workspace during the mint round trip all fail closed.
+    // providerResourceId in particular is rewritten by session reconciliation (session-reconciliation.ts)
+    // while a session stays live, so pinning it is what stops a grant leaking for a workspace whose
+    // backing provider resource moved under us. The one pin the sibling's SQL has that we intentionally
+    // omit is adapter_create_pending=0: the InteractiveSession model does not surface that flag, and it
+    // is unreachable here anyway — every writer sets it only alongside a provisioning/stopping status,
+    // and reconciliation rewrites status and the flag atomically, so a live-status row can never carry it.
+    const revalidated = await this.dependencies.readSession(user, sessionId);
+    if (
+      !revalidated ||
+      revalidated.canControl !== true ||
+      revalidated.runtime !== "crabbox" ||
+      revalidated.adapter !== "runtime-v1" ||
+      revalidated.capabilities.nativeVnc !== true ||
+      revalidated[interactiveSessionAdapterControlPlane] !== controlPlane ||
+      revalidated.adapterWorkspaceId !== session.adapterWorkspaceId ||
+      revalidated.providerResourceId !== session.providerResourceId ||
+      revalidated.profile !== session.profile ||
+      !NATIVE_VNC_LIVE_STATUSES.includes(revalidated.status)
+    ) {
+      throw conflict("session authorization changed; retry");
+    }
+    return grant;
+  }
+}

--- a/src/worker/worker-application.ts
+++ b/src/worker/worker-application.ts
@@ -18,7 +18,8 @@ import type { RuntimeEnv } from "./env.ts";
 import { githubHeaders } from "./github.ts";
 import { GitHubActionsApplication } from "./github-actions-application.ts";
 import { GitHubReferenceService } from "./github-reference-service.ts";
-import { conflict, forbidden, notFound, readJson } from "./http.ts";
+import { readJson } from "./http.ts";
+import { NativeVNCService } from "./native-vnc-service.ts";
 import { InteractiveSessionApplication } from "./interactive-session-application.ts";
 import { createInteractiveDesktopService } from "./interactive-desktop-service.ts";
 import { DesktopHostRepository } from "./desktop-host-repository.ts";
@@ -41,10 +42,7 @@ import { scheduleNativeAuthPruning, scheduleRecurringCardTick } from "./schedule
 import { createSandboxSessionResourceService } from "./sandbox-session-resources.ts";
 import { ServiceRegistry } from "./service-registry.ts";
 import type { InteractiveSession } from "./session-model.ts";
-import {
-  interactiveSessionAdapterControlPlane,
-  interactiveSessionOwnerSubject,
-} from "./session-model.ts";
+import { interactiveSessionOwnerSubject } from "./session-model.ts";
 import { readInteractiveSessionShareCredential } from "./session-repository.ts";
 import { ownsInteractiveSession } from "./session-access.ts";
 import { readSandboxFleetPolicies } from "./session-control-do.ts";
@@ -204,24 +202,14 @@ export class WorkerApplication {
       requireUser: (request) => auth.authenticate(request),
       revokeToken: (request) => auth.revoke(request),
       readFleet: (user) => this.readFleetState(user, undefined, context),
-      createNativeVNCGrant: async (user, sessionId) => {
-        const session = await this.sessions.readVisibleFresh(user, sessionId);
-        if (!session) throw notFound("session not found");
-        if (session.canControl !== true) throw forbidden("session control required");
-        const controlPlane = session[interactiveSessionAdapterControlPlane];
-        if (
-          session.runtime !== "crabbox" ||
-          session.adapter !== "runtime-v1" ||
-          session.capabilities.nativeVnc !== true ||
-          !session.adapterWorkspaceId ||
-          !controlPlane
-        ) {
-          throw conflict("native VNC is unavailable for this session");
-        }
-        return await this.runtime
-          .workspaceLifecycle()
-          .createNativeVNCGrant(session.profile, controlPlane, session.adapterWorkspaceId);
-      },
+      createNativeVNCGrant: (user, sessionId) =>
+        new NativeVNCService({
+          readSession: (u, id) => this.sessions.readVisibleFresh(u, id),
+          mintGrant: (profile, controlPlane, adapterWorkspaceId) =>
+            this.runtime
+              .workspaceLifecycle()
+              .createNativeVNCGrant(profile, controlPlane, adapterWorkspaceId),
+        }).createGrant(user, sessionId),
       deployment: publicDeploymentConfig(this.env),
     };
   }

--- a/tests/native-vnc-service.test.ts
+++ b/tests/native-vnc-service.test.ts
@@ -1,0 +1,269 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import type { AdapterNativeVNCGrant } from "../src/runtime-adapter.ts";
+import type { User } from "../src/worker/models.ts";
+import { NativeVNCService } from "../src/worker/native-vnc-service.ts";
+import {
+  interactiveSession,
+  interactiveSessionAdapterControlPlane,
+  type InteractiveSession,
+} from "../src/worker/session-model.ts";
+import { sessionRow } from "./helpers/session-row.ts";
+
+const owner: User = {
+  subject: "github:1",
+  login: "owner",
+  email: null,
+  name: "Owner",
+  role: "viewer",
+  allowed: true,
+  teams: [],
+};
+
+const grant: AdapterNativeVNCGrant = {
+  brokerUrl: "wss://broker.example/native",
+  leaseId: "lease-1",
+  ticket: "ticket-1",
+  expiresAt: 1_000,
+};
+
+// A native-VNC-eligible session in a given lifecycle status. status + canControl are set explicitly
+// so the test is independent of how interactiveSession derives them.
+function nativeSession(status: string): InteractiveSession {
+  const base = interactiveSession(
+    sessionRow({
+      adapter: "runtime-v1",
+      adapter_workspace_id: "workspace-1",
+      adapter_control_plane: "cp1",
+      capabilities_json: JSON.stringify({ nativeVnc: true }),
+      created_by: owner.subject,
+      owner: owner.subject,
+      profile: "desktop",
+      runtime: "crabbox",
+    }),
+    [],
+  );
+  return { ...base, status: status as InteractiveSession["status"], canControl: true };
+}
+
+function statusCode(error: unknown): number | undefined {
+  return typeof error === "object" && error !== null && "status" in error
+    ? Number((error as { status: unknown }).status)
+    : undefined;
+}
+
+test("native VNC mints a grant for a live session", async () => {
+  const service = new NativeVNCService({
+    readSession: async () => nativeSession("ready"),
+    mintGrant: async () => grant,
+  });
+  assert.deepEqual(await service.createGrant(owner, "IS-1"), grant);
+});
+
+test("native VNC rejects a stopping session before minting", async () => {
+  const calls: string[] = [];
+  const service = new NativeVNCService({
+    readSession: async () => nativeSession("stopping"),
+    mintGrant: async () => {
+      calls.push("mint");
+      return grant;
+    },
+  });
+  await assert.rejects(
+    () => service.createGrant(owner, "IS-1"),
+    (error) => {
+      assert.equal(statusCode(error), 409);
+      return true;
+    },
+  );
+  assert.deepEqual(calls, [], "must not mint a grant for a session that is not live");
+});
+
+test("native VNC fails closed when the session begins teardown during the mint", async () => {
+  let reads = 0;
+  const service = new NativeVNCService({
+    // live at the pre-mint check, stopping by the post-mint re-validation.
+    readSession: async () => {
+      reads += 1;
+      return nativeSession(reads === 1 ? "ready" : "stopping");
+    },
+    mintGrant: async () => grant,
+  });
+  await assert.rejects(
+    () => service.createGrant(owner, "IS-1"),
+    (error) => {
+      assert.equal(statusCode(error), 409);
+      return true;
+    },
+  );
+  assert.equal(reads, 2, "re-reads the session after the mint to catch a concurrent stop");
+});
+
+test("native VNC fails closed when control is revoked during the mint", async () => {
+  let reads = 0;
+  const service = new NativeVNCService({
+    // controllable at the pre-mint check, control revoked by the post-mint re-validation.
+    readSession: async () => {
+      reads += 1;
+      return { ...nativeSession("ready"), canControl: reads === 1 };
+    },
+    mintGrant: async () => grant,
+  });
+  await assert.rejects(
+    () => service.createGrant(owner, "IS-1"),
+    (error) => {
+      assert.equal(statusCode(error), 409);
+      return true;
+    },
+  );
+  assert.equal(reads, 2, "re-checks control authorization after the mint, not just status");
+});
+
+test("native VNC fails closed when the control-plane is re-bound during the mint", async () => {
+  let reads = 0;
+  const service = new NativeVNCService({
+    // same session, but its control-plane moves during the mint round trip.
+    readSession: async () => {
+      reads += 1;
+      const session = nativeSession("ready");
+      return reads === 1 ? session : { ...session, [interactiveSessionAdapterControlPlane]: "cp2" };
+    },
+    mintGrant: async () => grant,
+  });
+  await assert.rejects(
+    () => service.createGrant(owner, "IS-1"),
+    (error) => {
+      assert.equal(statusCode(error), 409);
+      return true;
+    },
+  );
+  assert.equal(reads, 2, "re-checks the control-plane binding after the mint");
+});
+
+test("native VNC fails closed when the provider resource is re-bound during the mint", async () => {
+  let reads = 0;
+  const service = new NativeVNCService({
+    // session reconciliation can rewrite providerResourceId while the session stays live.
+    readSession: async () => {
+      reads += 1;
+      return { ...nativeSession("ready"), providerResourceId: reads === 1 ? "p1" : "p2" };
+    },
+    mintGrant: async () => grant,
+  });
+  await assert.rejects(
+    () => service.createGrant(owner, "IS-1"),
+    (error) => {
+      assert.equal(statusCode(error), 409);
+      return true;
+    },
+  );
+  assert.equal(reads, 2, "re-checks the provider-resource binding after the mint");
+});
+
+test("native VNC fails closed when the profile changes during the mint", async () => {
+  let reads = 0;
+  const service = new NativeVNCService({
+    readSession: async () => {
+      reads += 1;
+      return { ...nativeSession("ready"), profile: reads === 1 ? "desktop" : "other" };
+    },
+    mintGrant: async () => grant,
+  });
+  await assert.rejects(
+    () => service.createGrant(owner, "IS-1"),
+    (error) => {
+      assert.equal(statusCode(error), 409);
+      return true;
+    },
+  );
+  assert.equal(reads, 2, "re-checks the profile after the mint");
+});
+
+test("native VNC rejects a missing or uncontrollable session", async () => {
+  const mint = async () => grant;
+  await assert.rejects(
+    () =>
+      new NativeVNCService({ readSession: async () => null, mintGrant: mint }).createGrant(
+        owner,
+        "IS-1",
+      ),
+    (error) => {
+      assert.equal(statusCode(error), 404);
+      return true;
+    },
+  );
+  await assert.rejects(
+    () =>
+      new NativeVNCService({
+        readSession: async () => ({ ...nativeSession("ready"), canControl: false }),
+        mintGrant: mint,
+      }).createGrant(owner, "IS-1"),
+    (error) => {
+      assert.equal(statusCode(error), 403);
+      return true;
+    },
+  );
+});
+
+test("native VNC rejects sessions ineligible for native VNC", async () => {
+  const base = nativeSession("ready");
+  const ineligible: InteractiveSession[] = [
+    { ...base, runtime: "container" },
+    { ...base, adapter: "container-v1" },
+    { ...base, capabilities: { ...base.capabilities, nativeVnc: false } },
+    { ...base, adapterWorkspaceId: null },
+    { ...base, [interactiveSessionAdapterControlPlane]: null },
+  ];
+  for (const session of ineligible) {
+    const mints: string[] = [];
+    await assert.rejects(
+      () =>
+        new NativeVNCService({
+          readSession: async () => session,
+          mintGrant: async () => {
+            mints.push("mint");
+            return grant;
+          },
+        }).createGrant(owner, "IS-1"),
+      (error) => {
+        assert.equal(statusCode(error), 409);
+        return true;
+      },
+    );
+    assert.deepEqual(mints, [], "an ineligible session must never reach the mint");
+  }
+});
+
+// The service is only load-bearing if the production native-VNC route actually delegates to it.
+// worker-application.ts can't be imported under `node --test` (its module graph pulls the Workers
+// runtime deps, e.g. @cloudflare/containers, which don't resolve here) — the same reason the path
+// was extracted — so this pins the wiring the way the repo's own application-architecture.test.ts
+// does: by asserting the composition in the source. If a refactor inlined the grant path or dropped
+// the guarded service, this fails.
+test("the native-VNC route delegates to the guarded NativeVNCService (production wiring)", async () => {
+  const worker = await readFile(
+    new URL("../src/worker/worker-application.ts", import.meta.url),
+    "utf8",
+  );
+  // createNativeVNCGrant is wired through NativeVNCService, not minting inline.
+  assert.match(
+    worker,
+    /createNativeVNCGrant:\s*\(user, sessionId\)\s*=>\s*\n?\s*new NativeVNCService\(/,
+    "the native route must construct NativeVNCService",
+  );
+  // its readSession/mintGrant deps are the real production seams.
+  assert.match(worker, /readSession:\s*\(u, id\)\s*=>\s*this\.sessions\.readVisibleFresh\(u, id\)/);
+  assert.match(
+    worker,
+    /mintGrant:[\s\S]*?this\.runtime[\s\S]*?\.workspaceLifecycle\(\)[\s\S]*?\.createNativeVNCGrant\(/,
+  );
+  // the pre-fix inline mint (workspaceLifecycle().createNativeVNCGrant reached straight from the
+  // route, with no NativeVNCService between) must be gone.
+  assert.doesNotMatch(
+    worker,
+    /return await this\.runtime\s*\n?\s*\.workspaceLifecycle\(\)\s*\n?\s*\.createNativeVNCGrant\(/,
+    "the native route must not mint inline (bypassing the status guard)",
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

The native-VNC grant endpoint hands a caller usable desktop credentials for a session whose workspace
is already stopping or gone.

`createNativeVNCGrant` (in `worker-application.ts`) checked only that the session *advertises*
`nativeVnc` before minting — it never checked the session's lifecycle `status`. The browser-VNC path
for the same runtime-adapter workspace (`InteractiveDesktopService.open`) does two things this path
did not:

- rejects `stopping` / `stopped` / `expired` / `failed` **before** minting, and
- re-validates the session **after** the mint round trip (`hasCurrentAccess`), because the session can
  begin teardown while the grant is being created.

So a client could obtain a working native-VNC credential for a workspace being torn down, and a stop
racing the mint would leak a credential for a dead workspace.

## The change

Extract the native-VNC path into a small `NativeVNCService` with injected deps (`readSession`,
`mintGrant`) so it is unit-testable, and give it the same guards as its browser-VNC sibling:

- a pre-mint live-status allowlist (`ready` / `attached` / `detached`), and
- a post-mint re-validation that fails closed (`session authorization changed; retry`) if — during the
  mint round trip — the session left a live state, control authorization was revoked, or its workspace
  identity moved (control-plane, workspace id, provider resource, or profile). This mirrors the
  browser-VNC sibling's `hasCurrentAccess`, which re-checks control and the full workspace identity
  after the mint, not just status. (`providerResourceId` in particular is rewritten by session
  reconciliation while a session stays live, so pinning it matters.)

`worker-application.ts` now just wires the service in; no behaviour change beyond the added guards.

## Real production-endpoint proof (before → after)

The fix on the **real HTTP endpoint**: crabfleet running under `wrangler dev` (workerd) with a real
local D1 (SQLite), a real native-auth access token (bootstrap-owner identity), and real routing — not
a harness. `POST /api/native/v1/native-vnc` for a seeded native-VNC session whose status is
`stopping`:

```
BASE (origin/main @f4ef10b — inline createNativeVNCGrant, NO status guard)
  -> HTTP 500  {"error":"internal error"}
  Not refused: proceeds PAST to workspaceLifecycle().createNativeVNCGrant (the mint) and only
  fails at the runtime-adapter call — i.e. it would issue a credential for a stopping workspace.

HEAD (this PR)
  -> HTTP 409  {"error":"native VNC is unavailable while the session is stopping"}
  Refused at the pre-mint guard, before any mint.
```

`409 (refused at the guard)` vs `500 (reached the mint)` on the production endpoint is the fix.
Reproducible transcript + seed: https://gist.github.com/anagnorisis2peripeteia/d4f681075a24801417f293aed70c4b12

### Service-level before/after (same two interleavings)

Driven through the extracted `NativeVNCService` (base = the verbatim inline body from
`worker-application.ts@f4ef10b` L207-224, since `worker-application.ts` can't be imported under
`node --test` — its module graph pulls `@cloudflare/containers`, which is *why* the path was
extracted):

```
BASE — no status guard, no post-mint revalidation
STOPPING-session    -> GRANT MINTED (leak) minted=true
STOP-during-mint    -> GRANT MINTED (leak) minted=true

HEAD — pre-mint status guard + post-mint revalidation
STOPPING-session    -> rejected 409 "native VNC is unavailable while the session is stopping"
STOP-during-mint    -> rejected 409 "session authorization changed; retry"
```

That the guard actually sits on the *production* path (and isn't just a property of a new class the
route could bypass) is pinned the way the repo's own `application-architecture.test.ts` pins
composition — a source assertion that the `createNativeVNCGrant` route delegates to `NativeVNCService`
with `readVisibleFresh` + `workspaceLifecycle().createNativeVNCGrant`, and no longer mints inline.

## Testing

`pnpm check` (tsc + oxlint + oxfmt), `pnpm build`, `pnpm exec wrangler deploy --dry-run`, `pnpm test`
all green (957 tests).

`tests/native-vnc-service.test.ts` covers: mints for a live session; rejects a stopping session
before minting; fails closed when the session begins teardown during the mint; rejects a
missing/uncontrollable session; rejects ineligible sessions (asserting the mint is never reached on
any rejection path); fails closed when control is revoked or the control-plane is re-bound during the
mint; when the provider resource or profile changes during the mint; and the production-wiring
assertion above. Mutation testing of the new service scores 87% (74/85). A concurrency lint of the
diff (a race/leak static pass) is clean.

Related: FINDING 1 of #88 (a small set of lifecycle concurrency findings; separate PRs to follow).

Review history: https://gist.github.com/2f7c872efcad9a64122db222f4a54e67
