### PR TITLE
fix(macos): stabilize required test gate

### DIFF
--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/LoopbackTestSupport.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/LoopbackTestSupport.swift
@@ -1,0 +1,26 @@
+import Darwin
+import Foundation
+
+func availableLoopbackPort(socketType: Int32) throws -> UInt16 {
+  let descriptor = socket(AF_INET, socketType, 0)
+  guard descriptor >= 0 else { throw POSIXError(.ENOTSOCK) }
+  defer { close(descriptor) }
+  var address = sockaddr_in()
+  address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+  address.sin_family = sa_family_t(AF_INET)
+  address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+  let bound = withUnsafePointer(to: &address) {
+    $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+      bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size)) == 0
+    }
+  }
+  guard bound else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EINVAL) }
+  var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+  let resolved = withUnsafeMutablePointer(to: &address) {
+    $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+      getsockname(descriptor, $0, &length) == 0
+    }
+  }
+  guard resolved else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EINVAL) }
+  return UInt16(bigEndian: address.sin_port)
+}

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
@@ -202,7 +202,7 @@ struct PrivateMacShareTests {
       try await runner.run(arguments: ["status"])
     }
     #expect(await waitUntilAsync {
-      FileManager.default.fileExists(atPath: descendantPIDFile.path)
+      (try? Int32(String(contentsOf: descendantPIDFile, encoding: .utf8))) != nil
     })
     let descendantPID = try #require(
       Int32(String(contentsOf: descendantPIDFile, encoding: .utf8))
@@ -1037,6 +1037,11 @@ struct PrivateMacShareTests {
       Notification(name: NSApplication.didFinishLaunchingNotification)
     )
     #expect(await waitUntilAsync { await runner.callCount == 1 })
+    let refreshFinished = Task { @MainActor in
+      for await isRefreshing in controller.$isRefreshing.values where !isRefreshing {
+        return
+      }
+    }
     #expect(delegate.applicationShouldTerminate(application) == .terminateLater)
     #expect(await waitUntilAsync { replies == [true] })
 
@@ -1051,6 +1056,7 @@ struct PrivateMacShareTests {
     }
 
     #expect(!continuedPreflight)
+    await refreshFinished.value
     #expect(!controller.isRefreshing)
     #expect(controller.phase == .idle)
   }
