### PR TITLE
fix(cards): stop finishRunForLane overwriting a run's stalled status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve stalled card-run provenance by fencing lane completion and its audit event in one guarded D1 batch, preventing concurrent completion from overwriting terminal state, thanks @anagnorisis2peripeteia.
 - Reject native-VNC grant issuance unless the session remains live and controllable before and after minting, preventing teardown races from returning stale workspace credentials, thanks @anagnorisis2peripeteia.
 - Fix the QUIC host identity leaking a new self-signed "Crabfleet QUIC" certificate into the login keychain on every launch: reuse the stored certificate by matching the stable host public key instead of a label macOS never persists, and collapse any already-accumulated duplicates back to one, restoring fast system-CA trust evaluation.
 - Extend the deck design language to the Quick Connect and desktop connection sheets: card-based fields and switches, gradient headers, pinned dark scheme, and a shared height-capped scrolling sheet container.

--- a/src/worker/card-repository.ts
+++ b/src/worker/card-repository.ts
@@ -477,25 +477,50 @@ export class CardRepository implements CardLifecycleStore {
   ): Promise<void> {
     const status: RunStatus =
       lane === "Done" ? "completed" : lane === "Human Review" ? "review" : "canceled";
-    const run = await database(this.env)
-      .selectFrom("run_attempts")
-      .select(["id", "card_id"])
-      .where("id", "=", runId)
-      .executeTakeFirst();
-    if (!run) return;
     const db = database(this.env);
-    await executeBatch(this.env, [
-      db
-        .updateTable("run_attempts")
-        .set({
-          status,
-          ended_at: now,
-          updated_at: now,
-          control_intent: status === "canceled" ? "cancel" : null,
-        })
-        .where("id", "=", runId),
-      eventInsert(db, run.card_id, actorName, `run ${status}`, now),
-    ]);
+    const controlIntent = status === "canceled" ? "cancel" : null;
+    // "review" is allowed in the precondition ONLY for the Done transition (review -> completed). For
+    // the Human Review / Backlog transitions the run must still be active, so a run already in
+    // "review" is never re-transitioned — a repeated or concurrent Human Review completion cannot
+    // emit a duplicate audit event or rewrite the run's terminal timing.
+    const guardStatuses =
+      status === "completed" ? [...activeRunStatuses, "review"] : [...activeRunStatuses];
+    // Transition the run and record its "run <status>" audit event in ONE atomic D1 batch — the same
+    // guarded-update + conditional-insert pattern claimRun already uses on this table:
+    //  - the UPDATE only fires for a still-pre-terminal run (active, or "review" moving to Done),
+    //    mirroring the WHERE status IN (...) precondition stall()/reconcileStalledRuns() use, so a run
+    //    a reconciler concurrently marked "stalled" during the caller's read→write window is not
+    //    overwritten;
+    //  - the event is inserted ONLY when THIS batch's UPDATE actually transitioned the run
+    //    (`(SELECT changes()) = 1` reads the row count of the immediately-preceding UPDATE), so a
+    //    stalled/terminal run gets no false completion event, an already-terminal run is not
+    //    re-announced, and two finish calls sharing the same `now` cannot each emit the event —
+    //    only the one whose UPDATE changed the row does.
+    // Because both statements share one batch, the status write and its event commit or roll back
+    // together — they can never persist separately.
+    const transition = sql`
+      UPDATE run_attempts
+        SET status = ${status},
+          ended_at = ${now},
+          updated_at = ${now},
+          control_intent = ${controlIntent}
+        WHERE id = ${runId}
+          AND status IN (${sql.join(guardStatuses)})
+    `;
+    const event = sql`
+      INSERT INTO events (card_id, actor, message, created_at)
+      SELECT card_id, ${actorName}, ${`run ${status}`}, ${now}
+      FROM run_attempts
+      WHERE id = ${runId}
+        AND status = ${status}
+        AND (SELECT changes()) = 1
+    `;
+    await this.env.DB.batch(
+      [transition, event].map((query) => {
+        const compiled = query.compile(db);
+        return this.env.DB.prepare(compiled.sql).bind(...compiled.parameters);
+      }),
+    );
   }
 
   async appendEvent(

--- a/tests/card-run-finish-guard.test.ts
+++ b/tests/card-run-finish-guard.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Miniflare } from "miniflare";
+
+import { CardRepository } from "../src/worker/card-repository.ts";
+import type { RuntimeEnv } from "../src/worker/env.ts";
+
+// finishRunForLane is a persistence race fix, so it is proven against a REAL D1 (Miniflare's
+// SQLite), not a mock: the guarded UPDATE + conditional event insert run as the actual compiled SQL
+// in one atomic batch. Each case seeds run_attempts + events, invokes the real CardRepository, then
+// reads the committed rows back.
+
+async function openD1(): Promise<{ mf: Miniflare; env: RuntimeEnv }> {
+  const mf = new Miniflare({
+    modules: true,
+    script: "export default { async fetch() { return new Response('ok'); } };",
+    d1Databases: ["DB"],
+  });
+  const db = await mf.getD1Database("DB");
+  await db.exec(
+    "CREATE TABLE run_attempts (id TEXT PRIMARY KEY, card_id TEXT NOT NULL, attempt INTEGER NOT NULL, runtime TEXT NOT NULL, status TEXT NOT NULL, control_intent TEXT, lease_id TEXT, attach_url TEXT, vnc_url TEXT, operator TEXT, last_heartbeat_at INTEGER NOT NULL, started_at INTEGER, ended_at INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, error TEXT)",
+  );
+  await db.exec(
+    "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, card_id TEXT NOT NULL, actor TEXT NOT NULL, message TEXT NOT NULL, created_at INTEGER NOT NULL)",
+  );
+  return { mf, env: { DB: db } as unknown as RuntimeEnv };
+}
+
+async function seedRun(env: RuntimeEnv, status: string, updatedAt = 0): Promise<void> {
+  await env.DB.prepare(
+    "INSERT INTO run_attempts (id, card_id, attempt, runtime, status, last_heartbeat_at, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?)",
+  )
+    .bind("R1", "CY-1", 1, "crabbox", status, 0, 0, updatedAt)
+    .run();
+}
+
+async function readRun(
+  env: RuntimeEnv,
+): Promise<{ status: string; control_intent: string | null }> {
+  return env.DB.prepare("SELECT status, control_intent FROM run_attempts WHERE id = ?")
+    .bind("R1")
+    .first() as Promise<{ status: string; control_intent: string | null }>;
+}
+
+async function eventMessages(env: RuntimeEnv): Promise<string[]> {
+  const { results } = await env.DB.prepare("SELECT card_id, message FROM events ORDER BY id").all<{
+    card_id: string;
+    message: string;
+  }>();
+  for (const row of results) assert.equal(row.card_id, "CY-1", "events carry the run's card id");
+  return results.map((row) => row.message);
+}
+
+test("finishRunForLane transitions a live run to completed and records exactly one event", async () => {
+  const { mf, env } = await openD1();
+  try {
+    await seedRun(env, "running");
+    await new CardRepository(env).finishRunForLane("R1", "Done", "actor", 100);
+    assert.equal((await readRun(env)).status, "completed");
+    assert.deepEqual(await eventMessages(env), ["run completed"]);
+  } finally {
+    await mf.dispose();
+  }
+});
+
+test("finishRunForLane leaves a stalled run untouched and emits no event (the race fix)", async () => {
+  const { mf, env } = await openD1();
+  try {
+    await seedRun(env, "stalled"); // a reconciler marked it during the caller's read->write window
+    await new CardRepository(env).finishRunForLane("R1", "Done", "actor", 100);
+    assert.equal((await readRun(env)).status, "stalled", "stalled provenance is preserved");
+    assert.deepEqual(await eventMessages(env), [], "no false 'run completed' event");
+  } finally {
+    await mf.dispose();
+  }
+});
+
+test("finishRunForLane does not re-announce an already-terminal run (atomic conditional event)", async () => {
+  const { mf, env } = await openD1();
+  try {
+    await seedRun(env, "completed", 50); // already finished by an earlier call (different updated_at)
+    await new CardRepository(env).finishRunForLane("R1", "Done", "actor", 100);
+    assert.equal((await readRun(env)).status, "completed");
+    assert.deepEqual(
+      await eventMessages(env),
+      [],
+      "the event only fires for the row THIS call transitioned (matched on updated_at)",
+    );
+  } finally {
+    await mf.dispose();
+  }
+});
+
+test("finishRunForLane promotes a review run to Done and records its event", async () => {
+  const { mf, env } = await openD1();
+  try {
+    await seedRun(env, "review");
+    await new CardRepository(env).finishRunForLane("R1", "Done", "actor", 100);
+    assert.equal((await readRun(env)).status, "completed");
+    assert.deepEqual(await eventMessages(env), ["run completed"]);
+  } finally {
+    await mf.dispose();
+  }
+});
+
+test("finishRunForLane cancels for a non-terminal lane and sets control_intent", async () => {
+  const { mf, env } = await openD1();
+  try {
+    await seedRun(env, "running");
+    await new CardRepository(env).finishRunForLane("R1", "Backlog", "actor", 100);
+    const run = await readRun(env);
+    assert.equal(run.status, "canceled");
+    assert.equal(run.control_intent, "cancel");
+    assert.deepEqual(await eventMessages(env), ["run canceled"]);
+  } finally {
+    await mf.dispose();
+  }
+});
+
+test("finishRunForLane emits exactly one event when two finish calls share the same now", async () => {
+  const { mf, env } = await openD1();
+  try {
+    await seedRun(env, "running");
+    const repo = new CardRepository(env);
+    await repo.finishRunForLane("R1", "Done", "actor", 100); // running -> completed, one event
+    await repo.finishRunForLane("R1", "Done", "actor", 100); // same now; run already completed -> UPDATE no-ops
+    assert.equal((await readRun(env)).status, "completed");
+    assert.deepEqual(
+      await eventMessages(env),
+      ["run completed"],
+      "a competing same-now finish call must not duplicate the audit event (changes()=1 gates it)",
+    );
+  } finally {
+    await mf.dispose();
+  }
+});
+
+test("finishRunForLane does not re-fire the event or rewrite timing on repeated Human Review completion", async () => {
+  const { mf, env } = await openD1();
+  try {
+    await seedRun(env, "running");
+    const repo = new CardRepository(env);
+    await repo.finishRunForLane("R1", "Human Review", "actor", 100); // running -> review, one event
+    await repo.finishRunForLane("R1", "Human Review", "actor", 200); // already review; must NOT re-transition
+    assert.equal((await readRun(env)).status, "review");
+    assert.deepEqual(
+      await eventMessages(env),
+      ["run review"],
+      "a repeated Human Review completion must not re-fire the audit event",
+    );
+    const row = (await env.DB.prepare("SELECT ended_at, updated_at FROM run_attempts WHERE id = ?")
+      .bind("R1")
+      .first()) as { ended_at: number; updated_at: number };
+    assert.equal(row.updated_at, 100, "the second call must not rewrite the run's terminal timing");
+    assert.equal(row.ended_at, 100, "the second call must not rewrite ended_at");
+  } finally {
+    await mf.dispose();
+  }
+});


