### PR TITLE
fix(terminal): don't let a stale upstream handler evict a live resubscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve live terminal resubscriptions when stale upstream close, error, or revocation callbacks arrive for a replaced subscription, thanks @anagnorisis2peripeteia.
 - Preserve stalled card-run provenance by fencing lane completion and its audit event in one guarded D1 batch, preventing concurrent completion from overwriting terminal state, thanks @anagnorisis2peripeteia.
 - Reject native-VNC grant issuance unless the session remains live and controllable before and after minting, preventing teardown races from returning stale workspace credentials, thanks @anagnorisis2peripeteia.
 - Fix the QUIC host identity leaking a new self-signed "Crabfleet QUIC" certificate into the login keychain on every launch: reuse the stored certificate by matching the stable host public key instead of a label macOS never persists, and collapse any already-accumulated duplicates back to one, restoring fast system-CA trust evaluation.

--- a/src/worker/terminal-hub.ts
+++ b/src/worker/terminal-hub.ts
@@ -586,9 +586,15 @@ export class TerminalHub {
       const revokeView = () => {
         if (!viewGranted) return;
         viewGranted = false;
-        if (subscriptions.delete(id)) this.dependencies.releaseInputState(id);
         if (viewCheck !== null) clearInterval(viewCheck);
         if (upstream.readyState === WebSocket.OPEN) upstream.close(1008, "share revoked");
+        // A canView() from a prior interval tick can still be in flight and resolve here after this
+        // subscription was replaced (unsubscribe -> resubscribe); clearInterval does not cancel that
+        // pending promise. Don't let the stale closure evict the live resubscription or tell its
+        // client the share was revoked — the same identity re-check the close/error handlers use.
+        if (subscriptions.get(id) !== activeSubscription) return;
+        subscriptions.delete(id);
+        this.dependencies.releaseInputState(id);
         sendTerminalJson(client, TerminalMessageType.Error, id, {
           error: "terminal share revoked",
         });
@@ -771,8 +777,14 @@ export class TerminalHub {
               [session.attachUrl],
             )
           : "";
-        if (subscriptions.delete(id)) this.dependencies.releaseInputState(id);
         if (viewCheck !== null) clearInterval(viewCheck);
+        // A newer subscription may already own this id (unsubscribe -> immediate resubscribe); this
+        // stale upstream's close must not evict the live subscription, release its input state, mark
+        // the session detached, or tell the client it closed — the same identity re-check the input
+        // loop uses (subscriptions.get(id) !== subscription).
+        if (subscriptions.get(id) !== activeSubscription) return;
+        subscriptions.delete(id);
+        this.dependencies.releaseInputState(id);
         if (!isPassiveTerminalClose(closeReason)) {
           const message = terminalCloseMessage(event.code, safeUpstreamReason);
           void this.dependencies.markDetached(user, id, message);
@@ -792,8 +804,13 @@ export class TerminalHub {
           error: "terminal input delivery outcome is unknown; the runner may still complete it",
         });
         const closeReason = closingReason;
-        if (subscriptions.delete(id)) this.dependencies.releaseInputState(id);
         if (viewCheck !== null) clearInterval(viewCheck);
+        // A newer subscription may already own this id (unsubscribe -> immediate resubscribe); this
+        // stale upstream's error must not evict the live subscription, release its input state, or
+        // surface a failure for it — the same identity re-check the input loop uses.
+        if (subscriptions.get(id) !== activeSubscription) return;
+        subscriptions.delete(id);
+        this.dependencies.releaseInputState(id);
         const message = "terminal unavailable: upstream terminal error";
         if (!isPassiveTerminalClose(closeReason)) {
           void this.dependencies.markConnectionFailure(user, session, message);

--- a/tests/terminal-hub.test.ts
+++ b/tests/terminal-hub.test.ts
@@ -2036,3 +2036,213 @@ test("terminal hub immediately acknowledges upstream output when the client opts
   assert.deepEqual(upstream.sent, ['{"type":"ack","bytes":3}']);
   server.emit("close");
 });
+
+test("terminal hub: a stale upstream close does not evict a live resubscription of the same id", async () => {
+  const client = socket();
+  const server = socket();
+  const upstreamA = socket();
+  const upstreamB = socket();
+  const upstreams = [upstreamA, upstreamB]; // first subscribe gets A, the resubscribe gets B
+  const releasedInputStates: string[] = [];
+  const detached: string[] = [];
+  const hub = new TerminalHub(
+    dependencies(client, server, upstreamA, {
+      async openUpstream() {
+        return {
+          socket: upstreams.shift()!,
+          outputAcknowledgements: true,
+          async markConnected() {},
+        };
+      },
+      releaseInputState(sessionId) {
+        releasedInputStates.push(sessionId);
+      },
+      async markDetached(_user, sessionId) {
+        detached.push(sessionId);
+      },
+    }),
+  );
+
+  await hub.open(
+    new Request("https://fleet.example/api/terminal/ws", { headers: { upgrade: "websocket" } }),
+    user,
+  );
+
+  const subscribe = () =>
+    server.emit("message", {
+      data: encodeTerminalFrame({
+        type: TerminalMessageType.Subscribe,
+        sessionId: session.id,
+        payload: encodeSubscribePayload({ flags: 0, columns: 120, rows: 34 }),
+      }),
+    });
+  const closedEvents = () =>
+    server.sent.filter((value) => {
+      const decoded = decodeTerminalFrame(value as Uint8Array);
+      if (!decoded || decoded.type !== TerminalMessageType.Event) return false;
+      return (decodeJsonPayload(decoded.payload) as { type?: string }).type === "closed";
+    }).length;
+
+  // 1) subscribe -> upstreamA
+  subscribe();
+  await flushQueues();
+  await flushQueues();
+  // 2) unsubscribe -> closeSubscription releases input state once and closes upstreamA
+  server.emit("message", {
+    data: encodeTerminalFrame({ type: TerminalMessageType.Unsubscribe, sessionId: session.id }),
+  });
+  await flushQueues();
+  // 3) immediately resubscribe -> upstreamB is the new, live subscription for the same id
+  subscribe();
+  await flushQueues();
+  await flushQueues();
+
+  const closedBefore = closedEvents();
+  // 4) the OLD upstream (A)'s deferred close event finally fires
+  upstreamA.emit("close", { code: 1000, reason: "" });
+  await flushQueues();
+
+  assert.deepEqual(
+    releasedInputStates,
+    [session.id],
+    "only the unsubscribe releases input state; the stale close must not release the live resubscription",
+  );
+  assert.equal(detached.length, 0, "the stale close must not mark the live session detached");
+  assert.equal(
+    closedEvents(),
+    closedBefore,
+    "the stale close must not tell the client its live session closed",
+  );
+
+  server.emit("close"); // drain the resubscription's view-check interval
+});
+
+function countClosed(server: WebSocket & TestSocket): number {
+  return server.sent.filter((value) => {
+    const decoded = decodeTerminalFrame(value as Uint8Array);
+    if (!decoded || decoded.type !== TerminalMessageType.Event) return false;
+    return (decodeJsonPayload(decoded.payload) as { type?: string }).type === "closed";
+  }).length;
+}
+function subscribeFrame(server: WebSocket & TestSocket): void {
+  server.emit("message", {
+    data: encodeTerminalFrame({
+      type: TerminalMessageType.Subscribe,
+      sessionId: session.id,
+      payload: encodeSubscribePayload({ flags: 0, columns: 120, rows: 34 }),
+    }),
+  });
+}
+
+test("terminal hub: a normal upstream close tears down the current subscription and notifies the client", async () => {
+  const client = socket();
+  const server = socket();
+  const upstream = socket();
+  const released: string[] = [];
+  const detached: string[] = [];
+  const hub = new TerminalHub(
+    dependencies(client, server, upstream, {
+      releaseInputState(id) {
+        released.push(id);
+      },
+      async markDetached(_user, id) {
+        detached.push(id);
+      },
+    }),
+  );
+  await hub.open(
+    new Request("https://fleet.example/api/terminal/ws", { headers: { upgrade: "websocket" } }),
+    user,
+  );
+  subscribeFrame(server);
+  await flushQueues();
+  await flushQueues();
+  upstream.emit("close", { code: 1006, reason: "runner gone" });
+  await flushQueues();
+  assert.deepEqual(released, [session.id], "the current subscription's input state is released");
+  assert.equal(detached.length, 1, "a non-passive close marks the session detached");
+  assert.equal(countClosed(server), 1, "the client is told its session closed");
+});
+
+test("terminal hub: a normal upstream error tears down the current subscription and surfaces a failure", async () => {
+  const client = socket();
+  const server = socket();
+  const upstream = socket();
+  const released: string[] = [];
+  let connectionFailures = 0;
+  const hub = new TerminalHub(
+    dependencies(client, server, upstream, {
+      releaseInputState(id) {
+        released.push(id);
+      },
+      async markConnectionFailure() {
+        connectionFailures += 1;
+      },
+    }),
+  );
+  await hub.open(
+    new Request("https://fleet.example/api/terminal/ws", { headers: { upgrade: "websocket" } }),
+    user,
+  );
+  subscribeFrame(server);
+  await flushQueues();
+  await flushQueues();
+  upstream.emit("error");
+  await flushQueues();
+  assert.deepEqual(released, [session.id], "the current subscription's input state is released");
+  assert.equal(connectionFailures, 1, "an upstream error surfaces a connection failure");
+});
+
+test("terminal hub: a stale upstream error does not evict a live resubscription of the same id", async () => {
+  const client = socket();
+  const server = socket();
+  const upstreamA = socket();
+  const upstreamB = socket();
+  const upstreams = [upstreamA, upstreamB];
+  const released: string[] = [];
+  let connectionFailures = 0;
+  const hub = new TerminalHub(
+    dependencies(client, server, upstreamA, {
+      async openUpstream() {
+        return {
+          socket: upstreams.shift()!,
+          outputAcknowledgements: true,
+          async markConnected() {},
+        };
+      },
+      releaseInputState(id) {
+        released.push(id);
+      },
+      async markConnectionFailure() {
+        connectionFailures += 1;
+      },
+    }),
+  );
+  await hub.open(
+    new Request("https://fleet.example/api/terminal/ws", { headers: { upgrade: "websocket" } }),
+    user,
+  );
+  subscribeFrame(server);
+  await flushQueues();
+  await flushQueues();
+  server.emit("message", {
+    data: encodeTerminalFrame({ type: TerminalMessageType.Unsubscribe, sessionId: session.id }),
+  });
+  await flushQueues();
+  subscribeFrame(server);
+  await flushQueues();
+  await flushQueues();
+  upstreamA.emit("error");
+  await flushQueues();
+  assert.deepEqual(
+    released,
+    [session.id],
+    "the stale error must not release the live resubscription",
+  );
+  assert.equal(
+    connectionFailures,
+    0,
+    "the stale error must not surface a failure for the live session",
+  );
+  server.emit("close");
+});


### PR DESCRIPTION
## What Problem This Solves

The terminal hub keys its live subscriptions by session id. When an upstream connection closes or
errors, the `close` / `error` handlers removed the subscription with `subscriptions.delete(id)` — by
id alone. So an **unsubscribe → immediate resubscribe** of the same session id could let the *old*
upstream's deferred `close` (or `error`) event fire *after* the new subscription was already stored,
and evict it: releasing the live subscription's input state and telling the client its session had
closed, while the connection stayed up.

The hub's own input loop already guards against exactly this with an identity re-check
(`subscriptions.get(id) !== subscription`); the two upstream lifecycle handlers did not.

## The change

Re-check subscription identity before acting in the three paths that tear a subscription down — the
`close` handler, the `error` handler, and the view-revocation path (`revokeView`) — matching the
input loop:

```
if (subscriptions.get(id) !== activeSubscription) return; // a newer subscription owns this id now
subscriptions.delete(id);
this.dependencies.releaseInputState(id);
```

If a newer subscription has taken over the id, the stale handler stops: it no longer evicts the live
subscription, releases its input state, marks the session detached, or sends the client a `closed` /
error / `share revoked` event. Each handler still cleans up its own subscription (pending input
acknowledgements, its view-check interval, its own upstream). `revokeView` is included because a
`canView()` from a prior interval tick can still be in flight and resolve *after* the id was
re-subscribed — `clearInterval` does not cancel that pending promise.

## Real Worker WebSocket proof (before → after)

Driven end-to-end against the **real worker** under `wrangler dev` (workerd): a real WebSocket client
connects to `/api/terminal/ws` (real `crabbox_session` cookie auth), and the subscription's upstream
is a real `ws://` server the harness controls. The production sequence — subscribe → unsubscribe →
immediate same-id resubscribe — opens two real upstream connections; the old upstream's close then
fires deferred (a real WS close handshake) after the resubscription:

```
BASE (origin/main, no identity guard)
  client 'closed' events for the live resubscription: 1
  => EVICTED: the old upstream's close closed the live resubscription

HEAD (this PR, identity guard on close/error/revokeView)
  client 'closed' events for the live resubscription: 0
  => PRESERVED: the resubscription survived the old upstream's close
```

Reproducible transcript + setup: https://gist.github.com/anagnorisis2peripeteia/a401c163be272045571337a9419c37a8

## Deterministic reproduction (unit)

The same interleaving through the real `TerminalHub`, which additionally makes the double-release
observable:

```
BASE — no identity guard
  releaseInputState calls=2, spurious client 'closed' after resubscribe=1  => EVICTED
HEAD — identity guard
  releaseInputState calls=1, spurious client 'closed' after resubscribe=0  => PRESERVED
```

(The extra `releaseInputState` on base is the second, wrong release — of the live subscription B's
input state.)

## Testing

`pnpm check` (tsc + oxlint + oxfmt), `pnpm build`, `pnpm exec wrangler deploy --dry-run`, `pnpm test`
all green. `tests/terminal-hub.test.ts` adds four cases covering the close and error handlers on both
paths: a stale close and a stale error must NOT evict a live resubscription; a normal close and a
normal error still tear down the current subscription and notify the client. Mutation testing of the
close/error guard conditions scores 100%. `revokeView` gets the identical one-line guard; its stale
trigger (an in-flight `canView()` resolving after the swap) isn't deterministically unit-testable
against the 5s view-check interval, so it relies on that same proven pattern rather than a flaky
fake-timer test. A concurrency lint of the diff is clean.

Related: FINDING 3 of #88.