@@ -2338,6 +2344,7 @@ struct PrivateMacShareTests {
 
   @Test @MainActor
   func expiresIncompleteRFBHandshakeAndReleasesInput() async throws {
+    try await RFBARDPrewarmer.shared.prepare()
     let identity = TailnetIdentity(
       tailnetName: "example.com",
       loginName: "tester@example.com",
@@ -2349,7 +2356,7 @@ struct PrivateMacShareTests {
     let capture = MacScreenCapture()
     let input = RemoteInputRecorder()
     let events = RFBEventRecorder()
-    let port: UInt16 = 5_923
+    let port = try availableLoopbackPort(socketType: SOCK_STREAM)
     let server = TailnetRFBServer(
       identity: identity,
       runner: StaticTailscaleRunner(output: ""),
@@ -2646,6 +2653,7 @@ struct PrivateMacShareTests {
       return
     }
 
+    try await RFBARDPrewarmer.shared.prepare()
     let runner = try SystemTailscaleCommandRunner()
     let status = try await runner.run(arguments: ["status", "--json"])
     let document = try JSONDecoder().decode(
@@ -2709,6 +2717,7 @@ struct PrivateMacShareTests {
 
   @Test @MainActor
   func syncsUTF8ClipboardAndNegotiatesResizeOverLoopback() async throws {
+    try await RFBARDPrewarmer.shared.prepare()
     // Full-protocol end-to-end: the production server and the RoyalVNCKit
     // client exchange handshake, Tight frames, Extended Clipboard, and
     // ExtendedDesktopSize over a real TCP connection on loopback. The
@@ -2731,7 +2740,7 @@ struct PrivateMacShareTests {
     hostPasteboard.clearContents()
     let hostClipboard = HostClipboardBridge(pasteboard: hostPasteboard, pollingInterval: 0.02)
 
-    let port: UInt16 = 5_921
+    let port = try availableLoopbackPort(socketType: SOCK_STREAM)
     let events = RFBEventRecorder()
     let server = TailnetRFBServer(
       identity: identity,

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/QUICTransportTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/QUICTransportTests.swift
@@ -82,8 +82,8 @@ struct QUICTransportTests {
     defer { scope.remove() }
 
     let created = try scope.loadOrCreate()
-    let certificate = try #require(certificate(of: created.identity))
-    let publicKeyData = try #require(publicKeyExternalRepresentation(of: certificate))
+    let hostCertificate = try #require(certificate(of: created.identity))
+    let publicKeyData = try #require(publicKeyExternalRepresentation(of: hostCertificate))
     let privateKey = try #require(storedPrivateKey(applicationTag: scope.applicationTag))
 
     // Reproduce the pre-fix leak: extra distinct certificates (random serials)
@@ -153,6 +153,7 @@ struct QUICTransportTests {
     .timeLimit(.minutes(1)))
   @MainActor
   func tailnetQUICListenerAuthenticatesWithARD() async throws {
+    try await RFBARDPrewarmer.shared.prepare()
     let fixture = try QUICIdentityFixture()
     defer { fixture.remove() }
     let tcpPort = try availableLoopbackPort(socketType: SOCK_STREAM)
@@ -452,6 +453,7 @@ struct QUICTransportTests {
 
   @Test(.enabled(if: udpLoopbackAvailable, "UDP loopback is unavailable in this sandbox"))
   func keepsTCPListenerReadyWhenQUICPortIsOccupied() async throws {
+    try await RFBARDPrewarmer.shared.prepare()
     let fixture = try QUICIdentityFixture()
     defer { fixture.remove() }
     let blocker = try UDPPortReservation()
@@ -499,6 +501,7 @@ struct QUICTransportTests {
     .enabled(if: udpLoopbackAvailable, "UDP loopback is unavailable in this sandbox"),
     .timeLimit(.minutes(1)))
   func connectionGroupsWithoutStreamsDoNotReserveViewerSlots() async throws {
+    try await RFBARDPrewarmer.shared.prepare()
     let fixture = try QUICIdentityFixture()
     defer { fixture.remove() }
     let tcpPort = try availableLoopbackPort(socketType: SOCK_STREAM)
@@ -578,30 +581,6 @@ struct QUICTransportTests {
     #expect(gate.activeCount == 0)
     #expect(gate.reservedCount == 0)
   }
-}
-
-private func availableLoopbackPort(socketType: Int32) throws -> UInt16 {
-  let descriptor = socket(AF_INET, socketType, 0)
-  guard descriptor >= 0 else { throw POSIXError(.ENOTSOCK) }
-  defer { close(descriptor) }
-  var address = sockaddr_in()
-  address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
-  address.sin_family = sa_family_t(AF_INET)
-  address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
-  let bound = withUnsafePointer(to: &address) {
-    $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-      bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size)) == 0
-    }
-  }
-  guard bound else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EINVAL) }
-  var length = socklen_t(MemoryLayout<sockaddr_in>.size)
-  let resolved = withUnsafeMutablePointer(to: &address) {
-    $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-      getsockname(descriptor, $0, &length) == 0
-    }
-  }
-  guard resolved else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EINVAL) }
-  return UInt16(bigEndian: address.sin_port)
 }
 
 private final class UDPPortReservation {

--- a/macos/CrabfleetMac/scripts/run-tests.sh
+++ b/macos/CrabfleetMac/scripts/run-tests.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+package_path=macos/CrabfleetMac
+integration_tests='tailnetQUICListenerAuthenticatesWithARD|keepsTCPListenerReadyWhenQUICPortIsOccupied|connectionGroupsWithoutStreamsDoNotReserveViewerSlots|expiresIncompleteRFBHandshakeAndReleasesInput|servesRoyalVNCKitOverTheCurrentTailnet|syncsUTF8ClipboardAndNegotiatesResizeOverLoopback|revokingNativeAccessStopsPendingCrabboxBridge'
+
+# TailnetRFBServer waits for the shared ARD crypto prewarm before binding.
+# The Crabbox bridge test likewise depends on prompt subprocess scheduling.
+# Bound unit-test fan-out, then run these integration tests alone so their
+# existing listener and lifecycle deadlines remain meaningful.
+swift test \
+  --package-path "$package_path" \
+  --experimental-maximum-parallelization-width 8 \
+  --skip "$integration_tests"
+swift test \
+  --package-path "$package_path" \
+  --skip-build \
+  --experimental-maximum-parallelization-width 1 \
+  --filter "$integration_tests"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "macos:build": "swift build --package-path macos/CrabfleetMac",
     "macos:bundle": "sh macos/CrabfleetMac/scripts/build-app.sh",
     "macos:run": "swift run --package-path macos/CrabfleetMac CrabfleetMac",
-    "macos:test": "pnpm macos:test:vendor && swift test --package-path macos/CrabfleetMac",
+    "macos:test": "pnpm macos:test:vendor && sh macos/CrabfleetMac/scripts/run-tests.sh",
     "macos:test:vendor": "swift test --package-path macos/CrabfleetMac/Vendor/RoyalVNCKit",
     "test": "node --test --experimental-strip-types tests/*.test.ts",
     "test:changed": "pnpm run test"


### PR DESCRIPTION
## Summary

- fix the QUIC certificate helper shadowing compile failure
- make lifecycle/subprocess fixtures await authoritative state instead of racy file or wall-clock observations
- prewarm ARD crypto before listener deadlines and allocate ephemeral loopback ports
- bound Swift Testing fan-out and serialize the seven environment-heavy integration tests

## Root cause

`TailnetRFBServer.start()` waits for the shared ARD crypto prewarm before binding. Under the default unbounded Swift Testing fan-out, that setup consumed listener deadlines and caused unrelated loopback failures. Two lifecycle fixtures also observed intermediate state: one read a PID file before its write completed, and one polled refresh completion instead of awaiting the published transition.

The repair keeps existing assertions and deadlines unchanged. Production LOC delta: 0.

## Validation

- `pnpm check`
- `pnpm test` (995 passed)
- `pnpm macos:test`
  - RoyalVNCKit: 121 passed
  - CrabfleetMac bounded pass: 294 passed
  - serialized integration pass: 7 passed
- repaired lifecycle/process tests: 5 repeated paired runs passed
