### PR TITLE
fix(macos): stop cursor reconcile and mailbox waits on cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Stop cursor-reconcile retries and mailbox timeout waits when the share task is cancelled, so teardown does not stall.
+
 ## 0.3.1 - 2026-08-28
 
 ### Highlights

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/MacScreenCapture.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/MacScreenCapture.swift
@@ -418,7 +418,14 @@ final class MacScreenCapture: NSObject, @unchecked Sendable {
             try await self.reconcileCursorConfiguration()
             break
           } catch {
-            try? await Task.sleep(for: delay)
+            guard Self.isRetryableCursorReconcileError(error) else { break }
+            do {
+              try await Task.sleep(for: delay)
+            } catch is CancellationError {
+              break
+            } catch {
+              break
+            }
             delay = min(delay * 2, .seconds(5))
           }
         }
@@ -432,6 +439,10 @@ final class MacScreenCapture: NSObject, @unchecked Sendable {
       return task
     }
     _ = task
+  }
+
+  static func isRetryableCursorReconcileError(_ error: Error) -> Bool {
+    !(error is CancellationError)
   }
 
   private func reconcileCursorConfiguration() async throws {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/VideoMailbox.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/VideoMailbox.swift
@@ -12,6 +12,7 @@ final class VideoMailbox<Element>: @unchecked Sendable {
   private let lock = NSLock()
   private var latestElement: Element?
   private var waiter: Waiter?
+  private var timeoutTask: Task<Void, Never>?
   private var finished = false
 
   var isFinished: Bool {
@@ -30,27 +31,36 @@ final class VideoMailbox<Element>: @unchecked Sendable {
   }
 
   func offer(_ element: Element, onDrop: () -> Void = {}) {
-    let continuation = withLock { () -> CheckedContinuation<Element?, Never>? in
-      guard !finished else { return nil }
+    let (continuation, timeoutTask) = withLock {
+      () -> (CheckedContinuation<Element?, Never>?, Task<Void, Never>?) in
+      guard !finished else { return (nil, nil) }
       guard let waiter else {
         if latestElement != nil { onDrop() }
         latestElement = element
-        return nil
+        return (nil, nil)
       }
       self.waiter = nil
-      return waiter.continuation
+      let timeoutTask = self.timeoutTask
+      self.timeoutTask = nil
+      return (waiter.continuation, timeoutTask)
     }
+    timeoutTask?.cancel()
     continuation?.resume(returning: element)
   }
 
   func finish() {
-    let continuation = withLock { () -> CheckedContinuation<Element?, Never>? in
-      guard !finished else { return nil }
+    let (continuation, timeoutTask) = withLock {
+      () -> (CheckedContinuation<Element?, Never>?, Task<Void, Never>?) in
+      guard !finished else { return (nil, nil) }
       finished = true
       latestElement = nil
-      defer { waiter = nil }
-      return waiter?.continuation
+      let continuation = waiter?.continuation
+      let timeoutTask = self.timeoutTask
+      waiter = nil
+      self.timeoutTask = nil
+      return (continuation, timeoutTask)
     }
+    timeoutTask?.cancel()
     continuation?.resume(returning: nil)
   }
 
@@ -64,6 +74,7 @@ final class VideoMailbox<Element>: @unchecked Sendable {
         var immediateElement: Element?
         var shouldResume = false
         var replacedWaiter: Waiter?
+        var replacedTimeout: Task<Void, Never>?
         lock.lock()
         if let latestElement {
           immediateElement = latestElement
@@ -73,16 +84,35 @@ final class VideoMailbox<Element>: @unchecked Sendable {
           shouldResume = true
         } else {
           replacedWaiter = waiter
+          replacedTimeout = timeoutTask
+          timeoutTask = nil
           waiter = (id, continuation)
         }
         lock.unlock()
 
         replacedWaiter?.continuation.resume(returning: nil)
+        replacedTimeout?.cancel()
         if shouldResume {
           continuation.resume(returning: immediateElement)
         } else {
-          Task {
-            try? await Task.sleep(for: timeout)
+          let task = Task {
+            do {
+              try await Task.sleep(for: timeout)
+              self.expire(id: id)
+            } catch is CancellationError {
+              // Do not expire a different waiter; expire already guards by id.
+            } catch {
+              self.expire(id: id)
+            }
+          }
+          let shouldCancelTimeout = withLock { () -> Bool in
+            guard waiter?.id == id else { return true }
+            timeoutTask = task
+            return false
+          }
+          if shouldCancelTimeout {
+            task.cancel()
+          } else if Task.isCancelled {
             self.expire(id: id)
           }
         }
@@ -93,11 +123,16 @@ final class VideoMailbox<Element>: @unchecked Sendable {
   }
 
   private func expire(id: UUID) {
-    let continuation = withLock { () -> CheckedContinuation<Element?, Never>? in
-      guard waiter?.id == id else { return nil }
-      defer { waiter = nil }
-      return waiter?.continuation
+    let (continuation, timeoutTask) = withLock {
+      () -> (CheckedContinuation<Element?, Never>?, Task<Void, Never>?) in
+      guard waiter?.id == id else { return (nil, nil) }
+      let continuation = waiter?.continuation
+      let timeoutTask = self.timeoutTask
+      waiter = nil
+      self.timeoutTask = nil
+      return (continuation, timeoutTask)
     }
+    timeoutTask?.cancel()
     continuation?.resume(returning: nil)
   }
 

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/VideoPipelineTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/VideoPipelineTests.swift
@@ -378,6 +378,30 @@ struct VideoPipelineTests {
   }
 
   @Test
+  func mailboxCancelledWaiterReturnsPromptlyWithoutResumingTwice() async {
+    let mailbox = VideoMailbox<Int>()
+    let startedAt = ContinuousClock().now
+    let task = Task {
+      withUnsafeCurrentTask { $0?.cancel() }
+      return await mailbox.next(timeout: .seconds(5))
+    }
+    let result = await task.value
+    #expect(result == nil)
+    #expect(ContinuousClock().now - startedAt < .milliseconds(500))
+
+    mailbox.offer(4)
+    #expect(await mailbox.next(timeout: .milliseconds(50)) == 4)
+  }
+
+  @Test
+  func cursorReconcileErrorsAreNotRetryableWhenCancelled() {
+    #expect(!MacScreenCapture.isRetryableCursorReconcileError(CancellationError()))
+    #expect(
+      MacScreenCapture.isRetryableCursorReconcileError(
+        NSError(domain: "CrabfleetMacTests", code: 1)))
+  }
+
+  @Test
   func videoNegotiationPrefersHEVCThenH264ThenTight() {
     let offered = [
       RFBWire.tightEncoding,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stopping Share This Mac (or cancelling a share task) could leave cursor-reconcile retries and mailbox timeout waits running. Cursor reconcile treated `CancellationError` as a normal failure and slept with `try?`, so cancel became another backoff retry. The video mailbox spawned an unstructured timeout task that used `try?` sleep and was never cancelled when a frame arrived or the waiter went away.

## Why This Change Was Made

Honor cancellation in both loops: break when reconcile or its sleep is cancelled, and cancel the mailbox timeout task on offer, finish, replace, and expire. `Task.sleep` now uses `try await` so cancel stops the wait.

## User Impact

Share teardown no longer waits out a 5s backoff or a leftover mailbox timeout after the user stops sharing.

## Evidence

Terminal output from the patched tree. Before the patch, a cancelled mailbox waiter sat for the full 5s timeout:

```console
$ swift test --package-path macos/CrabfleetMac --filter mailboxCancelledWaiter
Expectation failed: (ContinuousClock().now - startedAt -> 5.002 seconds) < 0.5 seconds
Test mailboxCancelledWaiterReturnsPromptlyWithoutResumingTwice() failed after 5.002 seconds
```

After the patch the same waiter returns immediately:

```console
$ swift test --package-path macos/CrabfleetMac --filter mailboxCancelledWaiter
Test mailboxCancelledWaiterReturnsPromptlyWithoutResumingTwice() passed after 0.001 seconds.
Test run with 1 test in 1 suite passed after 0.001 seconds.
```

## Real behavior proof

- **Behavior or issue addressed:** Share cancel no longer retries cursor reconcile or leaves mailbox timeout tasks sleeping.
- **Real environment tested:** macOS, Xcode at /Applications/Xcode.app, swift-testing on arm64, branch fix/macos-cancel-hangs at 0b6a6cc.
- **Exact steps or command run after this patch:**

  ```bash
  export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
  swift test --package-path macos/CrabfleetMac --filter mailboxCancelledWaiter
  ```

- **Evidence after fix:** terminal output from the patched tree:

  ```console
  $ swift test --package-path macos/CrabfleetMac --filter mailboxCancelledWaiter
  Test mailboxCancelledWaiterReturnsPromptlyWithoutResumingTwice() passed after 0.001 seconds.
  Test run with 1 test in 1 suite passed after 0.001 seconds.
  ```

- **Observed result after fix:** A cancelled mailbox `next(timeout: 5s)` returns in 0.001s instead of waiting the full 5s. Cursor reconcile treats CancellationError as non-retryable.
- **What was not tested:** Live ScreenCaptureKit session with a real display share and TCC grants.

Related: introduced in [#90](https://github.com/openclaw/crabfleet/pull/90) (cursor reconcile) and [#74](https://github.com/openclaw/crabfleet/pull/74) (mailbox timeout Task).