### PR DESCRIPTION
## What Problem This Solves

When a run finishes for a lane (advance to Done / Human Review / Backlog), `finishRunForLane` overwrote
the run's `status` unconditionally. If a reconciler had already marked that run **`stalled`** — a
heartbeat timeout or crash detected during the caller's read→write window — its terminal provenance
was silently replaced with `completed` / `review` / `canceled`, and a false "run &lt;status&gt;" event
was recorded. The stalled fact (and the preserved workspace it implies) was lost.

This is the same check-then-act race the two siblings on this table already guard against: `stall()`
and `reconcileStalledRuns()` both fence their `run_attempts` UPDATE with `WHERE status IN
(activeRunStatuses)` and only emit their event when a row actually changed. `finishRunForLane` was the
one writer that didn't.

## The change

Fence the transition on the run still being pre-terminal, and commit the transition and its audit
event in **one atomic `DB.batch`** — the same guarded-update + conditional-insert pattern `claimRun`
already uses on this table:

```
UPDATE run_attempts SET status = ?, ended_at = ?, updated_at = ?, control_intent = ?
  WHERE id = ? AND status IN (<active statuses [+ 'review' only when target = 'completed']>);
INSERT INTO events (card_id, actor, message, created_at)
  SELECT card_id, ?, ?, ? FROM run_attempts
  WHERE id = ? AND status = ? AND (SELECT changes()) = 1;               -- only if THIS batch's UPDATE transitioned the row
```

