### PR TITLE
fix(macos): stop cancelled share waits and cursor retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Stop cancelled Share This Mac cursor reconciliation and release video mailbox waits and their timeout tasks promptly, including cancellation before waiter registration, thanks @SebTardif (#114).
+
 ## 0.3.1 - 2026-08-28
 
 ### Highlights

--- a/docs/macos-native-client.md
+++ b/docs/macos-native-client.md
@@ -379,7 +379,9 @@ VeNCrypt would bring an RFB-layer TLS boundary to TCP and other transports too.
 The relay never stores the registration token or RFB bytes. The direct listener
 is not reachable on Wi-Fi, Ethernet, loopback, or a public address. The host app
 must remain running, and stopping the share cancels the listener, relay
-publisher, and capture stream.
+publisher, and capture stream. Cancelled video mailbox waits return without
+waiting for their frame timeout, and cursor configuration reconciliation stops
+on cancellation while retaining bounded backoff for transient failures.
 
 ### Browser viewer
 

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/MacScreenCapture.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/MacScreenCapture.swift
@@ -412,15 +412,8 @@ final class MacScreenCapture: NSObject, @unchecked Sendable {
       cursorReconcileTask?.cancel()
       let task = Task { [weak self] in
         guard let self else { return }
-        var delay = Duration.milliseconds(100)
-        while !Task.isCancelled {
-          do {
-            try await self.reconcileCursorConfiguration()
-            break
-          } catch {
-            try? await Task.sleep(for: delay)
-            delay = min(delay * 2, .seconds(5))
-          }
+        await Self.reconcileCursorConfigurationWithRetry {
+          try await self.reconcileCursorConfiguration()
         }
         self.withFrameLock {
           if self.cursorReconcileGeneration == generation {
@@ -432,6 +425,28 @@ final class MacScreenCapture: NSObject, @unchecked Sendable {
       return task
     }
     _ = task
+  }
+
+  static func reconcileCursorConfigurationWithRetry(
+    _ reconcile: () async throws -> Void
+  ) async {
+    var delay = Duration.milliseconds(100)
+    while !Task.isCancelled {
+      do {
+        try await reconcile()
+        return
+      } catch is CancellationError {
+        // The operation can be cancelled even when this retry task is not.
+        return
+      } catch {
+        do {
+          try await Task.sleep(for: delay)
+        } catch {
+          return
+        }
+        delay = min(delay * 2, .seconds(5))
+      }
+    }
   }
 
   private func reconcileCursorConfiguration() async throws {

--- a/macos/CrabfleetMac/Sources/CrabfleetMac/VideoMailbox.swift
+++ b/macos/CrabfleetMac/Sources/CrabfleetMac/VideoMailbox.swift
@@ -12,6 +12,7 @@ final class VideoMailbox<Element>: @unchecked Sendable {
   private let lock = NSLock()
   private var latestElement: Element?
   private var waiter: Waiter?
+  private var timeoutTask: Task<Void, Never>?
   private var finished = false
 
   var isFinished: Bool {
@@ -30,27 +31,36 @@ final class VideoMailbox<Element>: @unchecked Sendable {
   }
 
   func offer(_ element: Element, onDrop: () -> Void = {}) {
-    let continuation = withLock { () -> CheckedContinuation<Element?, Never>? in
-      guard !finished else { return nil }
+    let (continuation, timeoutTask) = withLock {
+      () -> (CheckedContinuation<Element?, Never>?, Task<Void, Never>?) in
+      guard !finished else { return (nil, nil) }
       guard let waiter else {
         if latestElement != nil { onDrop() }
         latestElement = element
-        return nil
+        return (nil, nil)
       }
       self.waiter = nil
-      return waiter.continuation
+      let timeoutTask = self.timeoutTask
+      self.timeoutTask = nil
+      return (waiter.continuation, timeoutTask)
     }
+    timeoutTask?.cancel()
     continuation?.resume(returning: element)
   }
 
   func finish() {
-    let continuation = withLock { () -> CheckedContinuation<Element?, Never>? in
-      guard !finished else { return nil }
+    let (continuation, timeoutTask) = withLock {
+      () -> (CheckedContinuation<Element?, Never>?, Task<Void, Never>?) in
+      guard !finished else { return (nil, nil) }
       finished = true
       latestElement = nil
-      defer { waiter = nil }
-      return waiter?.continuation
+      let continuation = waiter?.continuation
+      let timeoutTask = self.timeoutTask
+      waiter = nil
+      self.timeoutTask = nil
+      return (continuation, timeoutTask)
     }
+    timeoutTask?.cancel()
     continuation?.resume(returning: nil)
   }
 
@@ -64,6 +74,7 @@ final class VideoMailbox<Element>: @unchecked Sendable {
         var immediateElement: Element?
         var shouldResume = false
         var replacedWaiter: Waiter?
+        var replacedTimeout: Task<Void, Never>?
         lock.lock()
         if let latestElement {
           immediateElement = latestElement
@@ -73,16 +84,35 @@ final class VideoMailbox<Element>: @unchecked Sendable {
           shouldResume = true
         } else {
           replacedWaiter = waiter
+          replacedTimeout = timeoutTask
+          timeoutTask = nil
           waiter = (id, continuation)
         }
         lock.unlock()
 
         replacedWaiter?.continuation.resume(returning: nil)
+        replacedTimeout?.cancel()
         if shouldResume {
           continuation.resume(returning: immediateElement)
         } else {
-          Task {
-            try? await Task.sleep(for: timeout)
+          let task = Task {
+            do {
+              try await Task.sleep(for: timeout)
+              self.expire(id: id)
+            } catch is CancellationError {
+              // Do not expire a different waiter; expire already guards by id.
+            } catch {
+              self.expire(id: id)
+            }
+          }
+          let shouldCancelTimeout = withLock { () -> Bool in
+            guard waiter?.id == id else { return true }
+            timeoutTask = task
+            return false
+          }
+          if shouldCancelTimeout {
+            task.cancel()
+          } else if Task.isCancelled {
             self.expire(id: id)
           }
         }
@@ -93,11 +123,16 @@ final class VideoMailbox<Element>: @unchecked Sendable {
   }
 
   private func expire(id: UUID) {
-    let continuation = withLock { () -> CheckedContinuation<Element?, Never>? in
-      guard waiter?.id == id else { return nil }
-      defer { waiter = nil }
-      return waiter?.continuation
+    let (continuation, timeoutTask) = withLock {
+      () -> (CheckedContinuation<Element?, Never>?, Task<Void, Never>?) in
+      guard waiter?.id == id else { return (nil, nil) }
+      let continuation = waiter?.continuation
+      let timeoutTask = self.timeoutTask
+      waiter = nil
+      self.timeoutTask = nil
+      return (continuation, timeoutTask)
     }
+    timeoutTask?.cancel()
     continuation?.resume(returning: nil)
   }
 

--- a/macos/CrabfleetMac/Tests/CrabfleetMacTests/VideoPipelineTests.swift
+++ b/macos/CrabfleetMac/Tests/CrabfleetMacTests/VideoPipelineTests.swift
@@ -378,6 +378,102 @@ struct VideoPipelineTests {
   }
 
   @Test
+  func mailboxCancelledWaiterReturnsPromptlyWithoutResumingTwice() async {
+    let mailbox = VideoMailbox<Int>()
+    let startedAt = ContinuousClock().now
+    let task = Task {
+      withUnsafeCurrentTask { $0?.cancel() }
+      return await mailbox.next(timeout: .seconds(5))
+    }
+    let result = await task.value
+    #expect(result == nil)
+    #expect(ContinuousClock().now - startedAt < .milliseconds(500))
+
+    mailbox.offer(4)
+    #expect(await mailbox.next(timeout: .milliseconds(50)) == 4)
+  }
+
+  @Test
+  func mailboxCancellationRacingOfferLeavesMailboxUsable() async {
+    for value in 0..<100 {
+      let mailbox = VideoMailbox<Int>()
+      let waiter = Task { await mailbox.next(timeout: .seconds(5)) }
+      async let cancellation: Void = Task { waiter.cancel() }.value
+      async let offer: Void = Task { mailbox.offer(value) }.value
+      _ = await (cancellation, offer)
+      let received = await waiter.value
+      #expect(received == nil || received == value)
+      mailbox.offer(value + 1)
+      #expect(await mailbox.next(timeout: .milliseconds(50)) == value + 1)
+      mailbox.finish()
+    }
+  }
+
+  @Test
+  func mailboxCancelledWaitDoesNotRetainTimeout() async {
+    weak var releasedMailbox: VideoMailbox<Int>?
+    let task = Task {
+      let mailbox = VideoMailbox<Int>()
+      releasedMailbox = mailbox
+      withUnsafeCurrentTask { $0?.cancel() }
+      #expect(await mailbox.next(timeout: .seconds(5)) == nil)
+    }
+    await task.value
+    let deadline = ContinuousClock.now.advanced(by: .milliseconds(500))
+    while releasedMailbox != nil, ContinuousClock.now < deadline {
+      await Task.yield()
+    }
+    #expect(releasedMailbox == nil)
+  }
+
+  @Test
+  func cursorCancellationErrorStopsReconciliation() async {
+    var attempts = 0
+    await MacScreenCapture.reconcileCursorConfigurationWithRetry {
+      attempts += 1
+      if attempts == 1 { throw CancellationError() }
+    }
+    #expect(attempts == 1)
+  }
+
+  @Test
+  func cursorTransientFailureRetriesReconciliation() async {
+    var attempts = 0
+    await MacScreenCapture.reconcileCursorConfigurationWithRetry {
+      attempts += 1
+      if attempts == 1 { throw NSError(domain: "CrabfleetMacTests", code: 1) }
+    }
+    #expect(attempts == 2)
+  }
+
+  @Test
+  func cursorCancelledTaskDoesNotStartReconciliation() async {
+    let task = Task {
+      withUnsafeCurrentTask { $0?.cancel() }
+      var attempts = 0
+      await MacScreenCapture.reconcileCursorConfigurationWithRetry { attempts += 1 }
+      return attempts
+    }
+    #expect(await task.value == 0)
+  }
+
+  @Test
+  func cursorCancellationStopsRetryBackoff() async {
+    let startedAt = ContinuousClock.now
+    let task = Task {
+      var attempts = 0
+      await MacScreenCapture.reconcileCursorConfigurationWithRetry {
+        attempts += 1
+        withUnsafeCurrentTask { $0?.cancel() }
+        throw NSError(domain: "CrabfleetMacTests", code: 1)
+      }
+      return attempts
+    }
+    #expect(await task.value == 1)
+    #expect(startedAt.duration(to: .now) < .milliseconds(500))
+  }
+
+  @Test
   func videoNegotiationPrefersHEVCThenH264ThenTight() {
     let offered = [
       RFBWire.tightEncoding,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stopping or cancelling Share This Mac work could leave a video consumer waiting for its full frame timeout and treat a cancelled cursor configuration operation as a transient failure.

This supersedes #114 and preserves Sebastien Tardif's contribution with a co-author trailer and changelog credit. No linked bug issue exists in #114's closing references or the repository issue list, so this does not close an unrelated issue.

## Why This Change Was Made

The mailbox now owns its timeout task alongside the waiter, cancels it on completion/replacement/finish, and rechecks cancellation after registration. That closes the race where the cancellation handler ran before a continuation existed. Cursor reconciliation stops on `CancellationError` and cancelled backoff; ordinary errors retain the existing exponential backoff. The retry loop remains owned by `MacScreenCapture`, with a small extraction for behavioral tests.

The integration starts from current main `830832deb6f31c43a2eeabb71cc051eb0d147fd3`. It preserves the current release history and adds only an Unreleased entry. Listener admission, authentication, permission checks, and capture-configuration serialization are unchanged.

Provenance is clear: the mailbox path originated in `ed2354d` (#74), and cursor retry in `6471f31` (#90). The cursor problem is specifically an operation throwing `CancellationError` while the retry task remains active; cancelling the retry task itself already reached the loop's cancellation check on main.

## User Impact

Cancelled video waits return promptly instead of consuming the remaining frame timeout. Timeout tasks are released when their wait ends, and cancelled cursor operations are not retried.

## Evidence

Before any production edit, native Swift harnesses built from the unchanged owners on main reproduced both defects: an already-cancelled mailbox wait returned after **5.297 seconds**, and the cursor loop made **2 attempts** after the first operation threw `CancellationError` (expected 1). The larger package baseline build was interrupted during a filesystem stall and is not counted as a test result.

After integration, all **39 VideoPipelineTests** passed, including seven new cancellation/retry cases. Coverage includes cancellation before registration, 100 cancellation/offer races, mailbox reuse, timeout release, cancellation errors, cancellation during backoff, and preserving transient retries.

Real macOS proof used macOS 26.6.2 (`25G83`), arm64, and Xcode 27 beta (`27A5237l`). A test-only executable linked against the unchanged compiled production capture/mailbox objects was signed with the OpenClaw Foundation Developer ID and run from the stable `/Applications/Crabfleet.app` path. It received an actual **2560×1440 ScreenCaptureKit frame**, then returned `nil` from a cancelled five-second mailbox wait in **0.00021375 seconds**. `MacScreenCapture.stop()` completed in **0.006607625 seconds**, with **zero consumers** left. No pixels were saved or uploaded; no registry publication, audio, clipboard, remote input, or listener was enabled. The temporary installed probe was removed afterward.

A second paired live run used the preserved pre-edit main object files and then the integrated object files with the same signed probe and real captured frames: main took **5.006727 seconds** to return `nil` from the cancelled wait (probe failed its 500ms bound), versus **0.000169542 seconds** after the fix (probe passed). Both runs stopped capture cleanly and left zero consumers.

A full Share This Mac tailnet session was **not** exercised: the application's own signed Tailscale executable reported `BackendState: Stopped`. The host's network state and TCC permissions were not changed. The ScreenCaptureKit proof above is real capture/teardown evidence, not a claim of a connected remote viewer or a naturally occurring ScreenCaptureKit cancellation error.

Validation: `pnpm format`, `pnpm check`, `pnpm test` (**1,003 passed**), `pnpm build`, `pnpm build:static`, Worker package dry-run, `go test ./...`, `go vet ./...`, and `git diff --check` passed. The Go checks were rerun successfully with an isolated cache after the shared cache lost files during the first run. `pnpm macos:test` passed all tiers: **121 vendor**, **301 application**, and **7 serialized integration tests**. The opt-in real-tailnet smoke returned early because it was not enabled; the other six serialized cases exercised real loopback/ARD/lifecycle behavior. The first full run hit a one-second completion deadline in the existing file-sharing fixture; it passed unchanged in isolation (0.296s), and the entire unchanged native gate then passed. No production or test deadlines were increased. The native script retains its normal tests and concurrency settings; a task-local launcher supplies only external scratch directories to avoid host filesystem stalls.

Codex autoreview completed with no accepted/actionable findings at the configured default P0 threshold. No merge is requested or performed.
