### PR TITLE
fix(worker): hide internal session control failures

### DIFF
--- a/src/worker/session-control-do.ts
+++ b/src/worker/session-control-do.ts
@@ -213,11 +213,8 @@ export class SessionControlDO extends DurableObject<RuntimeEnv> {
         );
         return checkpoint ? json({ checkpoint }) : json({ error: "not found" }, { status: 404 });
       }
-    } catch (error) {
-      return json(
-        { error: error instanceof Error ? error.message : String(error) },
-        { status: 500 },
-      );
+    } catch {
+      return json({ error: "internal error" }, { status: 500 });
     }
     return json({ error: "not found" }, { status: 404 });
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where internal Session Control failures could return parser or exception details in an HTTP 500 response.

Related: https://github.com/openclaw/crabfleet/security/code-scanning/4

## Why This Change Was Made

The Session Control Durable Object now owns one fixed internal-error response for unexpected failures. Caught values are no longer serialized across the response boundary.

## User Impact

Unexpected Session Control failures remain visible as HTTP 500 responses without exposing internal error details.

## Evidence

- Real Wrangler/Miniflare Durable Object route, before: malformed JSON returned HTTP 500 containing a distinctive synthetic parser detail.
- Same route, after: returned exactly `{"error":"internal error"}` with no synthetic or parser detail.
- `pnpm check`
- `pnpm test` (1,003 passed)
- `pnpm build`
- `pnpm exec wrangler deploy --dry-run --containers-rollout=none`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer pnpm macos:test`
- Fresh no-hydration AWS Crabbox Worker proof: https://crabbox.openclaw.ai/portal/runs/run_3172bd3b2476
- Independent Codex `gpt-5.6-sol` high review: no findings.

Production LOC: +2/-5 (net -3). Tests: +0/-0.
