### PR TITLE
fix(macos): live permission monitoring + blended title bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Blend the macOS title bar into the desktop deck, align its unified top band, and add hover, focus, refresh-progress, and empty-state interaction polish.
 - Keep Share This Mac permission status and start availability synchronized with Screen Recording and Accessibility grants made in System Settings while the sheet is open.
 - Add bilaterally negotiated `QCTL` per-viewer Auto/Sharp/Smooth quality control with strict fail-closed message parsing, independent session rate and chroma policy, per-host native and session-scoped browser pickers, host default fallback for older peers, and active viewer-mode diagnostics.
 - Add SPKI-pinned QUIC-first direct tailnet viewing on per-display ports 5911+, with the unchanged single-stream RFB protocol, a transparent two-second TCP fallback, shared session accounting, stable same-publication capability refresh across host recovery, host and viewer transport diagnostics, and opaque Fleet capability forwarding for future WebTransport probing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Keep Share This Mac permission status and start availability synchronized with Screen Recording and Accessibility grants made in System Settings while the sheet is open.
 - Add bilaterally negotiated `QCTL` per-viewer Auto/Sharp/Smooth quality control with strict fail-closed message parsing, independent session rate and chroma policy, per-host native and session-scoped browser pickers, host default fallback for older peers, and active viewer-mode diagnostics.
 - Add SPKI-pinned QUIC-first direct tailnet viewing on per-display ports 5911+, with the unchanged single-stream RFB protocol, a transparent two-second TCP fallback, shared session accounting, stable same-publication capability refresh across host recovery, host and viewer transport diagnostics, and opaque Fleet capability forwarding for future WebTransport probing.
 - Require every direct Share This Mac tailnet listener to authenticate with a per-run in-memory 12-character password through ARD or VNC DES, add bounded source-IP failure backoff and lockout without serializing concurrent transports, native Keychain and browser sessionStorage credential flows with one-time-code autofill semantics, and an explicit relay-only RFB authentication bypass while leaving the owner-authenticated Worker relay wire unchanged.

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/CrabfleetMacApp.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/CrabfleetMacApp.swift
@@ -183,6 +183,7 @@ struct CrabfleetMacApp: App {
     }
     .defaultSize(width: 1_360, height: 860)
     .windowResizability(.contentMinSize)
+    .windowStyle(.hiddenTitleBar)
     .commands {
       CommandGroup(replacing: .newItem) {}
 
@@ -248,6 +249,7 @@ private struct CrabfleetAppRoot: View {
         )
       }
     }
+    .background(WindowConfigurator())
     .frame(minWidth: 1_080, minHeight: 680)
     .preferredColorScheme(.dark)
     .task(id: localOnly) {
@@ -266,4 +268,24 @@ private struct CrabfleetAppRoot: View {
     }
     localOnly = false
   }
+}
+
+private struct WindowConfigurator: NSViewRepresentable {
+  func makeNSView(context: Context) -> NSView {
+    let view = NSView()
+    DispatchQueue.main.async {
+      guard let window = view.window else { return }
+      window.backgroundColor = NSColor(
+        srgbRed: 0.018,
+        green: 0.023,
+        blue: 0.026,
+        alpha: 1
+      )
+      window.titlebarSeparatorStyle = .none
+      window.isOpaque = true
+    }
+    return view
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {}
 }

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/FleetRootView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/FleetRootView.swift
@@ -102,6 +102,7 @@ struct FleetRootView: View {
           )
         }
         .background(DeckBackground())
+        .ignoresSafeArea(.container, edges: .top)
       }
     }
     .tint(.mint)
