### PR TITLE
feat(macos): redesign Share This Mac sheet with custom deck-style controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Redesign the Share This Mac sheet in the app's dark deck design language: pulsing readiness beacons with two-line status rows, custom capsule switches with icon tiles and captions, an animated segmented quality control, a live phase badge, and a restyled connect card — no behavior changes.
 - Fix the Crabfleet Connect Linux X11 backend disabling capture entirely on keyboards with multiple XKB groups: bind only the primary group's base/shift levels so real screen capture and input injection work instead of silently falling back to the synthetic test pattern (validated on a headless Xvfb X server: real 1920x1080 Tight framebuffer + XTest pointer injection).
 
 - Add opt-in single-folder sharing to Share This Mac with security-scoped bookmark persistence, negotiated `FSH1` browsing, bounded native and browser download/upload streams, strict realpath containment, 512 MiB file and 256 KiB chunk limits, root-local temporary uploads with atomic rename and teardown cleanup, and host-controlled remote writes.

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
@@ -6,30 +6,42 @@ struct PrivateMacShareSheet: View {
   @Environment(\.dismiss) private var dismiss
   @Environment(\.scenePhase) private var scenePhase
 
+  @State private var contentHeight: CGFloat = 0
+
   var body: some View {
-    VStack(alignment: .leading, spacing: 16) {
-      header
-      readinessSection
+    ScrollView {
+      VStack(alignment: .leading, spacing: 16) {
+        header
+        readinessSection
 
-      if let warning = controller.tailnetWarning {
-        Label(warning, systemImage: "exclamationmark.triangle.fill")
-          .font(.caption)
-          .foregroundStyle(.orange)
-          .fixedSize(horizontal: false, vertical: true)
+        if let warning = controller.tailnetWarning {
+          Label(warning, systemImage: "exclamationmark.triangle.fill")
+            .font(.caption)
+            .foregroundStyle(.orange)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+
+        sharingSection
+        optionsSection
+
+        if controller.phase.isRunning, !controller.connectionAddresses.isEmpty {
+          connectSection
+        }
+
+        assurance
+        footer
       }
-
-      sharingSection
-      optionsSection
-
-      if controller.phase.isRunning, !controller.connectionAddresses.isEmpty {
-        connectSection
+      .padding(24)
+      .background {
+        GeometryReader { proxy in
+          Color.clear.preference(key: SheetContentHeightKey.self, value: proxy.size.height)
+        }
       }
-
-      assurance
-      footer
     }
-    .padding(24)
+    .scrollBounceBehavior(.basedOnSize)
+    .onPreferenceChange(SheetContentHeightKey.self) { contentHeight = $0 }
     .frame(width: 600)
+    .frame(height: contentHeight > 0 ? min(contentHeight, Self.maxSheetHeight) : nil)
     .background {
       LinearGradient(
         colors: [
@@ -39,6 +51,7 @@ struct PrivateMacShareSheet: View {
         startPoint: .topLeading,
         endPoint: .bottomTrailing)
     }
+    .preferredColorScheme(.dark)
     .tint(.mint)
     .toggleStyle(ShareToggleStyle())
     .task { await controller.refresh() }
@@ -479,6 +492,12 @@ struct PrivateMacShareSheet: View {
     }
   }
 
+  // Sheets cannot be moved on screen, so cap height below common laptop displays
+  // and let the content scroll instead of clipping the footer controls.
+  private static var maxSheetHeight: CGFloat {
+    max(480, (NSScreen.main?.visibleFrame.height ?? 900) - 120)
+  }
+
   private var phaseDetail: String {
     let viewers =
       controller.connectedViewerCount == 1
@@ -500,6 +519,13 @@ struct PrivateMacShareSheet: View {
       return "\(controller.phase.title) · \(peer)"
     }
     return controller.phase.title
+  }
+}
+
+private struct SheetContentHeightKey: PreferenceKey {
+  static var defaultValue: CGFloat = 0
+  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+    value = max(value, nextValue())
   }
 }
 

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
@@ -7,65 +7,9 @@ struct PrivateMacShareSheet: View {
   @Environment(\.scenePhase) private var scenePhase
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 20) {
-      HStack(spacing: 12) {
-        ZStack {
-          RoundedRectangle(cornerRadius: 10, style: .continuous)
-            .fill(.mint.opacity(0.1))
-          Image(systemName: "display.and.arrow.down")
-            .font(.system(size: 20, weight: .light))
-            .foregroundStyle(.mint)
-        }
-        .frame(width: 42, height: 42)
-
-        VStack(alignment: .leading, spacing: 2) {
-          Text("Share This Mac")
-            .font(.title3.weight(.semibold))
-          Text("App-owned remote desktop, restricted to your current Tailscale identity.")
-            .foregroundStyle(.secondary)
-        }
-      }
-
-      VStack(spacing: 1) {
-        ShareStatusRow(
-          title: "Tailscale tailnet",
-          detail: controller.identity.map {
-            "\($0.tailnetName) · \($0.loginName) · \($0.ipv4Address)"
-          } ?? "Not verified",
-          isReady: controller.identity != nil
-        )
-        ShareStatusRow(
-          title: controller.capturePermissionKind.title,
-          detail: controller.capturePermissionDetail,
-          isReady: controller.capturePermissionGranted,
-          actionTitle: controller.capturePermissionGranted
-            ? nil
-            : (controller.capturePermissionKind == .remoteDesktop ? "Open Settings" : "Allow")
-        ) {
-          Task { await controller.requestCapturePermission() }
-        }
-        ShareStatusRow(
-          title: "Remote control",
-          detail: controller.accessibilityGranted
-            ? "Accessibility allowed"
-            : "Optional · view-only without it",
-          isReady: controller.accessibilityGranted,
-          actionTitle: controller.accessibilityGranted ? nil : "Allow"
-        ) {
-          controller.requestAccessibilityPermission()
-        }
-        ShareStatusRow(
-          title: "Private desktop",
-          detail: phaseDetail,
-          isReady: controller.phase.isRunning
-        )
-        ShareStatusRow(
-          title: "Crabfleet registry",
-          detail: controller.registryPhase.detail,
-          isReady: controller.registryPhase.isReady
-        )
-      }
-      .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    VStack(alignment: .leading, spacing: 16) {
+      header
+      readinessSection
 
       if let warning = controller.tailnetWarning {
         Label(warning, systemImage: "exclamationmark.triangle.fill")
@@ -74,187 +18,410 @@ struct PrivateMacShareSheet: View {
           .fixedSize(horizontal: false, vertical: true)
       }
 
-      VStack(alignment: .leading, spacing: 10) {
-        if !controller.availableDisplays.isEmpty {
-          VStack(alignment: .leading, spacing: 6) {
-            Text("Shared displays")
-              .font(.caption.weight(.semibold))
-            ForEach(controller.availableDisplays) { display in
+      sharingSection
+      optionsSection
+
+      if controller.phase.isRunning, !controller.connectionAddresses.isEmpty {
+        connectSection
+      }
+
+      assurance
+      footer
+    }
+    .padding(24)
+    .frame(width: 600)
+    .background {
+      LinearGradient(
+        colors: [
+          Color(red: 0.035, green: 0.041, blue: 0.045),
+          Color(red: 0.018, green: 0.023, blue: 0.026),
+        ],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing)
+    }
+    .tint(.mint)
+    .toggleStyle(ShareToggleStyle())
+    .task { await controller.refresh() }
+    .onAppear { controller.startPermissionMonitoring() }
+    .onDisappear { controller.stopPermissionMonitoring() }
+    .onChange(of: scenePhase) { _, phase in
+      if phase == .active {
+        controller.refreshPermissions()
+      }
+    }
+  }
+
+  private var header: some View {
+    HStack(spacing: 12) {
+      ZStack {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .fill(
+            LinearGradient(
+              colors: [.mint.opacity(0.28), .mint.opacity(0.08)],
+              startPoint: .topLeading,
+              endPoint: .bottomTrailing))
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .strokeBorder(.mint.opacity(0.35), lineWidth: 1)
+        Image(systemName: "display.and.arrow.down")
+          .font(.system(size: 19, weight: .medium))
+          .foregroundStyle(.mint)
+      }
+      .frame(width: 44, height: 44)
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text("Share This Mac")
+          .font(.title3.weight(.semibold))
+        Text("App-owned remote desktop, restricted to your current Tailscale identity.")
+          .font(.system(size: 11.5, design: .rounded))
+          .foregroundStyle(.secondary)
+      }
+
+      Spacer()
+      SharePhaseBadge(phase: controller.phase)
+    }
+  }
+
+  private var readinessSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      ShareSectionHeader(title: "Readiness")
+      ShareCard {
+        VStack(spacing: 0) {
+          ShareStatusRow(
+            title: "Tailscale tailnet",
+            detail: controller.identity.map {
+              "\($0.tailnetName) · \($0.loginName) · \($0.ipv4Address)"
+            } ?? "Not verified",
+            isReady: controller.identity != nil,
+            truncationMode: .middle)
+          ShareCardDivider()
+          ShareStatusRow(
+            title: controller.capturePermissionKind.title,
+            detail: controller.capturePermissionDetail,
+            isReady: controller.capturePermissionGranted,
+            actionTitle: controller.capturePermissionGranted
+              ? nil
+              : (controller.capturePermissionKind == .remoteDesktop ? "Open Settings" : "Allow")
+          ) {
+            Task { await controller.requestCapturePermission() }
+          }
+          ShareCardDivider()
+          ShareStatusRow(
+            title: "Remote control",
+            detail: controller.accessibilityGranted
+              ? "Accessibility allowed"
+              : "Optional · view-only without it",
+            isReady: controller.accessibilityGranted,
+            actionTitle: controller.accessibilityGranted ? nil : "Allow"
+          ) {
+            controller.requestAccessibilityPermission()
+          }
+          ShareCardDivider()
+          ShareStatusRow(
+            title: "Private desktop",
+            detail: phaseDetail,
+            isReady: controller.phase.isRunning,
+            isPulsing: controller.phase == .starting)
+          ShareCardDivider()
+          ShareStatusRow(
+            title: "Crabfleet registry",
+            detail: controller.registryPhase.detail,
+            isReady: controller.registryPhase.isReady,
+            isPulsing: controller.registryPhase == .registering)
+        }
+      }
+    }
+  }
+
+  private var sharingSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      ShareSectionHeader(title: "Sharing")
+      ShareCard {
+        VStack(spacing: 0) {
+          if !controller.availableDisplays.isEmpty {
+            ForEach(Array(controller.availableDisplays.enumerated()), id: \.element.id) {
+              index, display in
+              let isSelected = controller.selectedDisplayIDs.contains(display.id)
               Toggle(
-                display.detail,
                 isOn: Binding(
                   get: { controller.selectedDisplayIDs.contains(display.id) },
                   set: { controller.setDisplay(display.id, selected: $0) }
                 )
-              )
+              ) {
+                ShareToggleLabel(
+                  systemName: "display",
+                  title: display.detail,
+                  isActive: isSelected)
+              }
               .disabled(
                 controller.phase.isRunning
-                  || (!controller.selectedDisplayIDs.contains(display.id)
-                    && controller.selectedDisplayIDs.count >= 4)
-                  || (controller.selectedDisplayIDs.contains(display.id)
-                    && controller.selectedDisplayIDs.count == 1)
+                  || (!isSelected && controller.selectedDisplayIDs.count >= 4)
+                  || (isSelected && controller.selectedDisplayIDs.count == 1)
               )
+              .help("Share up to four displays; stop sharing to change the selection.")
+
+              if index < controller.availableDisplays.count - 1 {
+                ShareCardDivider()
+              }
             }
+            ShareCardDivider()
           }
-          .help("Share up to four displays; stop sharing to change the selection.")
-        }
 
-        Picker("Default quality", selection: $controller.qualityMode) {
-          ForEach(ShareQualityMode.allCases) { mode in
-            Text(mode.title).tag(mode)
+          VStack(alignment: .leading, spacing: 7) {
+            Text("Default quality")
+              .font(.system(size: 12.5, weight: .medium, design: .rounded))
+            ShareSegmentedControl(
+              selection: $controller.qualityMode,
+              options: ShareQualityMode.allCases,
+              title: { $0.title })
           }
-        }
-        .pickerStyle(.segmented)
-        .help("Default for older viewers; capable viewers choose their own quality.")
+          .padding(14)
+          .help("Default for older viewers; capable viewers choose their own quality.")
 
-        if !controller.viewerSessions.isEmpty {
-          VStack(alignment: .leading, spacing: 5) {
-            Text("Viewer sessions")
-              .font(.caption.weight(.semibold))
-            ForEach(controller.viewerSessions) { viewer in
+          if !controller.viewerSessions.isEmpty {
+            ShareCardDivider(leadingInset: 14)
+            Text("VIEWER SESSIONS")
+              .font(.system(size: 9, weight: .bold, design: .monospaced))
+              .tracking(0.8)
+              .foregroundStyle(.secondary)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .padding(.horizontal, 14)
+              .padding(.vertical, 9)
+
+            ForEach(Array(controller.viewerSessions.enumerated()), id: \.element.id) {
+              index, viewer in
+              if index > 0 {
+                ShareCardDivider(leadingInset: 14)
+              }
               HStack(spacing: 8) {
                 Text(viewer.transport)
                   .font(.system(size: 9, weight: .bold, design: .monospaced))
+                  .foregroundStyle(.mint)
                   .padding(.horizontal, 6)
                   .padding(.vertical, 3)
                   .background(.mint.opacity(0.12), in: Capsule())
                 Text("\(viewer.display) · \(viewer.peer)")
+                  .font(.system(size: 11.5, design: .rounded))
                   .lineLimit(1)
                 Spacer()
                 Text(viewer.qualityMode.title)
+                  .font(.system(size: 11.5, design: .rounded))
                   .foregroundStyle(.secondary)
               }
-              .font(.caption)
+              .padding(.horizontal, 14)
+              .padding(.vertical, 9)
             }
           }
         }
+      }
+    }
+  }
 
-        Toggle(
-          "Sync clipboard with the connected device",
-          isOn: $controller.clipboardSyncEnabled
-        )
-        .disabled(controller.phase.isRunning)
-        .help("Text copied on either Mac is available on the other while connected.")
+  private var optionsSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      ShareSectionHeader(title: "Options")
+      ShareCard {
+        VStack(spacing: 0) {
+          Toggle(isOn: $controller.clipboardSyncEnabled) {
+            ShareToggleLabel(
+              systemName: "arrow.triangle.2.circlepath.doc.on.clipboard",
+              fallbackSystemName: "doc.on.clipboard",
+              title: "Sync clipboard",
+              caption: "Text copied on either Mac is available on the other.",
+              isActive: controller.clipboardSyncEnabled)
+          }
+          .disabled(controller.phase.isRunning)
+          .help("Text copied on either Mac is available on the other while connected.")
+          ShareCardDivider()
 
-        HStack(spacing: 10) {
           Toggle(
-            "Share a folder",
             isOn: Binding(
               get: { controller.sharedFolderName != nil },
               set: { enabled in
                 if enabled { controller.chooseSharedFolder() } else { controller.stopSharingFolder() }
               }
             )
-          )
+          ) {
+            ShareToggleLabel(
+              systemName: "folder",
+              title: "Share a folder",
+              caption: controller.sharedFolderName.map { "Sharing \($0)" }
+                ?? "Let capable viewers browse, download, and upload one folder.",
+              isActive: controller.sharedFolderName != nil)
+          }
           .disabled(controller.phase.isRunning)
-          Spacer()
+          .help("Lets capable viewers browse, download, and upload only inside this folder.")
+
           if let name = controller.sharedFolderName {
-            Label(name, systemImage: "folder.fill")
-              .foregroundStyle(.secondary)
-              .lineLimit(1)
-            Button("Change") { controller.chooseSharedFolder() }
+            HStack(spacing: 10) {
+              Label(name, systemImage: "folder.fill")
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+              Spacer()
+              Button("Change") { controller.chooseSharedFolder() }
+                .disabled(controller.phase.isRunning)
+              Button("Stop sharing folder", role: .destructive) {
+                controller.stopSharingFolder()
+              }
               .disabled(controller.phase.isRunning)
-            Button("Stop sharing folder", role: .destructive) {
-              controller.stopSharingFolder()
+            }
+            .padding(.horizontal, 14)
+            .padding(.bottom, 10)
+
+            ShareCardDivider(leadingInset: 14)
+            Toggle(isOn: $controller.allowRemoteFolderWrites) {
+              ShareToggleLabel(
+                systemName: "square.and.arrow.down",
+                title: "Allow remote uploads",
+                caption: "Allow new folders; completed uploads become visible atomically.",
+                isActive: controller.allowRemoteFolderWrites)
             }
             .disabled(controller.phase.isRunning)
-          }
-        }
-        .help("Lets capable viewers browse, download, and upload only inside this folder.")
-
-        if controller.sharedFolderName != nil {
-          Toggle("Allow remote uploads and new folders", isOn: $controller.allowRemoteFolderWrites)
-            .disabled(controller.phase.isRunning)
             .help("Uploads use a temporary file and become visible only after an atomic finish.")
-        }
+          }
+          ShareCardDivider()
 
-        Toggle(
-          "Allow browser access via Crabfleet",
-          isOn: $controller.browserAccessEnabled
-        )
-        .disabled(controller.registryPhase == .notConfigured)
-        .help("Publishes an authenticated browser relay while this private share is running.")
+          Toggle(isOn: $controller.browserAccessEnabled) {
+            ShareToggleLabel(
+              systemName: "globe",
+              title: "Browser access",
+              caption: "Authenticated web relay via your Crabfleet registry.",
+              isActive: controller.browserAccessEnabled)
+          }
+          .disabled(controller.registryPhase == .notConfigured)
+          .help("Publishes an authenticated browser relay while this private share is running.")
+          ShareCardDivider()
 
-        Toggle(
-          "View only (ignore remote input)",
-          isOn: $controller.viewOnlyEnabled
-        )
-        .help("Applies immediately and keeps remote keyboard and pointer events from reaching this Mac.")
-
-        Toggle("Stream audio", isOn: $controller.streamAudioEnabled)
-          .help("Streams system audio as AAC when the connected Crabfleet viewer supports it.")
-
-        Toggle(
-          "Start sharing when I log in",
-          isOn: Binding(
-            get: { controller.launchAtLoginEnabled },
-            set: { controller.setLaunchAtLogin($0) }
+          Toggle(isOn: $controller.viewOnlyEnabled) {
+            ShareToggleLabel(
+              systemName: "eye.slash",
+              title: "View only",
+              caption: "Remote keyboard and pointer input never reaches this Mac.",
+              isActive: controller.viewOnlyEnabled)
+          }
+          .help(
+            "Applies immediately and keeps remote keyboard and pointer events from reaching this Mac."
           )
-        )
-        .help("Adds Crabfleet as a login item and starts this private share automatically.")
-      }
-      .toggleStyle(.switch)
-      .controlSize(.small)
+          ShareCardDivider()
 
-      if controller.phase.isRunning, !controller.connectionAddresses.isEmpty {
-        VStack(alignment: .leading, spacing: 10) {
-          Text("CONNECT FROM YOUR OTHER MAC")
-            .font(.system(size: 9, weight: .bold, design: .monospaced))
-            .tracking(0.8)
-            .foregroundStyle(.secondary)
+          Toggle(isOn: $controller.streamAudioEnabled) {
+            ShareToggleLabel(
+              systemName: "speaker.wave.2",
+              title: "Stream audio",
+              caption: "System audio as AAC when the viewer supports it.",
+              isActive: controller.streamAudioEnabled)
+          }
+          .help("Streams system audio as AAC when the connected Crabfleet viewer supports it.")
+          ShareCardDivider()
+
+          Toggle(
+            isOn: Binding(
+              get: { controller.launchAtLoginEnabled },
+              set: { controller.setLaunchAtLogin($0) }
+            )
+          ) {
+            ShareToggleLabel(
+              systemName: "power",
+              title: "Start sharing at login",
+              caption: "Adds a login item and starts this share automatically.",
+              isActive: controller.launchAtLoginEnabled)
+          }
+          .help("Adds Crabfleet as a login item and starts this private share automatically.")
+        }
+      }
+    }
+  }
+
+  private var connectSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      ShareSectionHeader(title: "Connect from your other Mac")
+      ShareCard(tone: .connect) {
+        VStack(spacing: 0) {
           ForEach(Array(controller.connectionAddresses.enumerated()), id: \.offset) {
             index, address in
             HStack(spacing: 10) {
               Text("Display \(index + 1) · \(address)")
-                .font(.system(.body, design: .monospaced))
+                .font(.system(size: 12, design: .monospaced))
                 .textSelection(.enabled)
               Spacer()
-              Button("Copy", systemImage: "doc.on.doc") {
+              Button {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(address, forType: .string)
+              } label: {
+                Image(systemName: "doc.on.doc")
+                  .font(.system(size: 11, weight: .medium))
               }
+              .buttonStyle(ShareCapsuleActionButtonStyle(appearance: .icon))
+              .accessibilityLabel("Copy address")
             }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+
+            ShareCardDivider(leadingInset: 14)
           }
+
           HStack(spacing: 10) {
             Text("Password · \(controller.accessCode)")
-              .font(.system(.body, design: .monospaced))
+              .font(.system(size: 12, design: .monospaced))
               .textSelection(.enabled)
             Spacer()
-            Button("Copy password", systemImage: "doc.on.doc") {
+            Button {
               NSPasteboard.general.clearContents()
               NSPasteboard.general.setString(controller.accessCode, forType: .string)
+            } label: {
+              Image(systemName: "doc.on.doc")
+                .font(.system(size: 11, weight: .medium))
             }
-            Button("Regenerate", systemImage: "arrow.clockwise") {
+            .buttonStyle(ShareCapsuleActionButtonStyle(appearance: .icon))
+            .accessibilityLabel("Copy password")
+
+            Button {
               controller.regenerateAccessCode()
+            } label: {
+              Image(systemName: "arrow.clockwise")
+                .font(.system(size: 11, weight: .medium))
             }
+            .buttonStyle(ShareCapsuleActionButtonStyle(appearance: .icon))
+            .accessibilityLabel("Regenerate password")
+            .help("Regenerate password")
           }
+          .padding(.horizontal, 14)
+          .padding(.vertical, 9)
+
           Text(
             "Open Crabfleet, choose Quick Connect, paste an address, and enter this password. Existing authenticated viewers stay connected after regeneration."
           )
-          .font(.caption)
+          .font(.system(size: 10.5, design: .rounded))
           .foregroundStyle(.secondary)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.horizontal, 14)
+          .padding(.bottom, 12)
         }
-        .padding(14)
-        .background(.mint.opacity(0.07), in: RoundedRectangle(cornerRadius: 10))
       }
+    }
+  }
 
-      if let notice = controller.notice {
-        Label(notice, systemImage: "exclamationmark.triangle")
-          .font(.caption)
-          .foregroundStyle(.orange)
-          .fixedSize(horizontal: false, vertical: true)
-      } else {
-        Label(
-          "No Apple Screen Sharing service is used. The listener binds only to this Mac’s Tailscale address and accepts only another device owned by the same Tailscale user.",
-          systemImage: "lock.shield"
-        )
+  @ViewBuilder
+  private var assurance: some View {
+    if let notice = controller.notice {
+      Label(notice, systemImage: "exclamationmark.triangle")
         .font(.caption)
-        .foregroundStyle(.secondary)
+        .foregroundStyle(.orange)
         .fixedSize(horizontal: false, vertical: true)
-      }
+    } else {
+      Label(
+        "No Apple Screen Sharing service is used. The listener binds only to this Mac’s Tailscale address and accepts only another device owned by the same Tailscale user.",
+        systemImage: "lock.shield"
+      )
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .fixedSize(horizontal: false, vertical: true)
+    }
+  }
 
+  private var footer: some View {
+    VStack(alignment: .leading, spacing: 8) {
       HStack {
-        Menu("Privacy Settings") {
+        Menu {
           Button("Screen Recording") {
             controller.openPrivacySettings(.screenRecording)
           }
@@ -270,7 +437,16 @@ struct PrivateMacShareSheet: View {
             isOn: $controller.experimentalRemoteDesktopCaptureEnabled
           )
           .disabled(controller.phase.isRunning)
+        } label: {
+          HStack(spacing: 4) {
+            Text("Privacy Settings")
+            Image(systemName: "chevron.down")
+              .font(.system(size: 8, weight: .semibold))
+          }
         }
+        .menuStyle(.button)
+        .buttonStyle(ShareCapsuleActionButtonStyle())
+        .fixedSize()
 
         Button("Refresh") {
           Task { await controller.refresh() }
@@ -301,20 +477,11 @@ struct PrivateMacShareSheet: View {
         .font(.caption2)
         .foregroundStyle(.tertiary)
     }
-    .padding(24)
-    .frame(width: 590)
-    .task { await controller.refresh() }
-    .onAppear { controller.startPermissionMonitoring() }
-    .onDisappear { controller.stopPermissionMonitoring() }
-    .onChange(of: scenePhase) { _, phase in
-      if phase == .active {
-        controller.refreshPermissions()
-      }
-    }
   }
 
   private var phaseDetail: String {
-    let viewers = controller.connectedViewerCount == 1
+    let viewers =
+      controller.connectedViewerCount == 1
       ? "1 viewer"
       : "\(controller.connectedViewerCount) viewers"
     if let stats = controller.streamStats, controller.phase == .connected {
@@ -336,32 +503,114 @@ struct PrivateMacShareSheet: View {
   }
 }
 
+private struct SharePhaseBadge: View {
+  let phase: PrivateMacShareController.Phase
+
+  @State private var pulse = false
+
+  private var color: Color {
+    switch phase {
+    case .starting, .stopping: .orange
+    case .sharing, .authorizing, .connected: .mint
+    case .failed: .red
+    case .idle: .secondary
+    }
+  }
+
+  private var isPulsing: Bool {
+    phase == .starting || phase == .stopping
+  }
+
+  var body: some View {
+    HStack(spacing: 5) {
+      Circle()
+        .fill(color)
+        .frame(width: 5, height: 5)
+        .opacity(isPulsing && pulse ? 0.28 : 1)
+      Text(phase.title.uppercased())
+        .font(.system(size: 9, weight: .semibold, design: .rounded))
+        .tracking(0.5)
+    }
+    .foregroundStyle(color)
+    .padding(.horizontal, 8)
+    .padding(.vertical, 5)
+    .background(.white.opacity(0.06), in: Capsule())
+    .onAppear { updatePulse(isPulsing) }
+    .onChange(of: isPulsing) { _, active in updatePulse(active) }
+  }
+
+  private func updatePulse(_ active: Bool) {
+    if active {
+      pulse = false
+      withAnimation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true)) {
+        pulse = true
+      }
+    } else {
+      withAnimation(.easeOut(duration: 0.15)) { pulse = false }
+    }
+  }
+}
+
 private struct ShareStatusRow: View {
   let title: String
   let detail: String
   let isReady: Bool
+  var isPulsing = false
+  var truncationMode: Text.TruncationMode = .tail
   var actionTitle: String?
   var action: () -> Void = {}
 
   var body: some View {
     HStack(spacing: 10) {
-      Image(systemName: isReady ? "checkmark.circle.fill" : "circle.dashed")
-        .foregroundStyle(isReady ? .mint : .orange)
-        .frame(width: 18)
-      Text(title)
-        .font(.system(size: 12, weight: .semibold, design: .rounded))
-      Spacer()
-      Text(detail)
-        .font(.system(size: 11, design: .rounded))
-        .foregroundStyle(.secondary)
-        .lineLimit(1)
+      ShareStatusBeacon(isReady: isReady, isPulsing: isPulsing)
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title)
+          .font(.system(size: 13, weight: .semibold, design: .rounded))
+        Text(detail)
+          .font(.system(size: 11, design: .rounded))
+          .foregroundStyle(.secondary)
+          .lineLimit(2)
+          .truncationMode(truncationMode)
+      }
+
+      Spacer(minLength: 10)
+
       if let actionTitle {
         Button(actionTitle, action: action)
-          .controlSize(.small)
+          .buttonStyle(ShareCapsuleActionButtonStyle())
       }
     }
-    .padding(.horizontal, 12)
-    .frame(height: 42)
-    .background(.white.opacity(0.045))
+    .padding(.horizontal, 14)
+    .padding(.vertical, 10)
+  }
+}
+
+private struct ShareToggleLabel: View {
+  let systemName: String
+  var fallbackSystemName: String?
+  let title: String
+  var caption: String?
+  let isActive: Bool
+
+  var body: some View {
+    HStack(spacing: 10) {
+      ShareIconTile(
+        systemName: systemName,
+        fallbackSystemName: fallbackSystemName,
+        isActive: isActive)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title)
+          .font(.system(size: 12.5, weight: .medium, design: .rounded))
+          .foregroundStyle(.primary)
+          .lineLimit(1)
+        if let caption {
+          Text(caption)
+            .font(.system(size: 10.5, design: .rounded))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+      }
+    }
   }
 }

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/ShareDesignSystem.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/ShareDesignSystem.swift
@@ -1,0 +1,291 @@
+import AppKit
+import SwiftUI
+
+struct ShareCard<Content: View>: View {
+  enum Tone {
+    case standard
+    case connect
+  }
+
+  let tone: Tone
+  @ViewBuilder let content: Content
+
+  init(tone: Tone = .standard, @ViewBuilder content: () -> Content) {
+    self.tone = tone
+    self.content = content()
+  }
+
+  var body: some View {
+    content
+      .background(fill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+      .overlay {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .strokeBorder(stroke, lineWidth: 1)
+      }
+  }
+
+  private var fill: Color {
+    tone == .connect ? .mint.opacity(0.06) : .white.opacity(0.045)
+  }
+
+  private var stroke: Color {
+    tone == .connect ? .mint.opacity(0.18) : .white.opacity(0.07)
+  }
+}
+
+struct ShareSectionHeader: View {
+  let title: String
+
+  var body: some View {
+    Text(title.uppercased())
+      .font(.system(size: 9, weight: .bold, design: .monospaced))
+      .tracking(0.8)
+      .foregroundStyle(.secondary)
+  }
+}
+
+struct ShareCardDivider: View {
+  var leadingInset: CGFloat = 44
+
+  var body: some View {
+    Rectangle()
+      .fill(.white.opacity(0.05))
+      .frame(height: 1)
+      .padding(.leading, leadingInset)
+  }
+}
+
+struct ShareStatusBeacon: View {
+  let isReady: Bool
+  var isPulsing = false
+
+  @State private var pulse = false
+
+  private var color: Color { isReady ? .mint : .orange }
+
+  var body: some View {
+    ZStack {
+      Circle()
+        .fill(color.opacity(0.16))
+        .frame(width: 16, height: 16)
+        .opacity(isPulsing && pulse ? 0.28 : 1)
+      Circle()
+        .fill(color)
+        .frame(width: 6, height: 6)
+    }
+    .frame(width: 18, height: 18)
+    .onAppear { updatePulse(isPulsing) }
+    .onChange(of: isPulsing) { _, active in updatePulse(active) }
+    .accessibilityHidden(true)
+  }
+
+  private func updatePulse(_ active: Bool) {
+    if active {
+      pulse = false
+      withAnimation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true)) {
+        pulse = true
+      }
+    } else {
+      withAnimation(.easeOut(duration: 0.15)) { pulse = false }
+    }
+  }
+}
+
+struct ShareToggleStyle: ToggleStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    ShareToggleBody(configuration: configuration)
+  }
+}
+
+private struct ShareToggleBody: View {
+  let configuration: ShareToggleStyle.Configuration
+
+  @Environment(\.isEnabled) private var isEnabled
+  @State private var isHovering = false
+
+  var body: some View {
+    Button {
+      configuration.isOn.toggle()
+    } label: {
+      HStack(spacing: 12) {
+        configuration.label
+        Spacer(minLength: 12)
+        ZStack {
+          Capsule()
+            .fill(trackFill)
+          Capsule()
+            .strokeBorder(
+              .white.opacity(configuration.isOn ? 0 : 0.14),
+              lineWidth: 1)
+          if isHovering && isEnabled {
+            Capsule().fill(.white.opacity(0.05))
+          }
+          Circle()
+            .fill(.white)
+            .frame(width: 16, height: 16)
+            .shadow(color: .black.opacity(0.35), radius: 2, y: 1)
+            .offset(x: configuration.isOn ? 7 : -7)
+        }
+        .frame(width: 34, height: 20)
+        .animation(
+          .spring(response: 0.25, dampingFraction: 0.8),
+          value: configuration.isOn
+        )
+        .animation(.easeOut(duration: 0.12), value: isHovering)
+      }
+      .contentShape(Rectangle())
+      .padding(.horizontal, 14)
+      .padding(.vertical, 9)
+    }
+    .buttonStyle(.plain)
+    .opacity(isEnabled ? 1 : 0.45)
+    .onHover { hovering in
+      isHovering = isEnabled && hovering
+    }
+    .accessibilityValue(configuration.isOn ? "On" : "Off")
+  }
+
+  private var trackFill: AnyShapeStyle {
+    if configuration.isOn {
+      return AnyShapeStyle(
+        LinearGradient(
+          colors: [.mint, .mint.opacity(0.7)],
+          startPoint: .leading,
+          endPoint: .trailing))
+    }
+    return AnyShapeStyle(Color.white.opacity(0.09))
+  }
+}
+
+struct ShareSegmentedControl<Option: Hashable>: View {
+  @Binding var selection: Option
+  let options: [Option]
+  let title: (Option) -> String
+
+  @Namespace private var selectedSegment
+
+  init(
+    selection: Binding<Option>,
+    options: [Option],
+    title: @escaping (Option) -> String
+  ) {
+    _selection = selection
+    self.options = options
+    self.title = title
+  }
+
+  var body: some View {
+    HStack(spacing: 2) {
+      ForEach(options, id: \.self) { option in
+        Button {
+          withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+            selection = option
+          }
+        } label: {
+          Text(title(option))
+            .font(
+              .system(
+                size: 11.5,
+                weight: option == selection ? .semibold : .medium,
+                design: .rounded)
+            )
+            .foregroundStyle(option == selection ? Color.mint : Color.secondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background {
+              if option == selection {
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                  .fill(.mint.opacity(0.18))
+                  .overlay {
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                      .strokeBorder(.mint.opacity(0.4), lineWidth: 1)
+                  }
+                  .matchedGeometryEffect(id: "selected", in: selectedSegment)
+              }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(option == selection ? .isSelected : .isButton)
+      }
+    }
+    .padding(2)
+    .frame(height: 30)
+    .background(.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: 9, style: .continuous)
+        .strokeBorder(.white.opacity(0.07), lineWidth: 1)
+    }
+  }
+}
+
+struct ShareCapsuleActionButtonStyle: ButtonStyle {
+  enum Appearance {
+    case action
+    case icon
+  }
+
+  var appearance: Appearance = .action
+
+  func makeBody(configuration: Configuration) -> some View {
+    ShareCapsuleActionButton(configuration: configuration, appearance: appearance)
+  }
+}
+
+private struct ShareCapsuleActionButton: View {
+  let configuration: ShareCapsuleActionButtonStyle.Configuration
+  let appearance: ShareCapsuleActionButtonStyle.Appearance
+
+  @Environment(\.isEnabled) private var isEnabled
+  @State private var isHovering = false
+
+  var body: some View {
+    configuration.label
+      .font(.system(size: 11, weight: .semibold, design: .rounded))
+      .foregroundStyle(appearance == .action ? Color.mint : Color.secondary)
+      .frame(
+        width: appearance == .icon ? 26 : nil,
+        height: appearance == .icon ? 26 : nil
+      )
+      .padding(.horizontal, appearance == .action ? 10 : 0)
+      .padding(.vertical, appearance == .action ? 5 : 0)
+      .background {
+        if appearance == .icon {
+          Circle().fill(.white.opacity(isHovering && isEnabled ? 0.15 : 0.07))
+        } else {
+          Capsule().fill(.mint.opacity(isHovering && isEnabled ? 0.24 : 0.14))
+        }
+      }
+      .scaleEffect(configuration.isPressed ? 0.97 : 1)
+      .opacity(isEnabled ? 1 : 0.45)
+      .animation(.easeOut(duration: 0.12), value: isHovering)
+      .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
+      .onHover { hovering in
+        isHovering = isEnabled && hovering
+      }
+  }
+}
+
+struct ShareIconTile: View {
+  let systemName: String
+  var fallbackSystemName: String?
+  let isActive: Bool
+
+  private var resolvedSystemName: String {
+    if NSImage(systemSymbolName: systemName, accessibilityDescription: nil) != nil {
+      return systemName
+    }
+    return fallbackSystemName ?? systemName
+  }
+
+  var body: some View {
+    Image(systemName: resolvedSystemName)
+      .font(.system(size: 12, weight: .medium))
+      .foregroundStyle(isActive ? Color.mint : Color.secondary)
+      .frame(width: 26, height: 26)
+      .background(
+        isActive ? Color.mint.opacity(0.15) : Color.white.opacity(0.06),
+        in: RoundedRectangle(cornerRadius: 7, style: .continuous)
+      )
+      .animation(.easeOut(duration: 0.18), value: isActive)
+  }
+}


### PR DESCRIPTION
## Summary

Complete visual redesign of the Share This Mac sheet. The old sheet was a pile of stock controls — dashed-circle status icons, small stock switches, a stock segmented picker, right-truncated detail text — sitting on flat gray, disconnected from the app's dark deck design language. This PR rebuilds the sheet with a small reusable design system while changing zero behavior.

## What changed

- **New `ShareDesignSystem.swift`**: reusable card container + section headers, hairline row dividers, pulsing status beacons, a custom capsule `ToggleStyle` (gradient mint track, sprung knob, hover/disabled states, full-row hit target), an animated segmented control (`matchedGeometryEffect` selection), capsule action/icon button styles, and state-tinted icon tiles.
- **`PrivateMacShareView.swift` rewrite**: deck-gradient background; header with gradient icon tile and a live phase badge (pulses while starting/stopping); READINESS card with two-line status rows (kills the truncated right-aligned details); SHARING card with display toggles and the new segmented quality control; OPTIONS card with icon + caption rows and the custom switches; mint-toned connect card with icon-only copy/regenerate buttons; the Privacy Settings menu restyled to match.
- **No behavior changes**: every binding, action, disabled rule, help string, keyboard shortcut, pasteboard call, and the scene-phase permission monitoring from #97 are preserved. The old sheet also leaked the stock blue accent when key (no tint inside the sheet) — the redesign pins the app's mint accent.
- **Hardening from review**: the sheet is height-capped to the visible screen with a measured ScrollView (footer controls stay reachable when connect rows and viewer sessions grow — sheets can't be moved to reach clipped content), and `preferredColorScheme(.dark)` is pinned on the sheet presentation so the deck gradient never pairs with light-resolved semantic colors on light-mode Macs.

## Before / after

| Before | After |
| --- | --- |
| ![before](https://gist.githubusercontent.com/steipete/e0a952d4d8d92c7f088bb091e8d41b04/raw/before-redacted.png) | ![after](https://gist.githubusercontent.com/steipete/e0a952d4d8d92c7f088bb091e8d41b04/raw/after-redacted.png) |

(Tailnet identity and display name pixelated.)

## Proof

- `pnpm check` ✓, `pnpm test` ✓, `pnpm macos:test` ✓ (264 tests, 18 suites) — rerun after rebasing onto #97.
- Developer-ID-signed bundle deployed to `/Applications` and exercised live: sheet opens, custom toggles switch with animation, segmented control animates selection, disabled states (single display, unconfigured registry) render dimmed, phase badge shows OFF when idle.
- Codex autoreview clean.