`'review'` is allowed in the precondition **only for the Done transition** (`review` → `completed`).
For the Human Review / Backlog transitions the run must still be active, so a run already in `review`
is never re-transitioned — a repeated or concurrent Human Review completion cannot re-fire the audit
event or rewrite the run's terminal timing.

A run a reconciler moved to `stalled` (or any terminal status) no longer matches the UPDATE, so the
transition is skipped. The event insert is gated on `(SELECT changes()) = 1` — the row count of the
immediately-preceding UPDATE — so it belongs strictly to the transition *this* batch performed: a
stalled/terminal run gets no false event, an already-terminal run is not re-announced, and two finish
calls sharing the same `now` cannot each emit the event (only the one whose UPDATE changed the row
does — this closes the duplicate-audit-event risk raised on the previous revision). Sharing one batch
means the status write and its event commit or roll back together — they can never persist separately.

## Real-behaviour proof (before → after, real D1)

The same interleaving, driven against a **real Miniflare D1** (SQLite) so the actual compiled SQL runs:

```
BASE origin/main — unconditional UPDATE, no status guard (real D1)
  after finishRunForLane(Done): run status=completed, run-finished events=1 ("run completed")
  => STOMPED: stalled overwritten to 'completed' + false 'run completed' event

HEAD (this PR) — guarded UPDATE + conditional event, one atomic batch (real D1)
  after finishRunForLane(Done): run status=stalled, run-finished events=0
  => PRESERVED: stalled provenance intact, no false 'run completed' event
```

Reproducible transcript: https://gist.github.com/anagnorisis2peripeteia/1c6b581b8cd3236008ee787582a7040e

## Testing

`pnpm check` (tsc + oxlint + oxfmt), `pnpm build`, `pnpm exec wrangler deploy --dry-run`, `pnpm test`
all green. `tests/card-run-finish-guard.test.ts` runs against a **real Miniflare D1** (not a mock):
a live run transitions and records exactly one event; a `stalled` run is left untouched with no event
(the race fix); an **already-terminal run is not re-announced**; **two finish calls sharing the same
`now` emit exactly one event** (pins the `changes()`-gated conditional insert against duplicate audit
events); a `review` run promotes to Done; a **repeated Human Review completion re-fires no event and
does not rewrite the run's timing** (pins the review-only-for-Done restriction); and a non-terminal
lane cancels with `control_intent`. Mutation testing of the changed range scores 100%. A concurrency
lint of the diff is clean.

**Scope:** this fixes only the run-provenance overwrite. The card's own lane move (`moveCard`) is a
separate, pre-existing, user-initiated step and is intentionally left as-is.

Related: FINDING 2 of #88.
