### PR TITLE
fix(terminal): fork the Resize auth check onto the per-subscription queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Keep slow terminal resize authorization off the shared multiplexed connection queue so other sessions and pings remain responsive, thanks @anagnorisis2peripeteia.
 - Preserve live terminal resubscriptions when stale upstream close, error, or revocation callbacks arrive for a replaced subscription, thanks @anagnorisis2peripeteia.
 - Preserve stalled card-run provenance by fencing lane completion and its audit event in one guarded D1 batch, preventing concurrent completion from overwriting terminal state, thanks @anagnorisis2peripeteia.
 - Reject native-VNC grant issuance unless the session remains live and controllable before and after minting, preventing teardown races from returning stale workspace credentials, thanks @anagnorisis2peripeteia.

--- a/src/worker/terminal-hub.ts
+++ b/src/worker/terminal-hub.ts
@@ -359,23 +359,30 @@ export class TerminalHub {
           }
           if (frame.type === TerminalMessageType.Resize) {
             const size = tryDecodeResizePayload(frame.payload);
-            const canInput = await subscription.canInput();
-            updateTerminalInputCapability(server, subscription, canInput);
-            if (!canInput) {
-              return;
-            }
-            if (size) {
-              subscription.cols = size.cols;
-              subscription.rows = size.rows;
-              if (subscription.upstream.readyState === WebSocket.OPEN) {
-                subscription.upstream.send(JSON.stringify({ type: "resize", ...size }));
-              }
-            }
-            sendTerminalJson(server, TerminalMessageType.Event, frame.sessionId, {
-              type: "resize",
-              cols: size?.cols ?? null,
-              rows: size?.rows ?? null,
-            });
+            // Fork the canInput() authorization round-trip and the resize onto the per-subscription
+            // queue, exactly as the Input path does. Awaiting canInput() inline here would hold the
+            // shared per-connection queue for the duration of a DB call, head-of-line-blocking
+            // Input/Subscribe/Stop for every other multiplexed session on this connection.
+            subscription.inputQueue = subscription.inputQueue
+              .catch(() => undefined)
+              .then(async () => {
+                const canInput = await subscription.canInput();
+                updateTerminalInputCapability(server, subscription, canInput);
+                if (!canInput) return;
+                if (subscriptions.get(frame.sessionId) !== subscription) return;
+                if (size) {
+                  subscription.cols = size.cols;
+                  subscription.rows = size.rows;
+                  if (subscription.upstream.readyState === WebSocket.OPEN) {
+                    subscription.upstream.send(JSON.stringify({ type: "resize", ...size }));
+                  }
+                }
+                sendTerminalJson(server, TerminalMessageType.Event, frame.sessionId, {
+                  type: "resize",
+                  cols: size?.cols ?? null,
+                  rows: size?.rows ?? null,
+                });
+              });
             return;
           }
           if (frame.type === TerminalMessageType.Ack) {

--- a/tests/terminal-hub.test.ts
+++ b/tests/terminal-hub.test.ts
@@ -7,6 +7,7 @@ import {
   decodeJsonPayload,
   decodeTerminalFrame,
   encodeAckPayload,
+  encodeResizePayload,
   encodeSubscribePayload,
   encodeTerminalFrame,
 } from "@openclaw/libterminal/protocol";
@@ -2244,5 +2245,114 @@ test("terminal hub: a stale upstream error does not evict a live resubscription 
     0,
     "the stale error must not surface a failure for the live session",
   );
+  server.emit("close");
+});
+
+test("terminal hub: a slow Resize auth check does not head-of-line-block other frames", async () => {
+  const client = socket();
+  const server = socket();
+  const upstream = socket();
+  let authCalls = 0;
+  let resolveResizeAuth: ((allowed: boolean) => void) | null = null;
+  const hub = new TerminalHub(
+    dependencies(client, server, upstream, {
+      // first canInput() (subscribe) resolves immediately; the Resize handler's canInput() then stays
+      // pending until we release it, standing in for a slow authorization round-trip.
+      inputGrant: () => () => {
+        authCalls += 1;
+        return authCalls === 1
+          ? Promise.resolve(true)
+          : new Promise<boolean>((resolve) => {
+              resolveResizeAuth = resolve;
+            });
+      },
+    }),
+  );
+  await hub.open(
+    new Request("https://fleet.example/api/terminal/ws", { headers: { upgrade: "websocket" } }),
+    user,
+  );
+  server.emit("message", {
+    data: encodeTerminalFrame({
+      type: TerminalMessageType.Subscribe,
+      sessionId: session.id,
+      payload: encodeSubscribePayload({ flags: 0, columns: 120, rows: 34 }),
+    }),
+  });
+  await flushQueues();
+  await flushQueues();
+  // Resize forks its canInput() onto the per-subscription queue; that auth check is now pending.
+  server.emit("message", {
+    data: encodeTerminalFrame({
+      type: TerminalMessageType.Resize,
+      sessionId: session.id,
+      payload: encodeResizePayload({ columns: 100, rows: 40 }),
+    }),
+  });
+  await flushQueues();
+  // A later frame on the SHARED connection queue must not wait behind the resize's pending auth check.
+  server.emit("message", {
+    data: encodeTerminalFrame({
+      type: TerminalMessageType.Ping,
+      sessionId: session.id,
+      payload: new Uint8Array([1, 2, 3]),
+    }),
+  });
+  await flushQueues();
+  const pongs = server.sent.filter((value) => {
+    const decoded = decodeTerminalFrame(value as Uint8Array);
+    return decoded?.type === TerminalMessageType.Pong;
+  }).length;
+  assert.equal(
+    pongs,
+    1,
+    "a Ping behind a slow Resize is answered without waiting on the resize's auth round-trip",
+  );
+  resolveResizeAuth?.(true);
+  await flushQueues();
+  server.emit("close");
+});
+
+test("terminal hub: an authorized Resize applies the size and notifies the client and upstream", async () => {
+  const client = socket();
+  const server = socket();
+  const upstream = socket();
+  const hub = new TerminalHub(dependencies(client, server, upstream));
+  await hub.open(
+    new Request("https://fleet.example/api/terminal/ws", { headers: { upgrade: "websocket" } }),
+    user,
+  );
+  server.emit("message", {
+    data: encodeTerminalFrame({
+      type: TerminalMessageType.Subscribe,
+      sessionId: session.id,
+      payload: encodeSubscribePayload({ flags: 0, columns: 120, rows: 34 }),
+    }),
+  });
+  await flushQueues();
+  await flushQueues();
+  server.emit("message", {
+    data: encodeTerminalFrame({
+      type: TerminalMessageType.Resize,
+      sessionId: session.id,
+      payload: encodeResizePayload({ columns: 100, rows: 40 }),
+    }),
+  });
+  await flushQueues();
+  await flushQueues();
+  const resizeEvents = server.sent
+    .map((value) => decodeTerminalFrame(value as Uint8Array))
+    .filter((d) => d?.type === TerminalMessageType.Event)
+    .map((d) => decodeJsonPayload(d!.payload) as { type?: string; cols?: number; rows?: number })
+    .filter((p) => p.type === "resize");
+  assert.deepEqual(
+    resizeEvents.at(-1),
+    { type: "resize", cols: 100, rows: 40 },
+    "client is told the new size",
+  );
+  const upstreamResize = upstream.sent.find(
+    (s) => typeof s === "string" && s.includes('"resize"') && s.includes("100"),
+  );
+  assert.ok(upstreamResize, "the upstream receives the resize with the new dimensions");
   server.emit("close");
 });


