### PR TITLE
chore(admin): disable retired repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Disable the retired `openclaw/clawsweeper-home` and `openclaw/crabbox-fleet` repository targets while keeping `openclaw/test-permissions-check` enabled for permission probes.
 - Keep slow terminal resize authorization off the shared multiplexed connection queue so other sessions and pings remain responsive, thanks @anagnorisis2peripeteia.
 - Preserve live terminal resubscriptions when stale upstream close, error, or revocation callbacks arrive for a replaced subscription, thanks @anagnorisis2peripeteia.
 - Preserve stalled card-run provenance by fencing lane completion and its audit event in one guarded D1 batch, preventing concurrent completion from overwriting terminal state, thanks @anagnorisis2peripeteia.

--- a/migrations/0043_disable_retired_repositories.sql
+++ b/migrations/0043_disable_retired_repositories.sql
@@ -1,0 +1,7 @@
+UPDATE repos
+SET
+  enabled = 0,
+  updated_at = unixepoch() * 1000
+WHERE
+  repo IN ('openclaw/clawsweeper-home', 'openclaw/crabbox-fleet')
+  AND enabled <> 0;

--- a/tests/repository-retirement-migration.test.ts
+++ b/tests/repository-retirement-migration.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+
+import { AdminRepository } from "../src/worker/admin-repository.ts";
+import type { RuntimeEnv } from "../src/worker/env.ts";
+
+const migration = readFileSync(
+  new URL("../migrations/0043_disable_retired_repositories.sql", import.meta.url),
+  "utf8",
+);
+
+type BoundStatement = {
+  execute(): {
+    results: Record<string, unknown>[];
+    success: true;
+    meta: { changes: number; last_row_id?: number };
+  };
+};
+
+function repositoryDatabase(): DatabaseSync {
+  const database = new DatabaseSync(":memory:");
+  database.exec(`
+    CREATE TABLE repos (
+      repo TEXT PRIMARY KEY,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    INSERT INTO repos (repo, enabled, created_at, updated_at) VALUES
+      ('openclaw/clawsweeper-home', 1, 1, 11),
+      ('openclaw/crabbox-fleet', 1, 2, 22),
+      ('openclaw/test-permissions-check', 1, 3, 33),
+      ('openclaw/crabfleet', 1, 4, 44);
+  `);
+  return database;
+}
+
+function repoRows(database: DatabaseSync): Record<string, unknown>[] {
+  return database
+    .prepare("SELECT repo, enabled, created_at, updated_at FROM repos ORDER BY repo")
+    .all()
+    .map((row) => ({ ...row }));
+}
+
+function sqliteRuntimeEnv(sqlite: DatabaseSync): RuntimeEnv {
+  function execute(sql: string, parameters: unknown[]) {
+    const statement = sqlite.prepare(sql);
+    if (/^\s*(?:select|pragma|with)\b|\breturning\b/i.test(sql)) {
+      return {
+        results: statement.all(...parameters).map((row) => ({ ...row })),
+        success: true as const,
+        meta: {
+          changes: Number(sqlite.prepare("SELECT changes() AS changes").get()?.changes ?? 0),
+        },
+      };
+    }
+    const result = statement.run(...parameters);
+    return {
+      results: [],
+      success: true as const,
+      meta: {
+        changes: Number(result.changes),
+        last_row_id: Number(result.lastInsertRowid),
+      },
+    };
+  }
+  return {
+    DB: {
+      prepare(sql: string) {
+        return {
+          bind(...parameters: unknown[]) {
+            const bound = {
+              execute: () => execute(sql, parameters),
+              async all() {
+                return bound.execute();
+              },
+              async run() {
+                return bound.execute();
+              },
+            };
+            return bound;
+          },
+        };
+      },
+      async batch(statements: D1PreparedStatement[]) {
+        sqlite.exec("BEGIN IMMEDIATE");
+        try {
+          const results = statements.map((statement) =>
+            (statement as unknown as BoundStatement).execute(),
+          );
+          sqlite.exec("COMMIT");
+          return results;
+        } catch (error) {
+          sqlite.exec("ROLLBACK");
+          throw error;
+        }
+      },
+    } as unknown as D1Database,
+  } as RuntimeEnv;
+}
+
+test("repository retirement migration disables only the retired repositories idempotently", () => {
+  const database = repositoryDatabase();
+  database.exec(migration);
+
+  const firstRun = repoRows(database);
+  assert.deepEqual(
+    firstRun.map(({ repo, enabled }) => ({ repo, enabled })),
+    [
+      { repo: "openclaw/clawsweeper-home", enabled: 0 },
+      { repo: "openclaw/crabbox-fleet", enabled: 0 },
+      { repo: "openclaw/crabfleet", enabled: 1 },
+      { repo: "openclaw/test-permissions-check", enabled: 1 },
+    ],
+  );
+  assert.equal(
+    firstRun.find((row) => row.repo === "openclaw/test-permissions-check")?.updated_at,
+    33,
+  );
+
+  database.exec(migration);
+  assert.deepEqual(repoRows(database), firstRun);
+});
+
+test("admin repository exposes the migrated enabled set and keeps permission probes available", async () => {
+  const database = repositoryDatabase();
+  database.exec(migration);
+  const repository = new AdminRepository(sqliteRuntimeEnv(database));
+
+  assert.deepEqual(await repository.readEnabledRepos(), [
+    "openclaw/crabfleet",
+    "openclaw/test-permissions-check",
+  ]);
+  await repository.requireRepo("openclaw/test-permissions-check");
+  await assert.rejects(repository.requireRepo("openclaw/clawsweeper-home"), (error) => {
+    assert.equal(
+      typeof error === "object" && error !== null && "status" in error ? error.status : undefined,
+      403,
+    );
+    return true;
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where two retired repository targets remained enabled in Crabfleet's repository allowlist after their workloads were retired.

## Why This Change Was Made

Adds the next additive, idempotent D1 migration to disable only `openclaw/clawsweeper-home` and `openclaw/crabbox-fleet`. The migration deliberately leaves `openclaw/test-permissions-check` enabled, and focused coverage exercises both the migrated rows and the canonical `AdminRepository` runtime behavior.

This changes only Crabfleet allowlist state. It does not delete or otherwise modify any GitHub repository.

## User Impact

Operators can no longer select the two retired targets, while permission-probe workflows using `openclaw/test-permissions-check` continue to work.

## Evidence

- `node --test --experimental-strip-types tests/repository-retirement-migration.test.ts` - 2/2 passed
- `pnpm check` - passed
- `pnpm test` - 997/997 passed
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer pnpm macos:test`
  - RoyalVNCKit: 121/121 passed
  - CrabfleetMac app suite: 294/294 passed
  - Serialized loopback suite: 7/7 passed
- Migration applied twice in the focused test produces identical rows.
- Runtime proof confirms `openclaw/test-permissions-check` remains enabled and `openclaw/clawsweeper-home` is rejected by the allowlist.
