### PR TITLE
fix(macos): wait for complete PID fixtures

### DIFF
--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/FleetModelsTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/FleetModelsTests.swift
@@ -128,18 +128,16 @@ struct FleetModelsTests {
       }
     )
 
-    let pid = try #require(
-      Int(String(contentsOf: pidFile, encoding: .utf8))
-    )
-    #expect(Darwin.kill(Int32(pid), 0) == 0)
+    let pid = try #require(readProcessID(from: pidFile))
+    #expect(Darwin.kill(pid, 0) == 0)
     bridge?.stop()
     bridge = nil
 
     let deadline = Date().addingTimeInterval(3)
-    while Darwin.kill(Int32(pid), 0) == 0 && Date() < deadline {
+    while Darwin.kill(pid, 0) == 0 && Date() < deadline {
       try await Task.sleep(for: .milliseconds(50))
     }
-    #expect(Darwin.kill(Int32(pid), 0) != 0)
+    #expect(Darwin.kill(pid, 0) != 0)
   }
 
   @Test @MainActor
@@ -169,15 +167,13 @@ struct FleetModelsTests {
       grant: { nativeVNCGrant() }
     )
     let launched = await waitUntil(timeout: .seconds(2)) {
-      FileManager.default.fileExists(atPath: pidFile.path)
+      readProcessID(from: pidFile) != nil
     }
-    let pid = try #require(
-      launched ? Int(String(contentsOf: pidFile, encoding: .utf8)) : nil
-    )
+    let pid = try #require(launched ? readProcessID(from: pidFile) : nil)
 
     pool.reconcile(validTargetIDs: ["fleet-native"], nativeSessionIDs: [:])
     let stopped = await waitUntil(timeout: .seconds(3)) {
-      Darwin.kill(Int32(pid), 0) != 0
+      Darwin.kill(pid, 0) != 0
     }
     #expect(stopped)
   }

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/PrivateMacShareTests.swift
@@ -89,15 +89,15 @@ struct PrivateMacShareTests {
       try await cancellableRunner.run(arguments: ["status"])
     }
     let launched = await waitUntilAsync {
-      FileManager.default.fileExists(atPath: pidFile.path)
+      readProcessID(from: pidFile) != nil
     }
     #expect(launched)
-    let cancelledPID = try #require(Int(String(contentsOf: pidFile, encoding: .utf8)))
+    let cancelledPID = try #require(readProcessID(from: pidFile))
     task.cancel()
     await #expect(throws: CancellationError.self) {
       try await task.value
     }
-    #expect(await waitUntilAsync { Darwin.kill(Int32(cancelledPID), 0) != 0 })
+    #expect(await waitUntilAsync { Darwin.kill(cancelledPID, 0) != 0 })
   }
 
   @Test
@@ -130,9 +130,7 @@ struct PrivateMacShareTests {
     }
     let elapsed = startedAt.duration(to: clock.now)
 
-    let descendantPID = try #require(
-      Int32(String(contentsOf: descendantPIDFile, encoding: .utf8))
-    )
+    let descendantPID = try #require(readProcessID(from: descendantPIDFile))
     #expect(await waitUntilAsync { Darwin.kill(descendantPID, 0) != 0 })
     #expect(elapsed < .seconds(4))
   }
@@ -165,9 +163,7 @@ struct PrivateMacShareTests {
     let result = try await runner.run(arguments: ["status"])
     let elapsed = startedAt.duration(to: clock.now)
 
-    let descendantPID = try #require(
-      Int32(String(contentsOf: descendantPIDFile, encoding: .utf8))
-    )
+    let descendantPID = try #require(readProcessID(from: descendantPIDFile))
     defer {
       _ = Darwin.kill(descendantPID, SIGKILL)
     }
@@ -202,11 +198,9 @@ struct PrivateMacShareTests {
       try await runner.run(arguments: ["status"])
     }
     #expect(await waitUntilAsync {
-      (try? Int32(String(contentsOf: descendantPIDFile, encoding: .utf8))) != nil
+      readProcessID(from: descendantPIDFile) != nil
     })
-    let descendantPID = try #require(
-      Int32(String(contentsOf: descendantPIDFile, encoding: .utf8))
-    )
+    let descendantPID = try #require(readProcessID(from: descendantPIDFile))
     task.cancel()
     await #expect(throws: CancellationError.self) {
       try await task.value

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/ProcessTestSupport.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/ProcessTestSupport.swift
@@ -1,0 +1,13 @@
+import Darwin
+import Foundation
+
+func readProcessID(from file: URL) -> pid_t? {
+  guard
+    let contents = try? String(contentsOf: file, encoding: .utf8),
+    let processID = pid_t(contents),
+    processID > 0
+  else {
+    return nil
+  }
+  return processID
+}


### PR DESCRIPTION
## Summary

- treat a positive, parseable PID as the readiness boundary for subprocess fixtures
- share that PID parser across the Tailscale and Crabbox lifecycle tests
- preserve existing lifecycle assertions and timeout budgets

## Root cause

The shell fixture creates the PID path before `printf` has completed writing its contents. Tests that waited only for `fileExists` could immediately read an empty file and fail to parse the PID.

Unchanged `main` reproduced the failure on repetition 2. The production process runner publishes and cancels subprocesses correctly; the race belongs to the test fixture's readiness check.

## Repair

`readProcessID(from:)` makes the fixture's authoritative readiness condition explicit: the file must contain a positive process ID. All same-class PID readers in the Tailscale and Crabbox subprocess suites now use that helper.

No sleeps or timeouts were added, and no assertions were weakened. Production LOC delta: 0.

## Verification

- unchanged `main`: reproduced the empty PID read on repetition 2
- repaired exact failing test: 25 consecutive passes
- six related Tailscale/Crabbox subprocess lifecycle tests: passed
- `pnpm check`: passed
- `pnpm test`: passed (995 tests)
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer pnpm macos:test`: passed