@@ -310,6 +311,8 @@ private struct DesktopSourceRail: View {
   let shareThisMac: () -> Void
   let quickConnect: () -> Void
 
+  @State private var isSourcePickerHovering = false
+
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
       HStack(spacing: 11) {
@@ -334,7 +337,7 @@ private struct DesktopSourceRail: View {
         }
       }
       .padding(.horizontal, 17)
-      .padding(.top, 18)
+      .padding(.top, 34)
       .padding(.bottom, 20)
 
       VStack(spacing: 4) {
@@ -383,9 +386,17 @@ private struct DesktopSourceRail: View {
         }
         .padding(.horizontal, 10)
         .frame(height: 40)
-        .background(.white.opacity(0.045), in: RoundedRectangle(cornerRadius: 8))
+        .background(
+          .white.opacity(isSourcePickerHovering ? 0.07 : 0.045),
+          in: RoundedRectangle(cornerRadius: 8)
+        )
       }
       .menuStyle(.borderlessButton)
+      .onHover { hovering in
+        withAnimation(.easeOut(duration: 0.12)) {
+          isSourcePickerHovering = hovering
+        }
+      }
       .padding(.horizontal, 12)
       .padding(.bottom, 10)
 
@@ -435,7 +446,11 @@ private struct DesktopSourceRail: View {
       .padding(12)
     }
     .frame(width: 224)
-    .background(Color(red: 0.052, green: 0.058, blue: 0.062).opacity(0.98))
+    .background(
+      Color(red: 0.052, green: 0.058, blue: 0.062)
+        .opacity(0.98)
+        .ignoresSafeArea(edges: .top)
+    )
   }
 
   private func count(for scope: DesktopScope) -> Int {
@@ -455,6 +470,8 @@ private struct SourceRailButton: View {
   let isSelected: Bool
   let action: () -> Void
 
+  @State private var isHovering = false
+
   var body: some View {
     Button(action: action) {
       HStack(spacing: 9) {
@@ -472,7 +489,11 @@ private struct SourceRailButton: View {
       .frame(height: 34)
       .background(
         RoundedRectangle(cornerRadius: 8, style: .continuous)
-          .fill(isSelected ? Color.white.opacity(0.08) : .clear)
+          .fill(
+            isSelected
+              ? Color.mint.opacity(0.09)
+              : (isHovering ? Color.white.opacity(0.04) : .clear)
+          )
       )
       .overlay(alignment: .leading) {
         if isSelected {
@@ -481,6 +502,11 @@ private struct SourceRailButton: View {
       }
     }
     .buttonStyle(.plain)
+    .onHover { hovering in
+      withAnimation(.easeOut(duration: 0.12)) {
+        isHovering = hovering
+      }
+    }
   }
 }
 
@@ -494,6 +520,8 @@ private struct DesktopDeck: View {
   let refresh: () -> Void
   let quickConnect: () -> Void
   let focus: (DesktopTarget.ID) -> Void
+
+  @FocusState private var isSearchFocused: Bool
 
   private let columns = [
     GridItem(.adaptive(minimum: 292, maximum: 440), spacing: 17, alignment: .top)
@@ -518,6 +546,7 @@ private struct DesktopDeck: View {
           TextField("Search computers", text: $query)
             .textFieldStyle(.plain)
             .frame(width: 176)
+            .focused($isSearchFocused)
           if !query.isEmpty {
             Button {
               query = ""
@@ -532,12 +561,27 @@ private struct DesktopDeck: View {
         .padding(.horizontal, 10)
         .frame(height: 32)
         .background(.white.opacity(0.055), in: RoundedRectangle(cornerRadius: 8))
+        .overlay {
+          RoundedRectangle(cornerRadius: 8)
+            .stroke(
+              isSearchFocused ? Color.mint.opacity(0.4) : .clear,
+              lineWidth: 1
+            )
+        }
 
         Button(action: refresh) {
-          Image(systemName: "arrow.clockwise")
-            .opacity(isRefreshing ? 0.45 : 1)
+          Group {
+            if isRefreshing {
+              ProgressView()
+                .controlSize(.small)
+            } else {
+              Image(systemName: "arrow.clockwise")
+            }
+          }
+          .frame(width: 16, height: 16)
         }
         .buttonStyle(.borderless)
+        .disabled(isRefreshing)
         .help("Refresh Crabfleet")
 
         Button("Connect", systemImage: "plus", action: quickConnect)
@@ -545,16 +589,21 @@ private struct DesktopDeck: View {
           .controlSize(.small)
       }
       .padding(.horizontal, 22)
-      .padding(.vertical, 17)
+      .padding(.top, 20)
+      .padding(.bottom, 14)
 
       Divider().overlay(.white.opacity(0.055))
 
       if targets.isEmpty {
-        ContentUnavailableView(
-          "No desktops here",
-          systemImage: "rectangle.slash",
-          description: Text("Change the source or add a VNC connection.")
-        )
+        ContentUnavailableView {
+          Label("No desktops here", systemImage: "rectangle.slash")
+        } description: {
+          Text("Change the source or add a VNC connection.")
+        } actions: {
+          Button("Quick Connect", systemImage: "plus", action: quickConnect)
+            .buttonStyle(.borderedProminent)
+            .controlSize(.regular)
+        }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
       } else {
         ScrollView {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
@@ -690,9 +690,8 @@ final class PrivateMacShareController: ObservableObject {
 
   @Published private(set) var identity: TailnetIdentity?
   @Published private(set) var phase: Phase = .idle
-  @Published private(set) var screenRecordingGranted = CGPreflightScreenCaptureAccess()
-  @Published private(set) var accessibilityGranted = MacRemoteInputController
-    .isAccessibilityGranted
+  @Published private(set) var screenRecordingGranted: Bool
+  @Published private(set) var accessibilityGranted: Bool
   @Published private(set) var connectedPeer: String?
   @Published private(set) var notice: String?
   @Published private(set) var isRefreshing = false
@@ -785,6 +784,9 @@ final class PrivateMacShareController: ObservableObject {
   private let relayHostURL: ((String) -> URL?)?
   private let runnerInitializationError: Error?
   private let defaults: UserDefaults
+  private let screenRecordingPermissionCheck: () -> Bool
+  private let accessibilityPermissionCheck: () -> Bool
+  private var permissionMonitoringTask: Task<Void, Never>?
   private var displayStacks: [DisplayStack] = []
   private var isRevertingQualityMode = false
   private var qualityModeChangePending = false
@@ -817,8 +819,18 @@ final class PrivateMacShareController: ObservableObject {
     runner: (any TailscaleCommandRunning)? = nil,
     desktopRegistration: (any DesktopHostRegistering)? = CrabfleetDesktopRegistration(),
     registrationLifecycle: DesktopHostRegistrationLifecycle? = nil,
-    defaults: UserDefaults = .standard
+    defaults: UserDefaults = .standard,
+    screenRecordingPermissionCheck: @escaping () -> Bool = {
+      CGPreflightScreenCaptureAccess()
+    },
+    accessibilityPermissionCheck: @escaping () -> Bool = {
+      MacRemoteInputController.isAccessibilityGranted
+    }
   ) {
+    self.screenRecordingPermissionCheck = screenRecordingPermissionCheck
+    self.accessibilityPermissionCheck = accessibilityPermissionCheck
+    screenRecordingGranted = screenRecordingPermissionCheck()
+    accessibilityGranted = accessibilityPermissionCheck()
     self.desktopRegistration = desktopRegistration
     let registrationStateStore = UserDefaultsDesktopHostRegistrationStateStore(defaults: defaults)
     let recoveryScopeProvider = (desktopRegistration as? any DesktopHostRegistrationRecoveryScoping)
@@ -1048,6 +1060,27 @@ final class PrivateMacShareController: ObservableObject {
     if !accessibilityGranted {
       notice = PrivateMacShareError.accessibilityDenied.localizedDescription
     }
+  }
+
+  func startPermissionMonitoring() {
+    guard permissionMonitoringTask == nil else { return }
+    refreshPermissions()
+    permissionMonitoringTask = Task { [weak self] in
+      while !Task.isCancelled {
+        do {
+          try await Task.sleep(for: .seconds(1))
+        } catch {
+          return
+        }
+        guard let self, !Task.isCancelled else { return }
+        self.refreshPermissions()
+      }
+    }
+  }
+
+  func stopPermissionMonitoring() {
+    permissionMonitoringTask?.cancel()
+    permissionMonitoringTask = nil
   }
 
   func start() async {
@@ -1289,9 +1322,16 @@ final class PrivateMacShareController: ObservableObject {
     return try TailnetIdentityPolicy.identity(from: document)
   }
 
-  private func refreshPermissions() {
-    screenRecordingGranted = CGPreflightScreenCaptureAccess()
-    accessibilityGranted = MacRemoteInputController.isAccessibilityGranted
+  func refreshPermissions() {
+    let screenRecordingGranted = screenRecordingPermissionCheck()
+    if self.screenRecordingGranted != screenRecordingGranted {
+      self.screenRecordingGranted = screenRecordingGranted
+    }
+
+    let accessibilityGranted = accessibilityPermissionCheck()
+    if self.accessibilityGranted != accessibilityGranted {
+      self.accessibilityGranted = accessibilityGranted
+    }
   }
 
   private func refreshDisplays() async {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct PrivateMacShareSheet: View {
   @ObservedObject var controller: PrivateMacShareController
   @Environment(\.dismiss) private var dismiss
+  @Environment(\.scenePhase) private var scenePhase
 
   var body: some View {
     VStack(alignment: .leading, spacing: 20) {
@@ -253,6 +254,13 @@ struct PrivateMacShareSheet: View {
     .padding(24)
     .frame(width: 590)
     .task { await controller.refresh() }
+    .onAppear { controller.startPermissionMonitoring() }
+    .onDisappear { controller.stopPermissionMonitoring() }
+    .onChange(of: scenePhase) { _, phase in
+      if phase == .active {
+        controller.refreshPermissions()
+      }
+    }
   }
 
   private var phaseDetail: String {

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import Foundation
 import Network
 import Testing
@@ -1409,6 +1410,48 @@ struct PrivateMacShareTests {
         identityAvailable: true,
         screenRecordingGranted: false
       ))
+  }
+
+  @Test @MainActor
+  func permissionRefreshPublishesOnlyChangedValues() throws {
+    var screenRecordingGranted = false
+    var accessibilityGranted = false
+    let defaults = try #require(
+      UserDefaults(suiteName: "CrabfleetMacTests.\(UUID().uuidString)")
+    )
+    let controller = PrivateMacShareController(
+      runner: nil,
+      desktopRegistration: nil,
+      defaults: defaults,
+      screenRecordingPermissionCheck: { screenRecordingGranted },
+      accessibilityPermissionCheck: { accessibilityGranted }
+    )
+    var screenRecordingUpdates: [Bool] = []
+    var accessibilityUpdates: [Bool] = []
+    let screenRecordingSubscription = controller.$screenRecordingGranted
+      .dropFirst()
+      .sink { screenRecordingUpdates.append($0) }
+    let accessibilitySubscription = controller.$accessibilityGranted
+      .dropFirst()
+      .sink { accessibilityUpdates.append($0) }
+
+    controller.refreshPermissions()
+    #expect(screenRecordingUpdates.isEmpty)
+    #expect(accessibilityUpdates.isEmpty)
+
+    screenRecordingGranted = true
+    controller.refreshPermissions()
+    controller.refreshPermissions()
+    #expect(screenRecordingUpdates == [true])
+    #expect(accessibilityUpdates.isEmpty)
+
+    accessibilityGranted = true
+    controller.refreshPermissions()
+    controller.refreshPermissions()
+    #expect(screenRecordingUpdates == [true])
+    #expect(accessibilityUpdates == [true])
+
+    withExtendedLifetime((screenRecordingSubscription, accessibilitySubscription)) {}
   }
 
   @Test


### PR DESCRIPTION
## Summary

Two Mac-app fixes surfaced during the live Miniclaw test run.

### Live permission monitoring (functional)
The Share This Mac sheet did not react when Screen Recording / Accessibility were granted in System Settings while the app was running — the rows and the "Start Private Share" enablement stayed stale until a manual re-trigger. Added a lifecycle-aware ~1s poll (started on the sheet's `onAppear`, stopped on `onDisappear`, plus a refresh on app-activate) that re-reads the TCC state; `@Published` values now change only when the underlying grant changes, so there's no SwiftUI churn. Verified live: granting Screen Recording flips the row to "Allowed" and enables the share within ~1s, no click needed.

### Title-bar blend + top-band polish (design)
`.windowStyle(.hiddenTitleBar)` plus a tiny `WindowConfigurator` AppKit bridge (dark window background, no titlebar separator) so the app's dark chrome runs edge-to-edge to the top and the traffic lights float over the sidebar — no grey OS bar. Sidebar + deck header reclaim the top band via top-edge safe-area handling and adjusted padding (rail top 34pt for traffic-light clearance, deck header 20/14pt). Low-risk polish: sidebar row hover + mint selection tint, refresh spinner, empty-state Quick Connect action, source-picker hover, search focus ring.

## Proof

- `pnpm check` / `pnpm test`: 969/969
- `pnpm macos:test`: RoyalVNCKit 119, app tests pass (excluding the pre-existing load-flaky QUIC timing suite, which this branch does not touch — verified the diff has zero QUIC/transport code; only "Quick Connect" matches the keyword)
- Signed release bundle builds and passes strict codesign verification
- Autoreview clean (0.92)
- Verified live on Miniclaw via screenshots: titlebar blended, permission rows update live, Start Private Share enables
