### PR TITLE
feat(macos): extend the deck design language to the connection sheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Extend the deck design language to the Quick Connect and desktop connection sheets: card-based fields and switches, gradient headers, pinned dark scheme, and a shared height-capped scrolling sheet container.
 - Redesign the Share This Mac sheet in the app's dark deck design language: pulsing readiness beacons with two-line status rows, custom capsule switches with icon tiles and captions, an animated segmented quality control, a live phase badge, and a restyled connect card — no behavior changes.
 - Fix the Crabfleet Connect Linux X11 backend disabling capture entirely on keyboards with multiple XKB groups: bind only the primary group's base/shift levels so real screen capture and input injection work instead of silently falling back to the synthetic test pattern (validated on a headless Xvfb X server: real 1920x1080 Tight framebuffer + XTest pointer injection).
 

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/PrivateMacShareView.swift
@@ -6,12 +6,16 @@ struct PrivateMacShareSheet: View {
   @Environment(\.dismiss) private var dismiss
   @Environment(\.scenePhase) private var scenePhase
 
-  @State private var contentHeight: CGFloat = 0
-
   var body: some View {
-    ScrollView {
+    ShareSheetContainer(width: 600) {
       VStack(alignment: .leading, spacing: 16) {
-        header
+        ShareSheetHeader(
+          systemImage: "display.and.arrow.down",
+          title: "Share This Mac",
+          subtitle: "App-owned remote desktop, restricted to your current Tailscale identity."
+        ) {
+          SharePhaseBadge(phase: controller.phase)
+        }
         readinessSection
 
         if let warning = controller.tailnetWarning {
@@ -31,29 +35,7 @@ struct PrivateMacShareSheet: View {
         assurance
         footer
       }
-      .padding(24)
-      .background {
-        GeometryReader { proxy in
-          Color.clear.preference(key: SheetContentHeightKey.self, value: proxy.size.height)
-        }
-      }
     }
-    .scrollBounceBehavior(.basedOnSize)
-    .onPreferenceChange(SheetContentHeightKey.self) { contentHeight = $0 }
-    .frame(width: 600)
-    .frame(height: contentHeight > 0 ? min(contentHeight, Self.maxSheetHeight) : nil)
-    .background {
-      LinearGradient(
-        colors: [
-          Color(red: 0.035, green: 0.041, blue: 0.045),
-          Color(red: 0.018, green: 0.023, blue: 0.026),
-        ],
-        startPoint: .topLeading,
-        endPoint: .bottomTrailing)
-    }
-    .preferredColorScheme(.dark)
-    .tint(.mint)
-    .toggleStyle(ShareToggleStyle())
     .task { await controller.refresh() }
     .onAppear { controller.startPermissionMonitoring() }
     .onDisappear { controller.stopPermissionMonitoring() }
@@ -61,36 +43,6 @@ struct PrivateMacShareSheet: View {
       if phase == .active {
         controller.refreshPermissions()
       }
-    }
-  }
-
-  private var header: some View {
-    HStack(spacing: 12) {
-      ZStack {
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
-          .fill(
-            LinearGradient(
-              colors: [.mint.opacity(0.28), .mint.opacity(0.08)],
-              startPoint: .topLeading,
-              endPoint: .bottomTrailing))
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
-          .strokeBorder(.mint.opacity(0.35), lineWidth: 1)
-        Image(systemName: "display.and.arrow.down")
-          .font(.system(size: 19, weight: .medium))
-          .foregroundStyle(.mint)
-      }
-      .frame(width: 44, height: 44)
-
-      VStack(alignment: .leading, spacing: 2) {
-        Text("Share This Mac")
-          .font(.title3.weight(.semibold))
-        Text("App-owned remote desktop, restricted to your current Tailscale identity.")
-          .font(.system(size: 11.5, design: .rounded))
-          .foregroundStyle(.secondary)
-      }
-
-      Spacer()
-      SharePhaseBadge(phase: controller.phase)
     }
   }
 
@@ -492,12 +444,6 @@ struct PrivateMacShareSheet: View {
     }
   }
 
-  // Sheets cannot be moved on screen, so cap height below common laptop displays
-  // and let the content scroll instead of clipping the footer controls.
-  private static var maxSheetHeight: CGFloat {
-    max(480, (NSScreen.main?.visibleFrame.height ?? 900) - 120)
-  }
-
   private var phaseDetail: String {
     let viewers =
       controller.connectedViewerCount == 1
@@ -519,13 +465,6 @@ struct PrivateMacShareSheet: View {
       return "\(controller.phase.title) · \(peer)"
     }
     return controller.phase.title
-  }
-}
-
-private struct SheetContentHeightKey: PreferenceKey {
-  static var defaultValue: CGFloat = 0
-  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-    value = max(value, nextValue())
   }
 }
 
@@ -609,34 +548,5 @@ private struct ShareStatusRow: View {
     }
     .padding(.horizontal, 14)
     .padding(.vertical, 10)
-  }
-}
-
-private struct ShareToggleLabel: View {
-  let systemName: String
-  var fallbackSystemName: String?
-  let title: String
-  var caption: String?
-  let isActive: Bool
-
-  var body: some View {
-    HStack(spacing: 10) {
-      ShareIconTile(
-        systemName: systemName,
-        fallbackSystemName: fallbackSystemName,
-        isActive: isActive)
-      VStack(alignment: .leading, spacing: 2) {
-        Text(title)
-          .font(.system(size: 12.5, weight: .medium, design: .rounded))
-          .foregroundStyle(.primary)
-          .lineLimit(1)
-        if let caption {
-          Text(caption)
-            .font(.system(size: 10.5, design: .rounded))
-            .foregroundStyle(.secondary)
-            .lineLimit(1)
-        }
-      }
-    }
   }
 }

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/SessionWorkspaceView.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/SessionWorkspaceView.swift
@@ -542,74 +542,137 @@ struct DesktopConnectionSheet: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 20) {
-      ConnectionSheetHeader(
-        title: "Connect to \(target.title)",
-        subtitle: target.source == .crabfleet
-          ? "Use the loopback endpoint from the Crabbox tunnel."
-          : "Open a direct VNC connection with the native viewer."
-      )
+    ShareSheetContainer(width: 560) {
+      VStack(alignment: .leading, spacing: 16) {
+        ShareSheetHeader(
+          systemImage: "cable.connector",
+          title: "Connect to \(target.title)",
+          subtitle: target.source == .crabfleet
+            ? "Use the loopback endpoint from the Crabbox tunnel."
+            : "Open a direct VNC connection with the native viewer."
+        )
 
-      Form {
-        TextField("VNC address", text: $address, prompt: Text("host:5900 or vnc://host:5900"))
-        TextField("Username (optional)", text: $username)
-        SecureField("Password", text: $password)
-        Toggle("Crabfleet Share (prefer ARD)", isOn: $prefersPasswordOnlyARD)
-        Toggle("Remember password in Keychain", isOn: $rememberAccessCode)
-        Toggle("Synchronize text clipboard", isOn: $clipboardEnabled)
-        if target.profileID != nil {
-          Section("Wake-on-LAN") {
-            TextField(
-              "MAC address (optional)", text: $macAddress,
-              prompt: Text("aa:bb:cc:dd:ee:ff"))
-            TextField(
-              "Broadcast address", text: $wakeOnLanBroadcast,
-              prompt: Text(WakeOnLan.defaultBroadcastAddress)
-            )
-            .disabled(macAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-            Toggle("Wake after the initial TCP connection fails", isOn: $wakeOnLanAutomatically)
-              .disabled(macAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-            Text("Wake-on-LAN normally reaches only devices on the same local network.")
-              .font(.caption)
-              .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 8) {
+          ShareSectionHeader(title: "Connection")
+          ShareCard {
+            VStack(spacing: 0) {
+              ShareFieldRow(title: "VNC address") {
+                TextField("", text: $address, prompt: Text("host:5900 or vnc://host:5900"))
+                  .font(.system(size: 12, design: .monospaced))
+              }
+              ShareCardDivider(leadingInset: 14)
+              ShareFieldRow(title: "Username (optional)") {
+                TextField("", text: $username)
+              }
+              ShareCardDivider(leadingInset: 14)
+              ShareFieldRow(title: "Password") {
+                SecureField("", text: $password)
+              }
+            }
           }
         }
-      }
-      .formStyle(.grouped)
 
-      ClipboardConnectionWarning(isEnabled: clipboardEnabled)
+        VStack(alignment: .leading, spacing: 8) {
+          ShareSectionHeader(title: "Options")
+          ShareCard {
+            VStack(spacing: 0) {
+              Toggle(isOn: $prefersPasswordOnlyARD) {
+                ShareToggleLabel(
+                  systemName: "person.badge.key",
+                  title: "Crabfleet Share (prefer ARD)",
+                  caption: "Authenticates with the share password only.",
+                  isActive: prefersPasswordOnlyARD)
+              }
+              ShareCardDivider()
+              Toggle(isOn: $rememberAccessCode) {
+                ShareToggleLabel(
+                  systemName: "key.fill",
+                  title: "Remember password in Keychain",
+                  caption: "Stored per host and port on this Mac.",
+                  isActive: rememberAccessCode)
+              }
+              ShareCardDivider()
+              Toggle(isOn: $clipboardEnabled) {
+                ShareToggleLabel(
+                  systemName: "arrow.triangle.2.circlepath.doc.on.clipboard",
+                  fallbackSystemName: "doc.on.clipboard",
+                  title: "Synchronize text clipboard",
+                  caption: "Stable text changes flow to the focused desktop.",
+                  isActive: clipboardEnabled)
+              }
+            }
+          }
+        }
 
-      if let validationMessage {
-        Text(validationMessage)
-          .font(.caption)
-          .foregroundStyle(.red)
-      } else {
-        Label(
-          "Direct VNC is usually unencrypted. Prefer localhost through SSH or a trusted private network.",
-          systemImage: "lock.trianglebadge.exclamationmark"
-        )
-        .font(.caption)
-        .foregroundStyle(.secondary)
-      }
+        if target.profileID != nil {
+          VStack(alignment: .leading, spacing: 8) {
+            ShareSectionHeader(title: "Wake-on-LAN")
+            ShareCard {
+              VStack(spacing: 0) {
+                ShareFieldRow(title: "MAC address (optional)") {
+                  TextField("", text: $macAddress, prompt: Text("aa:bb:cc:dd:ee:ff"))
+                    .font(.system(size: 12, design: .monospaced))
+                }
+                ShareCardDivider(leadingInset: 14)
+                ShareFieldRow(title: "Broadcast address") {
+                  TextField(
+                    "", text: $wakeOnLanBroadcast,
+                    prompt: Text(WakeOnLan.defaultBroadcastAddress)
+                  )
+                  .font(.system(size: 12, design: .monospaced))
+                  .disabled(macAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+                ShareCardDivider(leadingInset: 14)
+                Toggle(isOn: $wakeOnLanAutomatically) {
+                  ShareToggleLabel(
+                    systemName: "power",
+                    title: "Wake after the initial TCP connection fails",
+                    isActive: wakeOnLanAutomatically)
+                }
+                .disabled(macAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                Text("Wake-on-LAN normally reaches only devices on the same local network.")
+                  .font(.system(size: 10.5, design: .rounded))
+                  .foregroundStyle(.secondary)
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .padding(.horizontal, 14)
+                  .padding(.bottom, 12)
+              }
+            }
+          }
+        }
 
-      HStack {
-        Text(
-          rememberAccessCode
-            ? "The password is stored in this Mac’s Keychain for this host and port."
-            : "The password stays in memory for this connection only."
-        )
-          .font(.caption)
-          .foregroundStyle(.tertiary)
-        Spacer()
-        Button("Cancel") { dismiss() }
-          .keyboardShortcut(.cancelAction)
-        Button("Connect", action: submit)
-          .buttonStyle(.borderedProminent)
-          .keyboardShortcut(.defaultAction)
+        ClipboardConnectionWarning(isEnabled: clipboardEnabled)
+
+        if let validationMessage {
+          Text(validationMessage)
+            .font(.system(.caption, design: .rounded))
+            .foregroundStyle(.red)
+        } else {
+          Label(
+            "Direct VNC is usually unencrypted. Prefer localhost through SSH or a trusted private network.",
+            systemImage: "lock.trianglebadge.exclamationmark"
+          )
+          .font(.system(.caption, design: .rounded))
+          .foregroundStyle(.secondary)
+        }
+
+        HStack {
+          Text(
+            rememberAccessCode
+              ? "The password is stored in this Mac’s Keychain for this host and port."
+              : "The password stays in memory for this connection only."
+          )
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+          Spacer()
+          Button("Cancel") { dismiss() }
+            .keyboardShortcut(.cancelAction)
+          Button("Connect", action: submit)
+            .buttonStyle(.borderedProminent)
+            .keyboardShortcut(.defaultAction)
+        }
       }
     }
-    .padding(24)
-    .frame(width: 540)
     .onChange(of: address) { _, _ in refreshPasswordForCredentialIdentity() }
     .onChange(of: username) { _, _ in refreshPasswordForCredentialIdentity() }
   }
@@ -682,66 +745,132 @@ struct QuickConnectSheet: View {
   @State private var credentialIdentity: VNCAddress?
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 20) {
-      ConnectionSheetHeader(
-        title: "Quick Connect",
-        subtitle: "Add any standard VNC server to your desktop deck."
-      )
+    ShareSheetContainer(width: 560) {
+      VStack(alignment: .leading, spacing: 16) {
+        ShareSheetHeader(
+          systemImage: "cable.connector",
+          title: "Quick Connect",
+          subtitle: "Add any standard VNC server to your desktop deck."
+        )
 
-      Form {
-        TextField("VNC address", text: $address, prompt: Text("host:5900 or vnc://host:5900"))
-          .focused($addressFocused)
-        TextField("Name", text: $name, prompt: Text("Design workstation"))
-        TextField("Username (optional)", text: $username)
-        SecureField("Password", text: $password)
-        Toggle("Crabfleet Share (prefer ARD)", isOn: $prefersPasswordOnlyARD)
-        Toggle("Remember password in Keychain", isOn: $rememberAccessCode)
-        Toggle("Synchronize text clipboard", isOn: $clipboardEnabled)
-        Section("Wake-on-LAN") {
-          TextField(
-            "MAC address (optional)", text: $macAddress,
-            prompt: Text("aa:bb:cc:dd:ee:ff"))
-          TextField(
-            "Broadcast address", text: $wakeOnLanBroadcast,
-            prompt: Text(WakeOnLan.defaultBroadcastAddress)
+        VStack(alignment: .leading, spacing: 8) {
+          ShareSectionHeader(title: "Connection")
+          ShareCard {
+            VStack(spacing: 0) {
+              ShareFieldRow(title: "VNC address") {
+                TextField("", text: $address, prompt: Text("host:5900 or vnc://host:5900"))
+                  .font(.system(size: 12, design: .monospaced))
+                  .focused($addressFocused)
+              }
+              ShareCardDivider(leadingInset: 14)
+              ShareFieldRow(title: "Name") {
+                TextField("", text: $name, prompt: Text("Design workstation"))
+              }
+              ShareCardDivider(leadingInset: 14)
+              ShareFieldRow(title: "Username (optional)") {
+                TextField("", text: $username)
+              }
+              ShareCardDivider(leadingInset: 14)
+              ShareFieldRow(title: "Password") {
+                SecureField("", text: $password)
+              }
+            }
+          }
+        }
+
+        VStack(alignment: .leading, spacing: 8) {
+          ShareSectionHeader(title: "Options")
+          ShareCard {
+            VStack(spacing: 0) {
+              Toggle(isOn: $prefersPasswordOnlyARD) {
+                ShareToggleLabel(
+                  systemName: "person.badge.key",
+                  title: "Crabfleet Share (prefer ARD)",
+                  caption: "Authenticates with the share password only.",
+                  isActive: prefersPasswordOnlyARD)
+              }
+              ShareCardDivider()
+              Toggle(isOn: $rememberAccessCode) {
+                ShareToggleLabel(
+                  systemName: "key.fill",
+                  title: "Remember password in Keychain",
+                  caption: "Stored per host and port on this Mac.",
+                  isActive: rememberAccessCode)
+              }
+              ShareCardDivider()
+              Toggle(isOn: $clipboardEnabled) {
+                ShareToggleLabel(
+                  systemName: "arrow.triangle.2.circlepath.doc.on.clipboard",
+                  fallbackSystemName: "doc.on.clipboard",
+                  title: "Synchronize text clipboard",
+                  caption: "Stable text changes flow to the focused desktop.",
+                  isActive: clipboardEnabled)
+              }
+            }
+          }
+        }
+
+        VStack(alignment: .leading, spacing: 8) {
+          ShareSectionHeader(title: "Wake-on-LAN")
+          ShareCard {
+            VStack(spacing: 0) {
+              ShareFieldRow(title: "MAC address (optional)") {
+                TextField("", text: $macAddress, prompt: Text("aa:bb:cc:dd:ee:ff"))
+                  .font(.system(size: 12, design: .monospaced))
+              }
+              ShareCardDivider(leadingInset: 14)
+              ShareFieldRow(title: "Broadcast address") {
+                TextField(
+                  "", text: $wakeOnLanBroadcast,
+                  prompt: Text(WakeOnLan.defaultBroadcastAddress)
+                )
+                .font(.system(size: 12, design: .monospaced))
+                .disabled(macAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+              }
+              ShareCardDivider(leadingInset: 14)
+              Toggle(isOn: $wakeOnLanAutomatically) {
+                ShareToggleLabel(
+                  systemName: "power",
+                  title: "Wake after the initial TCP connection fails",
+                  isActive: wakeOnLanAutomatically)
+              }
+              .disabled(macAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+              Text("Wake-on-LAN normally reaches only devices on the same local network.")
+                .font(.system(size: 10.5, design: .rounded))
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 14)
+                .padding(.bottom, 12)
+            }
+          }
+        }
+
+        ClipboardConnectionWarning(isEnabled: clipboardEnabled)
+
+        if let validationMessage {
+          Text(validationMessage)
+            .font(.system(.caption, design: .rounded))
+            .foregroundStyle(.red)
+        } else {
+          Text(
+            rememberAccessCode
+              ? "The connection is saved; the password is stored in this Mac’s Keychain."
+              : "The connection is saved; the password is not."
           )
-          .disabled(macAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-          Toggle("Wake after the initial TCP connection fails", isOn: $wakeOnLanAutomatically)
-            .disabled(macAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-          Text("Wake-on-LAN normally reaches only devices on the same local network.")
-            .font(.caption)
+            .font(.system(.caption, design: .rounded))
             .foregroundStyle(.secondary)
         }
-      }
-      .formStyle(.grouped)
 
-      ClipboardConnectionWarning(isEnabled: clipboardEnabled)
-
-      if let validationMessage {
-        Text(validationMessage)
-          .font(.caption)
-          .foregroundStyle(.red)
-      } else {
-        Text(
-          rememberAccessCode
-            ? "The connection is saved; the password is stored in this Mac’s Keychain."
-            : "The connection is saved; the password is not."
-        )
-          .font(.caption)
-          .foregroundStyle(.secondary)
-      }
-
-      HStack {
-        Spacer()
-        Button("Cancel") { dismiss() }
-          .keyboardShortcut(.cancelAction)
-        Button("Add & Connect", action: submit)
-          .buttonStyle(.borderedProminent)
-          .keyboardShortcut(.defaultAction)
+        HStack {
+          Spacer()
+          Button("Cancel") { dismiss() }
+            .keyboardShortcut(.cancelAction)
+          Button("Add & Connect", action: submit)
+            .buttonStyle(.borderedProminent)
+            .keyboardShortcut(.defaultAction)
+        }
       }
     }
-    .padding(24)
-    .frame(width: 540)
     .onAppear { addressFocused = true }
     .onChange(of: address) { _, _ in refreshRememberedState() }
     .onChange(of: username) { _, _ in refreshRememberedState() }
@@ -813,29 +942,6 @@ private struct ClipboardConnectionWarning: View {
       )
       .font(.caption)
       .foregroundStyle(.orange)
-    }
-  }
-}
-
-private struct ConnectionSheetHeader: View {
-  let title: String
-  let subtitle: String
-
-  var body: some View {
-    HStack(spacing: 12) {
-      ZStack {
-        RoundedRectangle(cornerRadius: 10, style: .continuous)
-          .fill(.mint.opacity(0.1))
-        Image(systemName: "cable.connector")
-          .font(.system(size: 20, weight: .light))
-          .foregroundStyle(.mint)
-      }
-      .frame(width: 42, height: 42)
-
-      VStack(alignment: .leading, spacing: 2) {
-        Text(title).font(.title3.weight(.semibold))
-        Text(subtitle).foregroundStyle(.secondary)
-      }
     }
   }
 }

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/ShareDesignSystem.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/ShareDesignSystem.swift
@@ -1,6 +1,144 @@
 import AppKit
 import SwiftUI
 
+private struct SheetContentHeightKey: PreferenceKey {
+  static var defaultValue: CGFloat = 0
+
+  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+    value = max(value, nextValue())
+  }
+}
+
+struct ShareSheetContainer<Content: View>: View {
+  let width: CGFloat
+  @ViewBuilder let content: Content
+
+  @State private var contentHeight: CGFloat = 0
+
+  init(width: CGFloat = 600, @ViewBuilder content: () -> Content) {
+    self.width = width
+    self.content = content()
+  }
+
+  var body: some View {
+    ScrollView {
+      content
+        .padding(24)
+        .background {
+          GeometryReader { proxy in
+            Color.clear.preference(key: SheetContentHeightKey.self, value: proxy.size.height)
+          }
+        }
+    }
+    .scrollBounceBehavior(.basedOnSize)
+    .onPreferenceChange(SheetContentHeightKey.self) { contentHeight = $0 }
+    .frame(width: width)
+    .frame(height: contentHeight > 0 ? min(contentHeight, maxSheetHeight) : nil)
+    .background {
+      LinearGradient(
+        colors: [
+          Color(red: 0.035, green: 0.041, blue: 0.045),
+          Color(red: 0.018, green: 0.023, blue: 0.026),
+        ],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing)
+    }
+    .preferredColorScheme(.dark)
+    .tint(.mint)
+    .toggleStyle(ShareToggleStyle())
+  }
+
+  // Sheets cannot be moved on screen, so cap height below common laptop displays
+  // and let the content scroll instead of clipping the footer controls.
+  private var maxSheetHeight: CGFloat {
+    max(480, (NSScreen.main?.visibleFrame.height ?? 900) - 120)
+  }
+}
+
+struct ShareSheetHeader<Trailing: View>: View {
+  let systemImage: String
+  let title: String
+  let subtitle: String
+  @ViewBuilder let trailing: Trailing
+
+  init(
+    systemImage: String,
+    title: String,
+    subtitle: String,
+    @ViewBuilder trailing: () -> Trailing
+  ) {
+    self.systemImage = systemImage
+    self.title = title
+    self.subtitle = subtitle
+    self.trailing = trailing()
+  }
+
+  var body: some View {
+    HStack(spacing: 12) {
+      ZStack {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .fill(
+            LinearGradient(
+              colors: [.mint.opacity(0.28), .mint.opacity(0.08)],
+              startPoint: .topLeading,
+              endPoint: .bottomTrailing))
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .strokeBorder(.mint.opacity(0.35), lineWidth: 1)
+        Image(systemName: systemImage)
+          .font(.system(size: 19, weight: .medium))
+          .foregroundStyle(.mint)
+      }
+      .frame(width: 44, height: 44)
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title)
+          .font(.title3.weight(.semibold))
+        Text(subtitle)
+          .font(.system(size: 11.5, design: .rounded))
+          .foregroundStyle(.secondary)
+      }
+
+      Spacer()
+      trailing
+    }
+  }
+}
+
+extension ShareSheetHeader where Trailing == EmptyView {
+  init(systemImage: String, title: String, subtitle: String) {
+    self.init(systemImage: systemImage, title: title, subtitle: subtitle) {
+      EmptyView()
+    }
+  }
+}
+
+struct ShareFieldRow<Field: View>: View {
+  let title: String
+  @ViewBuilder let field: Field
+
+  init(title: String, @ViewBuilder field: () -> Field) {
+    self.title = title
+    self.field = field()
+  }
+
+  var body: some View {
+    HStack(spacing: 12) {
+      Text(title)
+        .font(.system(size: 12, weight: .medium, design: .rounded))
+        .foregroundStyle(.secondary)
+        .frame(width: 130, alignment: .leading)
+        .accessibilityHidden(true)
+      field
+        .textFieldStyle(.plain)
+        .font(.system(size: 12.5, design: .rounded))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityLabel(title)
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 9)
+  }
+}
+
 struct ShareCard<Content: View>: View {
   enum Tone {
     case standard
@@ -142,6 +280,7 @@ private struct ShareToggleBody: View {
     .onHover { hovering in
       isHovering = isEnabled && hovering
     }
+    .accessibilityElement(children: .combine)
     .accessibilityValue(configuration.isOn ? "On" : "Off")
   }
 
@@ -287,5 +426,34 @@ struct ShareIconTile: View {
         in: RoundedRectangle(cornerRadius: 7, style: .continuous)
       )
       .animation(.easeOut(duration: 0.18), value: isActive)
+  }
+}
+
+struct ShareToggleLabel: View {
+  let systemName: String
+  var fallbackSystemName: String?
+  let title: String
+  var caption: String?
+  let isActive: Bool
+
+  var body: some View {
+    HStack(spacing: 10) {
+      ShareIconTile(
+        systemName: systemName,
+        fallbackSystemName: fallbackSystemName,
+        isActive: isActive)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title)
+          .font(.system(size: 12.5, weight: .medium, design: .rounded))
+          .foregroundStyle(.primary)
+          .lineLimit(1)
+        if let caption {
+          Text(caption)
+            .font(.system(size: 10.5, design: .rounded))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #100: the Quick Connect and desktop connection sheets still used stock grouped `Form`s, checkboxes-as-switches, and no dark pin — visually disconnected from the redesigned Share This Mac sheet. This PR extracts the sheet chrome from #100 into reusable components and rebuilds both connection sheets on the same system. Zero behavior change.

## What changed

- **`ShareDesignSystem.swift`**: new `ShareSheetContainer` (deck gradient, pinned dark scheme, mint tint, shared toggle style, and the height-capped measured ScrollView from #100), `ShareSheetHeader` (gradient icon tile + title/subtitle + optional trailing badge), `ShareFieldRow` (labeled plain-style field rows for cards), and `ShareToggleLabel` promoted from the share sheet. The custom switch also now merges its row text into its accessibility label (`.accessibilityElement(children: .combine)`) instead of reading as a bare "toggle button".
- **`SessionWorkspaceView.swift`**: `QuickConnectSheet` and `DesktopConnectionSheet` rebuilt as CONNECTION / OPTIONS / WAKE-ON-LAN cards with icon-tile toggle rows and captions; `ConnectionSheetHeader` deleted. Every binding, focus behavior, `onChange` handler, disabled rule, validation path, submit flow, prompt string, and keyboard shortcut is unchanged; `SecureField` stays a `SecureField`.
- **`PrivateMacShareView.swift`**: refactored onto the shared container/header — net −106 lines, rendering identical.

## Before / after (Quick Connect)

| Before | After |
| --- | --- |
| ![before](https://gist.githubusercontent.com/steipete/e0a952d4d8d92c7f088bb091e8d41b04/raw/qc-before.png) | ![after](https://gist.githubusercontent.com/steipete/e0a952d4d8d92c7f088bb091e8d41b04/raw/qc-after.png) |

`DesktopConnectionSheet` shares the identical structure (plus the profile-only Wake-on-LAN card condition).

## Proof

- `pnpm check`, `pnpm test`, `pnpm macos:test` green (see PR checks discussion below if any).
- Exercised live from a signed build: fields accept typed input with the address field auto-focused, custom switches toggle, disabled Wake-on-LAN rows dim until a MAC is entered, mint prominent action button.
- Codex autoreview clean.

Also investigated from #100's recap: the Share This Mac display picker hiding under the remote-desktop permission experiment is intended — `refreshDisplays()` correctly returns nothing while capture permission is missing, so there is nothing shareable to list.
