### PR TITLE
fix(macos): harden tailnet identity resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add opt-in single-folder sharing to Share This Mac with security-scoped bookmark persistence, negotiated `FSH1` browsing, bounded native and browser download/upload streams, strict realpath containment, 512 MiB file and 256 KiB chunk limits, root-local temporary uploads with atomic rename and teardown cleanup, and host-controlled remote writes.
 - Add the Crabfleet Connect foundation with a shared Go RFB 3.8 host core, per-run VNC-DES authentication, Tight/JPEG and client-side cursor/input support, a CI-safe synthetic backend, and a Linux X11 MIT-SHM/XFixes/XTest backend plus cross-compiled CLI, while documenting deferred codecs, Wayland, ARD, audio, and hardware validation.
+- Harden Share This Mac tailnet identity resolution with stable multi-IPv4 selection and candidate exposure, MagicDNS-free hostname fallback, actionable backend-state and malformed-status errors, and an explicit unsupported IPv6-only listener result.
 - Warn without blocking Share This Mac when Tailscale reports a numerically suffixed duplicate registration, while continuing to advertise the current `Self` node address.
 - Blend the macOS title bar into the desktop deck, align its unified top band, and add hover, focus, refresh-progress, and empty-state interaction polish.
 - Keep Share This Mac permission status and start availability synchronized with Screen Recording and Accessibility grants made in System Settings while the sheet is open.

--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ for the exact boundary and run command.
 - Named session grants are owner-managed, time-limited, and independently scoped to read-only or terminal-control access
 - Direct Share This Mac listeners require the per-run password after Tailscale peer authorization; native viewers prefer ARD (registered hosts automatically, copied addresses through the explicit Crabfleet Share toggle) and can remember it in the data-protection Keychain, while browser direct transports use VNC authentication and sessionStorage only. Owner-authenticated Worker relays retain their existing RFB None inner stream.
 - A shared folder is off by default and limited to the security-scoped folder chosen in the host sheet; traversal, absolute paths, and symlink escapes are rejected after realpath containment checks, and uploads become visible only after an atomic finish.
+- Share This Mac resolves multiple local Tailscale IPv4 addresses deterministically, works without MagicDNS by displaying the node hostname, and surfaces actionable sign-in, stopped, starting, malformed-status, and IPv6-only listener errors.
 - Merge policy is stored as intent; Crabfleet does not currently perform merges
 - Runtime tokens are scoped and short-lived
 - Secrets never logged or stored in D1/R2

--- a/docs/macos-native-client.md
+++ b/docs/macos-native-client.md
@@ -91,7 +91,13 @@ Mac-to-Mac path remains on Tailscale; a registered share can additionally use
 an owner-scoped Crabfleet Worker relay for first-party browser access.
 
 1. Tailscale status must report `BackendState=Running`, a valid active tailnet,
-   an online signed-in user, and a CGNAT address in `100.64.0.0/10`.
+   an online signed-in user, and a CGNAT address in `100.64.0.0/10`. When the
+   local node reports multiple eligible IPv4 addresses, Crabfleet sorts them
+   numerically, advertises the lowest stable candidate, and retains the full
+   candidate list for future selection. MagicDNS is optional: an absent, empty,
+   or non-FQDN `DNSName` falls back to `HostName` for display and does not trigger
+   duplicate-registration detection. IPv6-only tailnets are reported as
+   unsupported because the private desktop listener does not yet bind them.
 2. The app captures up to four selected displays (default: main), each at a
    bounded even resolution no larger than 2560×1600. A display with any HEVC or
    H.264 viewer captures at 60 frames per second; Tight/JPEG-only displays use

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareController.swift
@@ -1412,8 +1412,7 @@ final class PrivateMacShareController: ObservableObject {
       throw runnerInitializationError ?? PrivateMacShareError.tailscaleNotInstalled
     }
     let result = try await runner.run(arguments: ["status", "--json"])
