### PR TITLE
fix(quic): stop leaking a new QUIC host cert into the login keychain on every launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix the QUIC host identity leaking a new self-signed "Crabfleet QUIC" certificate into the login keychain on every launch: reuse the stored certificate by matching the stable host public key instead of a label macOS never persists, and collapse any already-accumulated duplicates back to one, restoring fast system-CA trust evaluation.
 - Extend the deck design language to the Quick Connect and desktop connection sheets: card-based fields and switches, gradient headers, pinned dark scheme, and a shared height-capped scrolling sheet container.
 - Redesign the Share This Mac sheet in the app's dark deck design language: pulsing readiness beacons with two-line status rows, custom capsule switches with icon tiles and captions, an animated segmented quality control, a live phase badge, and a restyled connect card — no behavior changes.
 - Fix the Crabfleet Connect Linux X11 backend disabling capture entirely on keyboards with multiple XKB groups: bind only the primary group's base/shift levels so real screen capture and input injection work instead of silently falling back to the synthetic test pattern (validated on a headless Xvfb X server: real 1920x1080 Tight framebuffer + XTest pointer injection).

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/QUICTransport.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/QUICTransport.swift
@@ -51,13 +51,10 @@ enum QUICIdentityStore {
     let publicKey = try publicKey(for: privateKey)
     let publicKeyData = try externalRepresentation(of: publicKey)
     let spki = try SubjectPublicKeyInfo.p256(publicKeyData: publicKeyData)
-    let certificate = try loadMatchingCertificate(
-      publicKeyData: publicKeyData,
-      certificateLabel: certificateLabel)
+    let certificate = try loadMatchingCertificate(publicKeyData: publicKeyData)
       ?? createAndStoreCertificate(
         privateKey: privateKey,
-        certificateLabel: certificateLabel,
-        spki: spki)
+        certificateLabel: certificateLabel)
     var identity: SecIdentity?
     guard SecIdentityCreateWithCertificate(nil, certificate, &identity) == errSecSuccess,
       let identity
@@ -68,13 +65,19 @@ enum QUICIdentityStore {
   }
 
   static func remove(applicationTag: Data, certificateLabel: String) {
+    // Delete the host certificate(s) by matching the permanent private key's
+    // public key. The certificate cannot be found by `certificateLabel`:
+    // macOS ignores the label supplied to `SecItemAdd` for a `SecCertificate`
+    // and stores it under the subject CN, so a label-keyed delete never hits.
+    if let privateKey = existingPrivateKey(applicationTag: applicationTag),
+      let publicKey = try? publicKey(for: privateKey),
+      let publicKeyData = try? externalRepresentation(of: publicKey),
+      let certificates = try? matchingCertificates(publicKeyData: publicKeyData) {
+      for certificate in certificates { deleteCertificate(certificate) }
+    }
     SecItemDelete([
       kSecClass: kSecClassKey,
       kSecAttrApplicationTag: applicationTag,
-    ] as CFDictionary)
-    SecItemDelete([
-      kSecClass: kSecClassCertificate,
-      kSecAttrLabel: certificateLabel,
     ] as CFDictionary)
   }
 
@@ -111,6 +114,21 @@ enum QUICIdentityStore {
     return key
   }
 
