### PR TITLE
fix(ci): add multi-language CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,103 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "49 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze-script:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - javascript-typescript
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  analyze-go:
+    name: Analyze (go)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: go
+          build-mode: autobuild
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: /language:go
+
+  analyze-swift:
+    name: Analyze (swift)
+    runs-on: macos-26
+    timeout-minutes: 45
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: swift
+          build-mode: manual
+
+      - name: Build
+        run: >-
+          swift build
+          --package-path macos/CrabfleetMac
+          --scratch-path "$RUNNER_TEMP/crabfleet-codeql-swift"
+          --arch arm64
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: /language:swift

--- a/tests/codeql-workflow.test.ts
+++ b/tests/codeql-workflow.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflow = await readFile(
+  new URL("../.github/workflows/codeql.yml", import.meta.url),
+  "utf8",
+);
+
+test("CodeQL covers every first-party language with its required build mode", () => {
+  assert.match(workflow, /- actions\s+- javascript-typescript/);
+  assert.match(workflow, /languages: go\s+build-mode: autobuild/);
+  assert.doesNotMatch(workflow, /github\/codeql-action\/autobuild@/);
+  assert.match(workflow, /languages: swift\s+build-mode: manual/);
+  assert.match(
+    workflow,
+    /swift build\s+--package-path macos\/CrabfleetMac\s+--scratch-path "\$RUNNER_TEMP\/crabfleet-codeql-swift"\s+--arch arm64/,
+  );
+});
+
+test("CodeQL uses pinned actions and least-privilege checkout", () => {
+  assert.match(workflow, /permissions:\s+contents: read\s+security-events: write/);
+  assert.doesNotMatch(workflow, /pull_request_target/);
+  assert.equal(
+    workflow.match(
+      /actions\/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7\.0\.1\s+with:\s+persist-credentials: false/g,
+    )?.length,
+    3,
+  );
+  assert.equal(
+    workflow.match(
+      /github\/codeql-action\/(?:init|analyze)@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4\.37\.9/g,
+    )?.length,
+    6,
+  );
+  assert.match(
+    workflow,
+    /actions\/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7\.0\.0\s+with:\s+go-version-file: go\.mod\s+cache-dependency-path: go\.sum/,
+  );
+  assert.doesNotMatch(workflow, /uses:\s+[^@\s]+@(?![0-9a-f]{40}(?:\s|$))/);
+});
+
+test("CodeQL analyzes pull requests, main, schedules, and manual runs", () => {
+  assert.match(workflow, /^on:$/m);
+  assert.match(workflow, /pull_request:\s+branches:\s+- main/);
+  assert.match(workflow, /push:\s+branches:\s+- main/);
+  assert.match(workflow, /schedule:\s+- cron:/);
+  assert.match(workflow, /workflow_dispatch:/);
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a gap where Crabfleet's GitHub Actions, TypeScript, Go, and Swift code did not share one repository-owned CodeQL workflow with explicit first-party extraction.

## Why This Change Was Made

Adds an immutable, least-privilege advanced CodeQL workflow. Actions and JavaScript/TypeScript use buildless analysis, Go uses the repository's `go.mod` toolchain with CodeQL autobuild, and Swift uses an arm64 package build with scratch data under `RUNNER_TEMP`. The workflow runs for pull requests, `main`, a weekly schedule, and manual runs.

The replay is based directly on `a394179d28e1c8d5fffe73ba624f5dd116de435f`. It intentionally contains no changelog or runtime changes.

## User Impact

Maintainers get consistent code-scanning results for all four first-party language categories. There is no runtime, deployment, release, or persistence behavior change.

## Evidence

- Head: `e073ca175ff847bf3e4828ad4e4658e13c47d6fe` (signed)
- Diff: workflow +103, contract test +49, production LOC 0
- `actionlint .github/workflows/codeql.yml`
- `node --test --experimental-strip-types tests/codeql-workflow.test.ts` (3 passed)
- `pnpm check`
- `pnpm test` (1001 passed)
- `pnpm build`
- `go test ./...`
- `go vet ./...`
- `swift build --package-path macos/CrabfleetMac --scratch-path "$RUNNER_TEMP/crabfleet-codeql-swift" --arch arm64`
- `pnpm macos:test` (RoyalVNCKit 121 passed; CrabfleetMac 294 passed; integration gate 7 passed)
- `git diff --check a394179d28e1c8d5fffe73ba624f5dd116de435f..HEAD`
- Test audit: the narrow contract test independently catches language, build-mode, action-pin, credential, trigger, and Swift extraction drift.
- Sol/high final patch review: clean, confidence 0.96.
- Separate exact-base/head review: trigger assertion applied; no C/C++ category warranted. The suggested changelog entry is skipped because repository policy and this PR's reviewed scope require no changelog. Expanding the single Go category across operating-system build tags would require extra analyses or manual extraction, conflicting with this PR's four-category Go-autobuild contract.
- Exact hosted synthetic merge: `bf4eefc40562e021a1775bffba4065823290f3ae`, with parents `a394179d28e1c8d5fffe73ba624f5dd116de435f` and `e073ca175ff847bf3e4828ad4e4658e13c47d6fe`; tree `ba3f081ab1c730b48ad2970f6fb710e8da3dbf00` matches the reviewed head.
- Exact-head hosted gates: Worker CI and all four CodeQL jobs passed.
- CodeQL analyses: Actions 17 rules, Go 34, JavaScript/TypeScript 87, Swift 27; every category reported zero results and no analysis error.
- Extraction proof: Actions extracted repository workflows; JavaScript/TypeScript extracted first-party `src/**`; Go extracted first-party commands and internals and reported success for its discovered project; Swift compiled the package under `RUNNER_TEMP` and reported 1,027,896 extracted AST nodes with zero unresolved.
- Fresh ClawSweeper review on `e073ca175ff847bf3e4828ad4e4658e13c47d6fe`: no findings; its only landing condition was completion of exact-head Swift and Worker checks, which are now green.

Action contracts were checked directly at the pinned revisions: checkout v7.0.1 uses `persist-credentials: false`; CodeQL v4.37.9 owns autobuild through `init` and does not require a redundant autobuild action; setup-go v7.0.0 reads `go.mod` and caches from `go.sum`.

Before the push, the repository was public, default setup was `not-configured`, the default branch remained exactly `a394179d28e1c8d5fffe73ba624f5dd116de435f`, the PR head remained exactly `bb242be0ec25ec8b5078d6e80f52a931d7638cae`, and no open CodeQL alerts existed. No alert was dismissed.
