### PR TITLE
fix(macos): warn when this Mac has a duplicate tailnet registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Warn without blocking Share This Mac when Tailscale reports a numerically suffixed duplicate registration, while continuing to advertise the current `Self` node address.
 - Blend the macOS title bar into the desktop deck, align its unified top band, and add hover, focus, refresh-progress, and empty-state interaction polish.
 - Keep Share This Mac permission status and start availability synchronized with Screen Recording and Accessibility grants made in System Settings while the sheet is open.
 - Add bilaterally negotiated `QCTL` per-viewer Auto/Sharp/Smooth quality control with strict fail-closed message parsing, independent session rate and chroma policy, per-host native and session-scoped browser pickers, host default fallback for older peers, and active viewer-mode diagnostics.

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
@@ -689,6 +689,7 @@ final class PrivateMacShareController: ObservableObject {
   nonisolated static let browserAccessDefaultsKey = "org.openclaw.crabfleet.share.browser-access"
 
   @Published private(set) var identity: TailnetIdentity?
+  @Published private(set) var tailnetRegistrationHealth: TailnetRegistrationHealth = .ok
   @Published private(set) var phase: Phase = .idle
   @Published private(set) var screenRecordingGranted: Bool
   @Published private(set) var accessibilityGranted: Bool
@@ -883,6 +884,21 @@ final class PrivateMacShareController: ObservableObject {
     connectionAddresses.first
   }
 
+  var tailnetWarning: String? {
+    guard
+      case .duplicateHostname(let advertised, let hostName, let matchingPeerPresent) =
+        tailnetRegistrationHealth
+    else { return nil }
+    guard let advertised = advertised ?? identity?.ipv4Address else { return nil }
+    let peerDetail = matchingPeerPresent
+      ? " Another registered node also uses the hostname \(hostName)."
+      : ""
+    return
+      "This Mac appears registered more than once in your tailnet (advertising \(advertised))."
+      + peerDetail
+      + " If viewers can’t connect, remove the duplicate node in the Tailscale admin console or re-authenticate this Mac."
+  }
+
   var connectionAddresses: [String] {
     guard let identity else { return [] }
     return activePlans.map { identity.vncAddress(port: Int($0.port)) }
@@ -1003,9 +1019,12 @@ final class PrivateMacShareController: ObservableObject {
     defer { finishRefresh() }
     notice = nil
     do {
-      identity = try await fetchIdentity()
+      let resolution = try await fetchIdentity()
+      identity = resolution.identity
+      tailnetRegistrationHealth = resolution.registrationHealth
     } catch {
       identity = nil
+      tailnetRegistrationHealth = .ok
       notice = error.localizedDescription
     }
     refreshPermissions()
@@ -1095,12 +1114,14 @@ final class PrivateMacShareController: ObservableObject {
     await waitForRefreshCompletion()
     guard canContinueStarting(generation) else { return }
     do {
-      let loadedIdentity = try await fetchIdentity()
+      let resolution = try await fetchIdentity()
       guard canContinueStarting(generation) else { return }
-      identity = loadedIdentity
+      identity = resolution.identity
+      tailnetRegistrationHealth = resolution.registrationHealth
     } catch {
       guard canContinueStarting(generation) else { return }
       identity = nil
+      tailnetRegistrationHealth = .ok
       phase = .failed
       notice = error.localizedDescription
       return
@@ -1310,7 +1331,10 @@ final class PrivateMacShareController: ObservableObject {
     case accessibility
   }
 
-  private func fetchIdentity() async throws -> TailnetIdentity {
+  private func fetchIdentity() async throws -> (
+    identity: TailnetIdentity,
+    registrationHealth: TailnetRegistrationHealth
+  ) {
     guard let runner else {
       throw runnerInitializationError ?? PrivateMacShareError.tailscaleNotInstalled
     }
@@ -1319,7 +1343,10 @@ final class PrivateMacShareController: ObservableObject {
       TailscaleStatusDocument.self,
       from: Data(result.standardOutput.utf8)
     )
-    return try TailnetIdentityPolicy.identity(from: document)
+    return (
+      try TailnetIdentityPolicy.identity(from: document),
+      TailnetRegistrationHealthPolicy.health(from: document)
+    )
   }
 
   func refreshPermissions() {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
@@ -65,6 +65,13 @@ struct PrivateMacShareSheet: View {
       }
       .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
 
+      if let warning = controller.tailnetWarning {
+        Label(warning, systemImage: "exclamationmark.triangle.fill")
+          .font(.caption)
+          .foregroundStyle(.orange)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
       VStack(alignment: .leading, spacing: 10) {
         if !controller.availableDisplays.isEmpty {
           VStack(alignment: .leading, spacing: 6) {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetIdentity.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetIdentity.swift
@@ -411,16 +411,77 @@ struct TailscaleStatusDocument: Decodable, Sendable {
     }
   }
 
+  struct PeerNode: Decodable, Sendable {
+    let hostName: String?
+
+    enum CodingKeys: String, CodingKey {
+      case hostName = "HostName"
+    }
+  }
+
   let backendState: String
   let currentTailnet: Tailnet?
   let selfNode: Node?
+  let peerNodes: [String: PeerNode]
   let users: [String: User]
 
   enum CodingKeys: String, CodingKey {
     case backendState = "BackendState"
     case currentTailnet = "CurrentTailnet"
     case selfNode = "Self"
+    case peerNodes = "Peer"
     case users = "User"
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    backendState = try container.decode(String.self, forKey: .backendState)
+    currentTailnet = try container.decodeIfPresent(Tailnet.self, forKey: .currentTailnet)
+    selfNode = try container.decodeIfPresent(Node.self, forKey: .selfNode)
+    users = try container.decode([String: User].self, forKey: .users)
+    peerNodes = (try? container.decode([String: PeerNode].self, forKey: .peerNodes)) ?? [:]
+  }
+}
+
+enum TailnetRegistrationHealth: Equatable, Sendable {
+  case ok
+  case duplicateHostname(
+    advertised: String?,
+    hostName: String,
+    matchingPeerPresent: Bool
+  )
+}
+
+enum TailnetRegistrationHealthPolicy {
+  static func health(from document: TailscaleStatusDocument) -> TailnetRegistrationHealth {
+    guard let node = document.selfNode else { return .ok }
+    var dnsName = node.dnsName
+    while dnsName.last == "." { dnsName.removeLast() }
+    guard
+      let firstLabel = dnsName.split(separator: ".", omittingEmptySubsequences: false).first,
+      !firstLabel.isEmpty,
+      let suffixSeparator = firstLabel.lastIndex(of: "-")
+    else { return .ok }
+
+    let base = firstLabel[..<suffixSeparator]
+    let suffix = firstLabel[firstLabel.index(after: suffixSeparator)...]
+    guard
+      !base.isEmpty,
+      !suffix.isEmpty,
+      suffix.utf8.allSatisfy({ (48...57).contains($0) }),
+      String(base).caseInsensitiveCompare(node.hostName) == .orderedSame
+    else { return .ok }
+
+    let advertised = node.tailscaleIPs.first(where: TailnetIdentityPolicy.isTailscaleIPv4)
+    let matchingPeerPresent = document.peerNodes.values.contains { peer in
+      guard let peerHostName = peer.hostName else { return false }
+      return peerHostName.caseInsensitiveCompare(String(base)) == .orderedSame
+    }
+    return .duplicateHostname(
+      advertised: advertised,
+      hostName: node.hostName,
+      matchingPeerPresent: matchingPeerPresent
+    )
   }
 }
 

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
@@ -1515,6 +1515,113 @@ struct PrivateMacShareTests {
   }
 
   @Test
+  func reportsHealthyNormalTailnetRegistration() throws {
+    let document = try registrationHealthDocument(
+      dnsName: "miniclaw.example.ts.net.",
+      hostName: "miniclaw"
+    )
+
+    #expect(TailnetRegistrationHealthPolicy.health(from: document) == .ok)
+  }
+
+  @Test
+  func detectsSuffixedDuplicateTailnetRegistrationAndMatchingPeer() throws {
+    let document = try registrationHealthDocument(
+      dnsName: "miniclaw-1.example.ts.net.",
+      hostName: "miniclaw",
+      peerHostNames: ["MINICLAW"]
+    )
+
+    #expect(
+      TailnetRegistrationHealthPolicy.health(from: document)
+        == .duplicateHostname(
+          advertised: "100.83.142.121",
+          hostName: "miniclaw",
+          matchingPeerPresent: true
+        )
+    )
+  }
+
+  @Test
+  func detectsSuffixedDuplicateWithoutAnIPv4Address() throws {
+    let json = registrationHealthJSON(
+      dnsName: "miniclaw-1.example.ts.net.",
+      hostName: "miniclaw"
+    ).replacingOccurrences(
+      of: #""TailscaleIPs": ["100.83.142.121", "fd7a:115c:a1e0::1"]"#,
+      with: #""TailscaleIPs": ["fd7a:115c:a1e0::1"]"#
+    )
+    let document = try JSONDecoder().decode(
+      TailscaleStatusDocument.self,
+      from: Data(json.utf8)
+    )
+
+    #expect(
+      TailnetRegistrationHealthPolicy.health(from: document)
+        == .duplicateHostname(
+          advertised: nil,
+          hostName: "miniclaw",
+          matchingPeerPresent: false
+        )
+    )
+  }
+
+  @Test
+  func acceptsHostnameThatLegitimatelyEndsInNumericSuffix() throws {
+    let document = try registrationHealthDocument(
+      dnsName: "miniclaw-1.example.ts.net.",
+      hostName: "miniclaw-1"
+    )
+
+    #expect(TailnetRegistrationHealthPolicy.health(from: document) == .ok)
+  }
+
+  @Test
+  func acceptsMalformedOrEmptyTailnetDNSName() throws {
+    for dnsName in ["", ".", ".miniclaw-1.example.ts.net."] {
+      let document = try registrationHealthDocument(
+        dnsName: dnsName,
+        hostName: "miniclaw",
+        peerHostNames: ["miniclaw"]
+      )
+      #expect(TailnetRegistrationHealthPolicy.health(from: document) == .ok)
+    }
+  }
+
+  @Test @MainActor
+  func refreshPublishesDuplicateTailnetWarningWithoutChangingIdentity() async throws {
+    let output = registrationHealthJSON(
+      dnsName: "miniclaw-1.example.ts.net.",
+      hostName: "miniclaw",
+      peerHostNames: ["miniclaw"]
+    )
+    let defaults = try #require(
+      UserDefaults(suiteName: "CrabfleetMacTests.\(UUID().uuidString)")
+    )
+    let controller = PrivateMacShareController(
+      runner: StaticTailscaleRunner(output: output),
+      desktopRegistration: nil,
+      defaults: defaults,
+      screenRecordingPermissionCheck: { false },
+      accessibilityPermissionCheck: { false }
+    )
+
+    await controller.refresh()
+
+    #expect(controller.identity?.ipv4Address == "100.83.142.121")
+    #expect(
+      controller.tailnetRegistrationHealth
+        == .duplicateHostname(
+          advertised: "100.83.142.121",
+          hostName: "miniclaw",
+          matchingPeerPresent: true
+        )
+    )
+    #expect(controller.tailnetWarning?.contains("appears registered more than once") == true)
+    #expect(controller.tailnetWarning?.contains("advertising 100.83.142.121") == true)
+  }
+
+  @Test
   func derivesGenericStableDesktopHostID() {
     let identity = TailnetIdentity(
       tailnetName: "example.com",
@@ -2534,6 +2641,50 @@ struct PrivateMacShareTests {
 
   private func statusDocument() throws -> TailscaleStatusDocument {
     try JSONDecoder().decode(TailscaleStatusDocument.self, from: Data(statusJSON().utf8))
+  }
+
+  private func registrationHealthDocument(
+    dnsName: String,
+    hostName: String,
+    peerHostNames: [String] = []
+  ) throws -> TailscaleStatusDocument {
+    try JSONDecoder().decode(
+      TailscaleStatusDocument.self,
+      from: Data(
+        registrationHealthJSON(
+          dnsName: dnsName,
+          hostName: hostName,
+          peerHostNames: peerHostNames
+        ).utf8
+      )
+    )
+  }
+
+  private func registrationHealthJSON(
+    dnsName: String,
+    hostName: String,
+    peerHostNames: [String] = []
+  ) -> String {
+    let peers = peerHostNames.enumerated().map { index, peerHostName in
+      "\"peer-\(index)\": { \"HostName\": \"\(peerHostName)\" }"
+    }.joined(separator: ",")
+    return """
+      {
+        "BackendState": "Running",
+        "CurrentTailnet": { "Name": "example.com" },
+        "Self": {
+          "DNSName": "\(dnsName)",
+          "HostName": "\(hostName)",
+          "Online": true,
+          "TailscaleIPs": ["100.83.142.121", "fd7a:115c:a1e0::1"],
+          "UserID": 42
+        },
+        "Peer": { \(peers) },
+        "User": {
+          "42": { "LoginName": "operator@example.com" }
+        }
+      }
+      """
   }
 
   private func desktopIdentity(name: String, address: String) -> TailnetIdentity {


### PR DESCRIPTION
## Summary

Surfaces a common tailnet mis-registration that otherwise fails silently. When a Mac is registered twice in a tailnet, Tailscale appends a `-N` suffix to the duplicate's DNSName (e.g. Self `HostName = miniclaw` but `DNSName = miniclaw-1.<tailnet>.ts.net`), and the daemon can end up bound to a registration whose advertised IP isn't the routable one — so a viewer just fails to connect with no explanation.

- Adds a pure, unit-tested detector (`TailnetRegistrationHealthPolicy`) over the parsed `tailscale status --json`: first DNS label matching `^base-<digits>$` where `base` == `HostName` (case-insensitive) → duplicate; corroborated by any other node sharing the base hostname. Fail-open — malformed/uncertain input is `.ok`, no false alarms.
- Does **not** change what address is advertised (still Self's IPv4) — this is detection + a non-blocking caution only.
- Share This Mac sheet shows a non-blocking orange warning pointing the user to remove the duplicate node or re-authenticate; sharing still works.

Found during the live Miniclaw E2E run, where this Mac was registered as both `miniclaw` (100.88.58.88) and `miniclaw-1` (100.83.142.121).

## Proof

- `pnpm check` / `pnpm test`: 969/969
- Focused: detector 6/6, PrivateMacShareTests 91/91, QUIC 10/10 (focused)
- Autoreview clean
- Note: full `pnpm macos:test` hit an environmental macOS 27-beta CoreImage/Metal hang (`MTLCopyAllDevices` hangs standalone too); all app suites pass focused.
