### PR TITLE
fix(worker): prevent long repository inputs from stalling requests

### DIFF
--- a/src/worker/repositories.ts
+++ b/src/worker/repositories.ts
@@ -1,10 +1,11 @@
 export function normalizeRepo(value: unknown): string {
-  return String(value ?? "")
+  const normalized = String(value ?? "")
     .trim()
     .toLowerCase()
-    .replace(/^https:\/\/github\.com\//, "")
-    .replace(/\/+$/, "")
-    .replace(/\.git$/, "");
+    .replace(/^https:\/\/github\.com\//, "");
+  let end = normalized.length;
+  while (end > 0 && normalized[end - 1] === "/") end -= 1;
+  return normalized.slice(0, end).replace(/\.git$/, "");
 }
 
 export function githubRepoParts(repo: string): { owner: string; name: string } | null {

--- a/tests/repositories.test.ts
+++ b/tests/repositories.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { performance } from "node:perf_hooks";
+import test from "node:test";
+
+import { normalizeRepo } from "../src/worker/repositories.ts";
+
+test("normalizeRepo preserves canonical repository normalization", () => {
+  const cases = [
+    [undefined, ""],
+    [" OpenClaw/Crabfleet ", "openclaw/crabfleet"],
+    ["HTTPS://github.com/OpenClaw/Crabfleet.git/", "openclaw/crabfleet"],
+    ["openclaw/crabfleet////", "openclaw/crabfleet"],
+    ["openclaw/crabfleet.git", "openclaw/crabfleet"],
+    ["openclaw/crabfleet.git/branch", "openclaw/crabfleet.git/branch"],
+  ] as const;
+
+  for (const [input, expected] of cases) {
+    assert.equal(normalizeRepo(input), expected);
+  }
+});
+
+test("normalizeRepo handles long internal slash runs in bounded time", () => {
+  const input = `openclaw/crabfleet${"/".repeat(32_768)}x`;
+  const startedAt = performance.now();
+
+  assert.equal(normalizeRepo(input), input);
+  assert.ok(performance.now() - startedAt < 250);
+});


### PR DESCRIPTION
Related: https://github.com/openclaw/crabfleet/security/code-scanning/3

## What Problem This Solves

Fixes an issue where repository inputs containing long internal slash runs could stall Worker requests during normalization.

## Why This Change Was Made

Trailing slash removal now uses one reverse index scan and one final slice instead of a backtracking regular expression. Existing trimming, case normalization, GitHub URL removal, `.git` handling, and valid outputs are unchanged.

## User Impact

Repository normalization remains responsive for adversarial input without changing accepted repository values.

## Evidence

- Pre-fix focused reproduction: 32,768 internal slashes took 583 ms and failed the 250 ms regression bound.
- Fixed focused test: the same input completes in approximately 0.1 ms.
- Generated equivalence check: 10,000 inputs matched the previous valid output behavior.
- `pnpm check`
- `pnpm test` (1,003 tests)
- `pnpm build`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer pnpm macos:test`
- Codex Sol/high autoreview: no accepted or actionable findings.
- AWS Crabbox `run_7584c26fa9cb`: clean no-hydration checkout at the exact head; Docker-backed Wrangler dry-run, focused test, check, full test, and build passed; owned lease released.
- Hosted exact-head Worker and CodeQL gates passed, including JavaScript/TypeScript and Swift analysis.
- Latest exact-head ClawSweeper review was read; its changelog finding was explicitly skipped under the frozen two-file execution scope, and every requested verification gate was completed.