+  private static func existingPrivateKey(applicationTag: Data) -> SecKey? {
+    let query: [CFString: Any] = [
+      kSecClass: kSecClassKey,
+      kSecAttrApplicationTag: applicationTag,
+      kSecAttrKeyClass: kSecAttrKeyClassPrivate,
+      kSecReturnRef: true,
+      kSecMatchLimit: kSecMatchLimitOne,
+    ]
+    var result: CFTypeRef?
+    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+      let key = result as! SecKey?
+    else { return nil }
+    return key
+  }
+
   private static func publicKey(for privateKey: SecKey) throws -> SecKey {
     guard let key = SecKeyCopyPublicKey(privateKey) else {
       throw QUICTransportError.keyGeneration("public key unavailable")
@@ -127,42 +145,73 @@ enum QUICIdentityStore {
     return data
   }
 
-  private static func loadMatchingCertificate(
-    publicKeyData: Data,
-    certificateLabel: String
-  ) throws -> SecCertificate? {
+  /// Returns the stored host certificate, keyed off the permanent host public
+  /// key rather than a label.
+  ///
+  /// Certificates must not be looked up by `kSecAttrLabel`: when a
+  /// `SecCertificate` is added via `kSecValueRef`, macOS ignores the supplied
+  /// label and derives the stored label from the subject CN ("Crabfleet
+  /// QUIC"). The old label-keyed query (`"…Host Certificate v1"`) therefore
+  /// always returned `errSecItemNotFound`, so every launch minted and stored a
+  /// brand-new certificate. Because macOS system-trust evaluation walks every
+  /// login-keychain certificate, hundreds of leaked host certs slowed a single
+  /// TLS read from ~66ms to ~223s and broke all TLS on the machine.
+  ///
+  /// Matching on the stable public key is authoritative regardless of how the
+  /// item is labeled. Any surplus certificates that share the host key (left
+  /// behind by the old per-launch minting) are deleted here so an
+  /// already-polluted keychain collapses back to a single cert on next launch.
+  private static func loadMatchingCertificate(publicKeyData: Data) throws -> SecCertificate? {
+    let matches = try matchingCertificates(publicKeyData: publicKeyData)
+    guard let keep = matches.first else { return nil }
+    for duplicate in matches.dropFirst() {
+      let status = deleteCertificate(duplicate)
+      guard status == errSecSuccess || status == errSecItemNotFound else {
+        throw QUICTransportError.keychain(status)
+      }
+    }
+    return keep
+  }
+
+  /// Enumerates every stored certificate whose public key equals the host key.
+  /// A P-256 point comparison is exact, so unrelated (e.g. system-root)
+  /// certificates never match. This runs once per launch, not per handshake.
+  private static func matchingCertificates(publicKeyData: Data) throws -> [SecCertificate] {
     let query: [CFString: Any] = [
       kSecClass: kSecClassCertificate,
-      kSecAttrLabel: certificateLabel,
       kSecReturnRef: true,
-      kSecMatchLimit: kSecMatchLimitOne,
+      kSecMatchLimit: kSecMatchLimitAll,
     ]
     var result: CFTypeRef?
     let status = SecItemCopyMatching(query as CFDictionary, &result)
-    if status == errSecItemNotFound { return nil }
-    guard status == errSecSuccess, let certificate = result as! SecCertificate? else {
+    if status == errSecItemNotFound { return [] }
+    guard status == errSecSuccess, let certificates = result as? [SecCertificate] else {
       throw QUICTransportError.keychain(status)
     }
-    guard let certificateKey = SecCertificateCopyKey(certificate),
-      try externalRepresentation(of: certificateKey) == publicKeyData
-    else {
-      let deleteStatus = SecItemDelete([
-        kSecClass: kSecClassCertificate,
-        kSecValueRef: certificate,
-      ] as CFDictionary)
-      guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
-        throw QUICTransportError.keychain(deleteStatus)
-      }
-      return nil
+    return certificates.filter { certificate in
+      guard let certificateKey = SecCertificateCopyKey(certificate),
+        let representation = try? externalRepresentation(of: certificateKey)
+      else { return false }
+      return representation == publicKeyData
     }
-    return certificate
   }
 
-  private static func createAndStoreCertificate(
+  @discardableResult
+  private static func deleteCertificate(_ certificate: SecCertificate) -> OSStatus {
+    SecItemDelete([
+      kSecClass: kSecClassCertificate,
+      kSecValueRef: certificate,
+    ] as CFDictionary)
+  }
+
+  // Exposed to the test suite so it can reproduce the legacy per-launch leak
+  // (several distinct certs sharing one host key) and prove the self-heal.
+  static func createAndStoreCertificate(
     privateKey: SecKey,
-    certificateLabel: String,
-    spki: Data
+    certificateLabel: String
   ) throws -> SecCertificate {
+    let publicKeyData = try externalRepresentation(of: publicKey(for: privateKey))
+    let spki = try SubjectPublicKeyInfo.p256(publicKeyData: publicKeyData)
     let signatureAlgorithm = DER.sequence(DER.oid([1, 2, 840, 10045, 4, 3, 2]))
     let commonName = DER.sequence(
       DER.set(
@@ -218,6 +267,9 @@ enum QUICIdentityStore {
     guard let certificate = SecCertificateCreateWithData(nil, certificateData as CFData) else {
       throw QUICTransportError.certificateGeneration("invalid certificate encoding")
     }
+    // macOS ignores `kSecAttrLabel` for a certificate added by ref and labels
+    // it by subject CN; this is kept only so the intent is documented at the
+    // add site. Reuse is enforced by `loadMatchingCertificate`, not the label.
     let addQuery: [CFString: Any] = [
       kSecClass: kSecClassCertificate,
       kSecValueRef: certificate,

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/QUICTransportTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/QUICTransportTests.swift
@@ -56,6 +56,49 @@ struct QUICTransportTests {
     #expect(X509SerialNumber.canonicalDERContent(Data([1])) == Data([1]))
   }
 
+  @Test
+  func loadOrCreateReusesTheStoredCertificateWithoutAddingKeychainItems() throws {
+    let scope = QUICKeychainScope()
+    defer { scope.remove() }
+
+    let first = try scope.loadOrCreate()
+    let firstCertificate = try #require(certificate(of: first.identity))
+    let publicKeyData = try #require(publicKeyExternalRepresentation(of: firstCertificate))
+    #expect(storedCertificates(publicKeyData: publicKeyData).count == 1)
+
+    let second = try scope.loadOrCreate()
+    let secondCertificate = try #require(certificate(of: second.identity))
+
+    // Reuse (not a fresh mint) means an identical certificate: same pinned
+    // SPKI hash and byte-identical DER (a re-mint would have a random serial).
+    #expect(first.certHash == second.certHash)
+    #expect(SecCertificateCopyData(firstCertificate) == SecCertificateCopyData(secondCertificate))
+    #expect(storedCertificates(publicKeyData: publicKeyData).count == 1)
+  }
+
+  @Test
+  func loadOrCreateCollapsesLeakedDuplicateHostCertificates() throws {
+    let scope = QUICKeychainScope()
+    defer { scope.remove() }
+
+    let created = try scope.loadOrCreate()
+    let certificate = try #require(certificate(of: created.identity))
+    let publicKeyData = try #require(publicKeyExternalRepresentation(of: certificate))
+    let privateKey = try #require(storedPrivateKey(applicationTag: scope.applicationTag))
+
+    // Reproduce the pre-fix leak: extra distinct certificates (random serials)
+    // for the same host key, exactly what per-launch minting used to pile up.
+    _ = try QUICIdentityStore.createAndStoreCertificate(
+      privateKey: privateKey, certificateLabel: scope.certificateLabel)
+    _ = try QUICIdentityStore.createAndStoreCertificate(
+      privateKey: privateKey, certificateLabel: scope.certificateLabel)
+    #expect(storedCertificates(publicKeyData: publicKeyData).count == 3)
+
+    // Next launch must self-heal back to a single certificate.
+    _ = try scope.loadOrCreate()
+    #expect(storedCertificates(publicKeyData: publicKeyData).count == 1)
+  }
+
   @Test(
     .enabled(if: udpLoopbackAvailable, "UDP loopback is unavailable in this sandbox"),
     .timeLimit(.minutes(1)))
@@ -641,6 +684,71 @@ private final class QUICConnectionGroupStore: @unchecked Sendable {
     }
     for group in values { group.cancel() }
   }
+}
+
+/// A unique-per-test keychain identity scope. Keying every item off a random
+/// application tag isolates the test from the real host identity
+/// (`org.openclaw.crabfleet.quic.host-key-v1`) and from concurrent tests: the
+/// public-key match in `QUICIdentityStore` only ever sees this scope's certs.
+private struct QUICKeychainScope {
+  let applicationTag: Data
+  let certificateLabel: String
+  let keyLabel: String
+
+  init() {
+    let id = UUID().uuidString
+    applicationTag = Data("org.openclaw.crabfleet.tests.quic.\(id)".utf8)
+    certificateLabel = "Crabfleet QUIC Test Certificate \(id)"
+    keyLabel = "Crabfleet QUIC Test Key \(id)"
+  }
+
+  func loadOrCreate() throws -> QUICHostIdentity {
+    try QUICIdentityStore.loadOrCreate(
+      applicationTag: applicationTag,
+      certificateLabel: certificateLabel,
+      keyLabel: keyLabel)
+  }
+
+  func remove() {
+    QUICIdentityStore.remove(applicationTag: applicationTag, certificateLabel: certificateLabel)
+  }
+}
+
+private func certificate(of identity: SecIdentity) -> SecCertificate? {
+  var certificate: SecCertificate?
+  guard SecIdentityCopyCertificate(identity, &certificate) == errSecSuccess else { return nil }
+  return certificate
+}
+
+private func publicKeyExternalRepresentation(of certificate: SecCertificate) -> Data? {
+  guard let key = SecCertificateCopyKey(certificate) else { return nil }
+  var error: Unmanaged<CFError>?
+  return SecKeyCopyExternalRepresentation(key, &error) as Data?
+}
+
+private func storedPrivateKey(applicationTag: Data) -> SecKey? {
+  let query: [CFString: Any] = [
+    kSecClass: kSecClassKey,
+    kSecAttrApplicationTag: applicationTag,
+    kSecAttrKeyClass: kSecAttrKeyClassPrivate,
+    kSecReturnRef: true,
+    kSecMatchLimit: kSecMatchLimitOne,
+  ]
+  var result: CFTypeRef?
+  guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess else { return nil }
+  return result as! SecKey?
+}
+
+private func storedCertificates(publicKeyData: Data) -> [SecCertificate] {
+  let query: [CFString: Any] = [
+    kSecClass: kSecClassCertificate,
+    kSecReturnRef: true,
+    kSecMatchLimit: kSecMatchLimitAll,
+  ]
+  var result: CFTypeRef?
+  let status = SecItemCopyMatching(query as CFDictionary, &result)
+  guard status == errSecSuccess, let certificates = result as? [SecCertificate] else { return [] }
+  return certificates.filter { publicKeyExternalRepresentation(of: $0) == publicKeyData }
 }
 
 private struct QUICIdentityFixture {


### PR DESCRIPTION
## What Problem This Solves

On macOS, Crabfleet's QUIC host transport was minting and importing a **brand-new self-signed certificate into the login keychain on every launch**, never reusing or removing the previous one. They accumulated without bound — one heavily-used host reached **606** certificates (all labeled "Crabfleet QUIC"). Because macOS system-trust evaluation walks every login-keychain certificate, this pushed a single system-CA TLS read from ~66 ms to **~223 seconds**, which broke effectively *all* TLS on the machine (Node `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`, the OpenClaw gateway freezing on first outbound TLS) even though `curl` (a separate trust path) still worked.

## Why This Change Was Made

The identity store *intended* to reuse one stable host identity, and the private key was reused correctly (keyed by the permanent `kSecAttrApplicationTag`). But the **certificate** dedup was broken: `createAndStoreCertificate` added the cert with `kSecAttrLabel = "Crabfleet QUIC Host Certificate v1"`, yet macOS **ignores `kSecAttrLabel` when a `SecCertificate` is added via `kSecValueRef`** and stores the item under the subject CN (`"Crabfleet QUIC"`). `loadMatchingCertificate` then looked the cert up **by that never-stored label** → always `errSecItemNotFound` → a fresh cert (random serial) was minted and added every launch. `remove()` had the identical label bug, so it never deleted anything either — meaning the test suite itself was leaking a cert on every run.

## User Impact

- The QUIC host certificate is now created once and reused; no more per-launch keychain growth.
- **Self-healing:** any already-polluted keychain (hundreds of leaked "Crabfleet QUIC" certs) collapses back to a single certificate on the next launch.
- No behavior or security change to the transport: certificate pinning (`QUICCertificatePin` / `sec_protocol_options_set_verify_block`) and the trust store are untouched.

## Evidence

- Fix: `macos/CrabfleetMac/Sources/CrabfleetMac/QUICTransport.swift` — `loadMatchingCertificate` now matches the stored cert on the **stable host public key** (exact P-256 point compare; system-root certs never collide), deletes any surplus certs sharing that key (self-heal), and `remove()` is fixed symmetrically via the permanent private key.
- Tests (`Tests/CrabfleetMacTests/QUICTransportTests.swift`): `loadOrCreate` twice yields byte-identical DER and keeps the stored-cert count at **1**; injecting 3 distinct certs that share one host key collapses to **1**. Both use a unique per-test `applicationTag` so they isolate from the real `org.openclaw.crabfleet.quic.host-key-v1` identity; they fail against the old code.
- `swift build` clean; `swift test --filter QUICTransportTests` → **12/12 pass** (2 new + 10 existing, incl. the UDP-loopback QUIC handshake tests). Verified **0** "Crabfleet QUIC" certs remain in the login keychain after the run.

Note: the macOS Swift package isn't covered by this repo's CI (worker/CLI/pages only), so proof is the local build + test above.