### PR DESCRIPTION
## What Problem This Solves

Terminal frames from a client are processed on a single shared per-connection `queue` (all
multiplexed sessions on that WebSocket serialize through it). The `Resize` handler `await`ed
`subscription.canInput()` — an authorization **DB round-trip** — **inline on that shared queue**. So
while one session's resize auth check was in flight, every other session's `Input` / `Subscribe` /
`Stop` / `Ping` frame was head-of-line-blocked behind it.

The `Input` path already avoids exactly this: it forks its own `canInput()` check onto a
per-subscription queue and returns from the shared queue immediately. `Resize` did not.

## The change

Fork the `canInput()` check and the resize work onto `subscription.inputQueue` (the same
per-subscription queue `Input` uses), so the shared connection queue returns immediately. The forked
work re-checks subscription identity before touching the upstream (the same stale-subscription guard
the `Input` path uses).

## Real-behaviour proof (before → after, real `TerminalHub`)

Captured by driving the **real `TerminalHub`** (the production class, unmocked): subscribe a session,
send a `Resize` whose `canInput()` authorization is held pending (standing in for a slow auth
round-trip), then a `Ping` on the shared per-connection queue. The timestamped transcripts below are
the **actual harness output on each revision** — the load-bearing line is *when the `Pong` arrives
relative to the `Resize` authorization being released*:

**BASE** (`origin/main` @`f4ef10b` — Resize `await`s `canInput()` inline on the shared queue)

```
t+14.050ms  client→hub   Subscribe(session, 120x34)
t+15.817ms  client→hub   Resize(100x40)  [its canInput() authorization is now PENDING]
t+16.214ms  client→hub   Ping(3 bytes)   [next frame on the SHARED connection queue]
            ---- Resize authorization released here (was pending; pongs so far = 0) ----
t+16.385ms  hub→upstream {"type":"resize","cols":100,"rows":40}
t+16.418ms  hub→client   Event resize cols=100 rows=40
t+16.447ms  hub→client   Pong            <- only AFTER the resize auth resolved
=> HEAD-OF-LINE BLOCKED: pongs received before the resize auth resolved = 0
```

**HEAD** (this PR @`3b35686` — Resize forked onto the per-subscription `inputQueue`)

```
t+12.453ms  client→hub   Subscribe(session, 120x34)
t+13.448ms  client→hub   Resize(100x40)  [its canInput() authorization is now PENDING]
t+13.625ms  client→hub   Ping(3 bytes)   [next frame on the SHARED connection queue]
t+13.694ms  hub→client   Pong            <- answered WHILE the resize auth is still pending
            ---- Resize authorization released here (was pending; pongs so far = 1) ----
t+13.808ms  hub→upstream {"type":"resize","cols":100,"rows":40}
t+13.838ms  hub→client   Event resize cols=100 rows=40
=> NOT BLOCKED: pongs received before the resize auth resolved = 1
```

The one-line difference: on base the `Pong` is emitted *after* the resize's auth round-trip
(t+16.447, past the release); on HEAD it is emitted *before* it (t+13.694, while still pending) — and
the resize itself still applies correctly on release (upstream `resize` + client `resize` event) on
both. Same interleaving, driven through the production `TerminalHub` on each revision.

A live WebSocket can't inject latency into the real authorization check, so this deterministic
real-`TerminalHub` reproduction is the strongest feasible proof for a head-of-line *stall*; it is
committed as the regression test below so it runs in CI.

## Testing

`pnpm check`, `pnpm build`, `pnpm exec wrangler deploy --dry-run`, `pnpm test` all green (953 tests).
`tests/terminal-hub.test.ts` adds the two cases behind the transcript above: a slow Resize does not
block a following Ping (the fix — pins pongs-before-release = 1); and an authorized Resize applies the
new size and notifies both client and upstream (pins the resize still lands). Mutation of the changed
range scores 76%. A concurrency lint of the diff is clean.

Related: FINDING 4 of #88.