-    let document = try JSONDecoder().decode(
-      TailscaleStatusDocument.self,
+    let document = try TailscaleStatusDocument.decode(
       from: Data(result.standardOutput.utf8)
     )
     return (

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetIdentity.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/TailnetIdentity.swift
@@ -380,11 +380,11 @@ private final class TailscaleCommandExecution: @unchecked Sendable {
 
 struct TailscaleStatusDocument: Decodable, Sendable {
   struct Node: Decodable, Sendable {
-    let dnsName: String
-    let hostName: String
-    let online: Bool
+    let dnsName: String?
+    let hostName: String?
+    let online: Bool?
     let tailscaleIPs: [String]
-    let userID: Int64
+    let userID: Int64?
 
     enum CodingKeys: String, CodingKey {
       case dnsName = "DNSName"
@@ -393,10 +393,20 @@ struct TailscaleStatusDocument: Decodable, Sendable {
       case tailscaleIPs = "TailscaleIPs"
       case userID = "UserID"
     }
+
+    init(from decoder: any Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      dnsName = try container.decodeIfPresent(String.self, forKey: .dnsName)
+      hostName = try container.decodeIfPresent(String.self, forKey: .hostName)
+      online = try container.decodeIfPresent(Bool.self, forKey: .online)
+      tailscaleIPs =
+        try container.decodeIfPresent([String].self, forKey: .tailscaleIPs) ?? []
+      userID = try container.decodeIfPresent(Int64.self, forKey: .userID)
+    }
   }
 
   struct Tailnet: Decodable, Sendable {
-    let name: String
+    let name: String?
 
     enum CodingKeys: String, CodingKey {
       case name = "Name"
@@ -404,7 +414,7 @@ struct TailscaleStatusDocument: Decodable, Sendable {
   }
 
   struct User: Decodable, Sendable {
-    let loginName: String
+    let loginName: String?
 
     enum CodingKeys: String, CodingKey {
       case loginName = "LoginName"
@@ -419,7 +429,7 @@ struct TailscaleStatusDocument: Decodable, Sendable {
     }
   }
 
-  let backendState: String
+  let backendState: String?
   let currentTailnet: Tailnet?
   let selfNode: Node?
   let peerNodes: [String: PeerNode]
@@ -435,11 +445,19 @@ struct TailscaleStatusDocument: Decodable, Sendable {
 
   init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    backendState = try container.decode(String.self, forKey: .backendState)
+    backendState = try container.decodeIfPresent(String.self, forKey: .backendState)
     currentTailnet = try container.decodeIfPresent(Tailnet.self, forKey: .currentTailnet)
     selfNode = try container.decodeIfPresent(Node.self, forKey: .selfNode)
-    users = try container.decode([String: User].self, forKey: .users)
+    users = try container.decodeIfPresent([String: User].self, forKey: .users) ?? [:]
     peerNodes = (try? container.decode([String: PeerNode].self, forKey: .peerNodes)) ?? [:]
+  }
+
+  static func decode(from data: Data) throws -> Self {
+    do {
+      return try JSONDecoder().decode(Self.self, from: data)
+    } catch {
+      throw PrivateMacShareError.invalidTailscaleStatus
+    }
   }
 }
 
@@ -454,9 +472,14 @@ enum TailnetRegistrationHealth: Equatable, Sendable {
 
 enum TailnetRegistrationHealthPolicy {
   static func health(from document: TailscaleStatusDocument) -> TailnetRegistrationHealth {
-    guard let node = document.selfNode else { return .ok }
-    var dnsName = node.dnsName
+    guard
+      let node = document.selfNode,
+      var dnsName = node.dnsName?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !dnsName.isEmpty,
+      let hostName = node.hostName
+    else { return .ok }
     while dnsName.last == "." { dnsName.removeLast() }
+    guard dnsName.contains(".") else { return .ok }
     guard
       let firstLabel = dnsName.split(separator: ".", omittingEmptySubsequences: false).first,
       !firstLabel.isEmpty,
@@ -469,17 +492,17 @@ enum TailnetRegistrationHealthPolicy {
       !base.isEmpty,
       !suffix.isEmpty,
       suffix.utf8.allSatisfy({ (48...57).contains($0) }),
-      String(base).caseInsensitiveCompare(node.hostName) == .orderedSame
+      String(base).caseInsensitiveCompare(hostName) == .orderedSame
     else { return .ok }
 
-    let advertised = node.tailscaleIPs.first(where: TailnetIdentityPolicy.isTailscaleIPv4)
+    let advertised = TailnetIdentityPolicy.tailscaleIPv4Candidates(in: node.tailscaleIPs).first
     let matchingPeerPresent = document.peerNodes.values.contains { peer in
       guard let peerHostName = peer.hostName else { return false }
       return peerHostName.caseInsensitiveCompare(String(base)) == .orderedSame
     }
     return .duplicateHostname(
       advertised: advertised,
-      hostName: node.hostName,
+      hostName: hostName,
       matchingPeerPresent: matchingPeerPresent
     )
   }
@@ -491,7 +514,27 @@ struct TailnetIdentity: Equatable, Sendable {
   let dnsName: String
   let hostName: String
   let ipv4Address: String
+  /// Numerically sorted, de-duplicated CGNAT addresses reported for this node.
+  let ipv4Candidates: [String]
   let userID: Int64
+
+  init(
+    tailnetName: String,
+    loginName: String,
+    dnsName: String,
+    hostName: String,
+    ipv4Address: String,
+    ipv4Candidates: [String]? = nil,
+    userID: Int64
+  ) {
+    self.tailnetName = tailnetName
+    self.loginName = loginName
+    self.dnsName = dnsName
+    self.hostName = hostName
+    self.ipv4Address = ipv4Address
+    self.ipv4Candidates = ipv4Candidates ?? [ipv4Address]
+    self.userID = userID
+  }
 
   func vncAddress(port: Int) -> String {
     "vnc://\(ipv4Address):\(port)"
@@ -502,7 +545,18 @@ enum TailnetIdentityPolicy {
   static func identity(from document: TailscaleStatusDocument) throws
     -> TailnetIdentity
   {
-    guard document.backendState == "Running" else {
+    switch document.backendState {
+    case "Running":
+      break
+    case "NeedsLogin":
+      throw PrivateMacShareError.tailscaleNeedsLogin
+    case "Stopped":
+      throw PrivateMacShareError.tailscaleStopped
+    case "Starting":
+      throw PrivateMacShareError.tailscaleStarting
+    case nil:
+      throw PrivateMacShareError.invalidTailscaleStatus
+    default:
       throw PrivateMacShareError.tailscaleNotRunning
     }
     guard
@@ -512,26 +566,50 @@ enum TailnetIdentityPolicy {
       throw PrivateMacShareError.invalidTailnetIdentity
     }
     let tailnetName = rawTailnetName.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard let node = document.selfNode, node.online else {
+    guard let node = document.selfNode else {
+      throw PrivateMacShareError.invalidTailscaleStatus
+    }
+    guard let online = node.online else {
+      throw PrivateMacShareError.invalidTailscaleStatus
+    }
+    guard online else {
       throw PrivateMacShareError.tailscaleOffline
     }
     guard
-      let user = document.users[String(node.userID)],
-      isValidLogin(user.loginName)
+      let userID = node.userID,
+      let loginName = document.users[String(userID)]?.loginName,
+      isValidLogin(loginName)
     else {
       throw PrivateMacShareError.invalidTailnetUser
     }
-    guard let ipv4Address = node.tailscaleIPs.first(where: isTailscaleIPv4) else {
+    let ipv4Candidates = tailscaleIPv4Candidates(in: node.tailscaleIPs)
+    guard let ipv4Address = ipv4Candidates.first else {
+      if node.tailscaleIPs.contains(where: isTailscaleIPv6) {
+        throw PrivateMacShareError.ipv4TailnetAddressUnavailable
+      }
       throw PrivateMacShareError.missingTailnetAddress
     }
+    guard
+      let rawHostName = node.hostName,
+      isValidHostName(rawHostName)
+    else {
+      throw PrivateMacShareError.invalidTailscaleStatus
+    }
+    let hostName = rawHostName.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedDNSName =
+      node.dnsName?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .trimmingCharacters(in: CharacterSet(charactersIn: ".")) ?? ""
+    let dnsName = trimmedDNSName.contains(".") ? trimmedDNSName : hostName
 
     return TailnetIdentity(
       tailnetName: tailnetName,
-      loginName: user.loginName.trimmingCharacters(in: .whitespacesAndNewlines),
-      dnsName: node.dnsName.trimmingCharacters(in: CharacterSet(charactersIn: ".")),
-      hostName: node.hostName,
+      loginName: loginName.trimmingCharacters(in: .whitespacesAndNewlines),
+      dnsName: dnsName,
+      hostName: hostName,
       ipv4Address: ipv4Address,
-      userID: node.userID
+      ipv4Candidates: ipv4Candidates,
+      userID: userID
     )
   }
 
@@ -543,11 +621,43 @@ enum TailnetIdentityPolicy {
     isValidIdentityField(value, maximumUTF8Bytes: 320)
   }
 
+  static func tailscaleIPv4Candidates(in addresses: [String]) -> [String] {
+    // Tailscale status ordering is not an identity contract. Numeric sorting gives
+    // every caller the same canonical address while preserving all viable choices.
+    Array(Set(addresses.filter(isTailscaleIPv4))).sorted {
+      ipv4SortKey($0) < ipv4SortKey($1)
+    }
+  }
+
   static func isTailscaleIPv4(_ value: String) -> Bool {
     let parts = value.split(separator: ".", omittingEmptySubsequences: false)
     guard parts.count == 4 else { return false }
     let octets = parts.compactMap { UInt8($0) }
     return octets.count == 4 && octets[0] == 100 && (64...127).contains(octets[1])
+  }
+
+  static func isTailscaleIPv6(_ value: String) -> Bool {
+    var address = in6_addr()
+    guard value.withCString({ inet_pton(AF_INET6, $0, &address) }) == 1 else {
+      return false
+    }
+    return withUnsafeBytes(of: &address) { bytes in
+      bytes.count == 16
+        && bytes[0] == 0xfd
+        && bytes[1] == 0x7a
+        && bytes[2] == 0x11
+        && bytes[3] == 0x5c
+        && bytes[4] == 0xa1
+        && bytes[5] == 0xe0
+    }
+  }
+
+  private static func ipv4SortKey(_ value: String) -> UInt32 {
+    value.split(separator: ".").reduce(0) { ($0 << 8) | UInt32(UInt8($1) ?? 0) }
+  }
+
+  private static func isValidHostName(_ value: String) -> Bool {
+    isValidIdentityField(value, maximumUTF8Bytes: 253)
   }
 
   private static func isValidIdentityField(_ value: String, maximumUTF8Bytes: Int) -> Bool {
@@ -626,10 +736,15 @@ struct TailnetPeerAuthorizer: TailnetPeerAuthorizing, Sendable {
 enum PrivateMacShareError: LocalizedError, Equatable {
   case tailscaleNotInstalled
   case tailscaleNotRunning
+  case tailscaleNeedsLogin
+  case tailscaleStopped
+  case tailscaleStarting
   case tailscaleOffline
+  case invalidTailscaleStatus
   case invalidTailnetIdentity
   case invalidTailnetUser
   case missingTailnetAddress
+  case ipv4TailnetAddressUnavailable
   case screenRecordingDenied
   case accessibilityDenied
   case commandFailed(status: Int32, message: String)
@@ -645,14 +760,24 @@ enum PrivateMacShareError: LocalizedError, Equatable {
       "Tailscale is not installed. Install Tailscale first."
     case .tailscaleNotRunning:
       "Tailscale is not running."
+    case .tailscaleNeedsLogin:
+      "Tailscale needs you to sign in. Open Tailscale and log in, then try again."
+    case .tailscaleStopped:
+      "Tailscale is stopped. Open Tailscale and connect, then try again."
+    case .tailscaleStarting:
+      "Tailscale is still starting. Wait for it to connect, then try again."
     case .tailscaleOffline:
       "This Mac is offline in Tailscale."
+    case .invalidTailscaleStatus:
+      "Tailscale returned incomplete or malformed status information."
     case .invalidTailnetIdentity:
       "Tailscale did not report a valid active tailnet."
     case .invalidTailnetUser:
       "Tailscale did not report a valid signed-in user."
     case .missingTailnetAddress:
       "Tailscale did not provide a private 100.64.0.0/10 address for this Mac."
+    case .ipv4TailnetAddressUnavailable:
+      "This Mac has only a Tailscale IPv6 address. IPv6-only tailnets are not yet supported for the private desktop listener."
     case .screenRecordingDenied:
       "Crabfleet needs Screen Recording permission to stream this display."
     case .accessibilityDenied:

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
@@ -1511,7 +1511,84 @@ struct PrivateMacShareTests {
     #expect(identity.tailnetName == "example.com")
     #expect(identity.loginName == "operator@example.com")
     #expect(identity.ipv4Address == "100.64.12.34")
+    #expect(identity.ipv4Candidates == ["100.64.12.34"])
     #expect(identity.vncAddress(port: 5901) == "vnc://100.64.12.34:5901")
+  }
+
+  @Test
+  func selectsCanonicalIPv4AndExposesStableCandidates() throws {
+    let document = try tailnetStatusFixture(
+      addresses: [
+        "100.100.0.2", "100.64.12.35", "fd7a:115c:a1e0::1", "100.64.12.34",
+        "100.64.12.35",
+      ],
+      unknownField: true
+    )
+    let identity = try TailnetIdentityPolicy.identity(from: document)
+
+    #expect(identity.ipv4Address == "100.64.12.34")
+    #expect(
+      identity.ipv4Candidates == ["100.64.12.34", "100.64.12.35", "100.100.0.2"])
+  }
+
+  @Test
+  func resolvesWithoutMagicDNSAndSkipsDuplicateHeuristic() throws {
+    for dnsName in [String?.none, "", "workstation", "workstation-1"] {
+      let document = try tailnetStatusFixture(dnsName: dnsName)
+      let identity = try TailnetIdentityPolicy.identity(from: document)
+
+      #expect(identity.dnsName == "Workstation")
+      #expect(identity.hostName == "Workstation")
+      #expect(identity.vncAddress(port: 5_901) == "vnc://100.64.12.34:5901")
+      #expect(TailnetRegistrationHealthPolicy.health(from: document) == .ok)
+    }
+  }
+
+  @Test
+  func rejectsIPv6OnlyTailnetWithSpecificListenerError() throws {
+    let document = try tailnetStatusFixture(
+      addresses: ["fd7a:115c:a1e0::1234", "2001:db8::1"])
+
+    #expect(throws: PrivateMacShareError.ipv4TailnetAddressUnavailable) {
+      try TailnetIdentityPolicy.identity(from: document)
+    }
+    #expect(
+      PrivateMacShareError.ipv4TailnetAddressUnavailable.localizedDescription.contains(
+        "IPv6-only tailnets are not yet supported"))
+  }
+
+  @Test
+  func reportsActionableBackendStateErrors() throws {
+    let fixtures: [(String, PrivateMacShareError?)] = [
+      ("Running", nil),
+      ("NeedsLogin", .tailscaleNeedsLogin),
+      ("Stopped", .tailscaleStopped),
+      ("Starting", .tailscaleStarting),
+    ]
+
+    for (backendState, expectedError) in fixtures {
+      let document = try tailnetStatusFixture(backendState: backendState)
+      if let expectedError {
+        #expect(throws: expectedError) {
+          try TailnetIdentityPolicy.identity(from: document)
+        }
+      } else {
+        #expect(try TailnetIdentityPolicy.identity(from: document).ipv4Address == "100.64.12.34")
+      }
+    }
+  }
+
+  @Test
+  func rejectsMalformedAndPartialStatusWithSpecificError() throws {
+    #expect(throws: PrivateMacShareError.invalidTailscaleStatus) {
+      try TailscaleStatusDocument.decode(from: Data(#"{"BackendState": "Running""#.utf8))
+    }
+
+    let partial = try TailscaleStatusDocument.decode(
+      from: Data(#"{"CurrentTailnet":{"Name":"example.com"}}"#.utf8))
+    #expect(throws: PrivateMacShareError.invalidTailscaleStatus) {
+      try TailnetIdentityPolicy.identity(from: partial)
+    }
   }
 
   @Test
@@ -2641,6 +2718,35 @@ struct PrivateMacShareTests {
 
   private func statusDocument() throws -> TailscaleStatusDocument {
     try JSONDecoder().decode(TailscaleStatusDocument.self, from: Data(statusJSON().utf8))
+  }
+
+  private func tailnetStatusFixture(
+    backendState: String = "Running",
+    dnsName: String? = "workstation.example.ts.net.",
+    addresses: [String] = ["100.64.12.34", "fd7a:115c:a1e0::1"],
+    unknownField: Bool = false
+  ) throws -> TailscaleStatusDocument {
+    let dnsField = dnsName.map { #""DNSName": "\#($0)","# } ?? ""
+    let encodedAddresses = addresses.map { #""\#($0)""# }.joined(separator: ", ")
+    let extraField = unknownField ? #", "FutureStatusField": {"ignored": true}"# : ""
+    let json = """
+      {
+        "BackendState": "\(backendState)",
+        "CurrentTailnet": { "Name": "example.com" },
+        "Self": {
+          \(dnsField)
+          "HostName": "Workstation",
+          "Online": true,
+          "TailscaleIPs": [\(encodedAddresses)],
+          "UserID": 42
+        },
+        "User": {
+          "42": { "LoginName": "operator@example.com" }
+        }
+        \(extraField)
+      }
+      """
+    return try TailscaleStatusDocument.decode(from: Data(json.utf8))
   }
 
   private func registrationHealthDocument(


### PR DESCRIPTION
Hardens TailnetIdentity resolution for real-world tailnet states beyond the happy path (found during the live Miniclaw run): stable deterministic selection among multiple Self IPv4 addresses (+ candidate exposure), MagicDNS-off fallback to hostname without crashing, explicit unsupported-IPv6-only listener error, and distinct actionable errors per backend state (NeedsLogin/Stopped/Starting) plus malformed-status handling — instead of one generic failure. Pure + fixture-tested (29 tailnet tests pass); advertised address unchanged. Builds clean; autoreview clean.