### PR TITLE
fix(connect): bind primary XKB group instead of disabling X11 capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix the Crabfleet Connect Linux X11 backend disabling capture entirely on keyboards with multiple XKB groups: bind only the primary group's base/shift levels so real screen capture and input injection work instead of silently falling back to the synthetic test pattern (validated on a headless Xvfb X server: real 1920x1080 Tight framebuffer + XTest pointer injection).
+
 - Add opt-in single-folder sharing to Share This Mac with security-scoped bookmark persistence, negotiated `FSH1` browsing, bounded native and browser download/upload streams, strict realpath containment, 512 MiB file and 256 KiB chunk limits, root-local temporary uploads with atomic rename and teardown cleanup, and host-controlled remote writes.
 - Add a pure-Go Windows Crabfleet Connect backend with synchronized GDI BitBlt primary-display capture, full-frame RGBA dirty updates, SendInput absolute pointer, wheel, and keyboard injection, active-layout shortcuts, Unicode and legacy X11 keysym text mapping, retry-safe teardown, and amd64/arm64 cross-build proof, while deferring DXGI, multi-monitor, per-monitor-DPI, packaging, and real-hardware validation.
 - Add the Crabfleet Connect foundation with a shared Go RFB 3.8 host core, per-run VNC-DES authentication, Tight/JPEG and client-side cursor/input support, a CI-safe synthetic backend, and a Linux X11 MIT-SHM/XFixes/XTest backend plus cross-compiled CLI, while documenting deferred codecs, Wayland, ARD, audio, and hardware validation.

--- a/internal/connect/x11_keymap.go
+++ b/internal/connect/x11_keymap.go
@@ -65,10 +65,17 @@ func buildX11Keymap(
 	for keyOffset := 0; keyOffset < count; keyOffset++ {
 		keycode := byte(int(minimum) + keyOffset)
 		rawLevels := keysyms[keyOffset*perKeycode : (keyOffset+1)*perKeycode]
-		if !x11GroupsEquivalent(rawLevels) {
-			return x11Keymap{}, errors.New("X11 multiple keyboard groups require XKB support")
-		}
 		levels := normalizedX11Levels(rawLevels)
+		if !x11GroupsEquivalent(rawLevels) {
+			// Extra XKB keyboard groups (secondary layouts) cannot be
+			// disambiguated from AltGr levels through the core protocol, so bind
+			// only the primary group's base and shift levels. Standard typing
+			// and — critically — screen capture keep working instead of the
+			// whole backend falling back to the synthetic test pattern.
+			// (Active-group-aware XKB mapping is a follow-up.)
+			primary := normalizedX11Levels(rawLevels[:2])
+			levels = []uint32{primary[0], primary[1], primary[0], primary[1]}
+		}
 		symbolsByKeycode[keycode] = levels
 		for level, keysym := range levels[:2] {
 			if keysym == 0 {

--- a/internal/connect/x11_keymap_test.go
+++ b/internal/connect/x11_keymap_test.go
@@ -35,20 +35,36 @@ func TestBuildX11KeymapPreservesRequiredLevels(t *testing.T) {
 	}
 }
 
-func TestBuildX11KeymapRejectsMultipleGroups(t *testing.T) {
+func TestBuildX11KeymapBindsPrimaryGroupIgnoringSecondary(t *testing.T) {
 	t.Parallel()
-	if _, err := buildX11Keymap([]uint32{'a', 'A', 0x06c1, 0x06e1}, 20, 1, 4, x11ModifierMap{}); err == nil {
-		t.Fatal("accepted an XKB multi-group keymap")
+	// A second XKB group (Arabic here) must not disable the keymap; the primary
+	// group's base and shift bind, and the secondary group's keysyms are ignored.
+	keymap, err := buildX11Keymap([]uint32{'a', 'A', 0x06c1, 0x06e1}, 20, 1, 4, x11ModifierMap{})
+	if err != nil {
+		t.Fatalf("multi-group keymap must build: %v", err)
+	}
+	if b, ok := keymap.bindings['a']; !ok || b.keycode != 20 || b.shift {
+		t.Fatalf("primary base binding missing/wrong: %+v ok=%v", b, ok)
+	}
+	if _, ok := keymap.bindings[0x06c1]; ok {
+		t.Fatal("secondary-group keysym must not be bound")
 	}
 }
 
-func TestBuildX11KeymapRejectsThirdGroup(t *testing.T) {
+func TestBuildX11KeymapIgnoresDifferingThirdGroup(t *testing.T) {
 	t.Parallel()
-	if _, err := buildX11Keymap(
+	keymap, err := buildX11Keymap(
 		[]uint32{'a', 'A', 'a', 'A', 0x06c1, 0x06e1},
 		20, 1, 6, x11ModifierMap{},
-	); err == nil {
-		t.Fatal("accepted a differing third XKB group")
+	)
+	if err != nil {
+		t.Fatalf("keymap with a differing third group must build: %v", err)
+	}
+	if _, ok := keymap.bindings['a']; !ok {
+		t.Fatal("primary base binding missing")
+	}
+	if _, ok := keymap.bindings[0x06c1]; ok {
+		t.Fatal("differing third-group keysym must not be bound")
 	}
 }
 


### PR DESCRIPTION
Found by real-hardware validation on a Crabbox Linux box (Xvfb X server). The Connect Linux X11 backend called `buildX11Keymap`, which **errored** whenever a keycode's keysyms differed across XKB groups (any keyboard with a secondary layout — extremely common, including default Xvfb). That error disabled the *entire* backend, silently falling back to the synthetic test pattern — so real screen capture never ran on a normal Linux desktop.

Fix: on multi-group keycodes, bind only the primary group's base+shift levels instead of aborting. Standard typing and, critically, screen capture + input injection keep working. Active-group-aware XKB mapping is a documented follow-up.

## Validation (real hardware, Crabbox aws cbx_5cd10de9bde9)

Before: `Backend: synthetic test pattern`, SERVER_INIT 640x360 (fake), pointer move ignored.
After: `Backend: Linux X11 (MIT-SHM capture + XTest input)`, **SERVER_INIT 1920x1080** (real display), Tight framebuffer enc=7, and a client PointerEvent to (321,210) **actually moved the X cursor** (xdotool confirmed x:321 y:210). Auth accept=0 / wrong-password reject=1; Security None absent.

`go build`/`go vet`/`go test ./...` pass; updated the two keymap tests to assert graceful primary-group degradation.
