### PR TITLE
fix: delete partial SESSION_LOGS objects when a put fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Delete leftover session log archive objects when one of the three SESSION_LOGS puts fails, so a failed archive attempt does not leave untracked R2 keys, thanks @SebTardif.
 - Stop cancelled Share This Mac cursor reconciliation and release video mailbox waits and their timeout tasks promptly, including cancellation before waiter registration, thanks @SebTardif (#114).
 
 ## 0.3.1 - 2026-08-28

--- a/src/worker/session-log-archive.ts
+++ b/src/worker/session-log-archive.ts
@@ -51,7 +51,7 @@ export async function archiveInteractiveSessionLogs(
   const transcriptKey = attemptedArchive.transcript_key;
   const summaryKey = attemptedArchive.summary_key;
   if (env.SESSION_LOGS) {
-    await Promise.all([
+    const results = await Promise.allSettled([
       env.SESSION_LOGS.put(eventsKey, sessionLogEventsNdjson(events), {
         httpMetadata: { contentType: "application/x-ndjson; charset=utf-8" },
       }),
@@ -64,6 +64,13 @@ export async function archiveInteractiveSessionLogs(
         { httpMetadata: { contentType: "application/json; charset=utf-8" } },
       ),
     ]);
+    const failure = results.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (failure) {
+      await cleanupSessionLogArchiveObjects(env, attemptedArchive).catch(() => undefined);
+      throw failure.reason;
+    }
   }
   await sql`
     INSERT INTO interactive_session_log_archives (

--- a/tests/session-log-archive.test.ts
+++ b/tests/session-log-archive.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import type { RuntimeEnv } from "../src/worker/env.ts";
 import {
+  archiveInteractiveSessionLogs,
   sessionLogArchiveBase,
   sessionLogEventsNdjson,
   sessionLogSummary,
@@ -10,6 +12,70 @@ import {
 } from "../src/worker/session-log-archive.ts";
 import { interactiveSession } from "../src/worker/session-model.ts";
 import { sessionRow } from "./helpers/session-row.ts";
+
+type D1Result = { results?: unknown[]; changes?: number };
+type D1Handler = (sql: string, parameters: unknown[], kind: "all" | "run") => D1Result;
+
+function runtimeEnv(
+  handler: D1Handler,
+  sessionLogs?: Pick<R2Bucket, "put" | "delete">,
+): RuntimeEnv {
+  return {
+    DB: {
+      prepare(sql: string) {
+        return {
+          bind(...parameters: unknown[]) {
+            return {
+              sql,
+              parameters,
+              async all() {
+                const result = handler(sql, parameters, "all");
+                return { results: result.results ?? [], meta: { changes: result.changes ?? 0 } };
+              },
+              async run() {
+                const result = handler(sql, parameters, "run");
+                return { meta: { changes: result.changes ?? 0 } };
+              },
+            };
+          },
+        };
+      },
+      async batch() {
+        return [];
+      },
+    } as unknown as D1Database,
+    ...(sessionLogs ? { SESSION_LOGS: sessionLogs as R2Bucket } : {}),
+  } as RuntimeEnv;
+}
+
+function archiveSessionRow() {
+  return sessionRow({ id: "IS-1", updated_at: 100 });
+}
+
+function archiveEventRow() {
+  return {
+    id: 1,
+    session_id: "IS-1",
+    actor: "operator",
+    event_key: null,
+    event_type: "message",
+    message: "started",
+    payload_json: null,
+    created_at: 50,
+  };
+}
+
+function archiveQueryHandler(): D1Handler {
+  const row = archiveSessionRow();
+  const event = archiveEventRow();
+  return (sql) => {
+    if (/from "interactive_sessions"/i.test(sql)) return { results: [row] };
+    if (/from "interactive_session_log_archives"/i.test(sql)) return { results: [] };
+    if (/count\(\*\)/i.test(sql)) return { results: [{ count: 1 }] };
+    if (/from "interactive_session_events"/i.test(sql)) return { results: [event] };
+    throw new Error(`unexpected query: ${sql}`);
+  };
+}
 
 const archive = {
   session_id: "IS-1",
@@ -108,6 +174,30 @@ test("transcripts accept domain sessions and summaries keep event anchors", () =
   assert.equal(summary.lastEventAt, 10);
   assert.equal(summary.lastEvent, "first");
   assert.equal(summary.updatedAt, 120);
+});
+
+test("failed session log puts delete the attempted archive objects", async () => {
+  const objects = new Map<string, string>();
+  const deleted: string[] = [];
+  const env = runtimeEnv(archiveQueryHandler(), {
+    async put(key, value) {
+      if (String(key).endsWith("/summary.json")) {
+        throw new Error("R2 put failed");
+      }
+      objects.set(String(key), String(value));
+      return undefined as unknown as R2Object;
+    },
+    async delete(key) {
+      deleted.push(String(key));
+      objects.delete(String(key));
+    },
+  });
+
+  await assert.rejects(() => archiveInteractiveSessionLogs(env, "IS-1", 200), /R2 put failed/);
+  assert.equal(objects.size, 0);
+  assert.ok(deleted.some((key) => key.endsWith("/events.ndjson")));
+  assert.ok(deleted.some((key) => key.endsWith("/transcript.md")));
+  assert.ok(deleted.some((key) => key.endsWith("/summary.json")));
 });
 
 test("event archives expose structured fields while preserving legacy messages", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who archive interactive session logs to SESSION_LOGS would leave untracked R2 objects behind when one of the three archive puts failed. Session event append, attach, metadata, stop, and terminal finalize all call `archiveInteractiveSessionLogs`. That function writes events, transcript, and summary under a unique `crypto.randomUUID()` prefix, then inserts the archive row. If a later put fails, the earlier objects stay in the bucket with no database row. A retry uses a new prefix, so those orphans are never reclaimed.

## Why This Change Was Made

Wait for every archive put to finish, then delete the attempted events, transcript, and summary keys before rethrowing the original put error. Existing `cleanupSessionLogArchiveObjects` already knows how to delete that key triple. The database insert still happens only after all three puts succeed.

## User Impact

A failed session-log archive attempt no longer leaves untracked SESSION_LOGS objects. Operators keep the original put error, and a later successful archive still writes a fresh unique prefix. Successful archives are unchanged.

## Evidence

Before this change, a SESSION_LOGS bucket that accepted events and transcript then rejected summary left two objects and deleted nothing:

```console
$ node --experimental-strip-types /tmp/crabfleet-F004-proof.mjs
BEFORE error: R2 put failed
BEFORE leftover keys: [
  'orgs/openclaw/interactive-sessions/IS-1/old/events.ndjson',
  'orgs/openclaw/interactive-sessions/IS-1/old/transcript.md'
]
BEFORE deletes: []
```

After the patch, the same failing summary put still raises `R2 put failed`, but the production archive path deletes all three attempted keys and leaves an empty store:

```console
AFTER error: R2 put failed
AFTER leftover keys: []
AFTER deletes: [
  'orgs/openclaw/interactive-sessions/IS-1/00000001-0000000000050-200-e2d1ea55-d796-451c-bd48-597c1fdfdf0c/events.ndjson',
  'orgs/openclaw/interactive-sessions/IS-1/00000001-0000000000050-200-e2d1ea55-d796-451c-bd48-597c1fdfdf0c/transcript.md',
  'orgs/openclaw/interactive-sessions/IS-1/00000001-0000000000050-200-e2d1ea55-d796-451c-bd48-597c1fdfdf0c/summary.json'
]
```

## Real behavior proof

- **Behavior or issue addressed:** A later SESSION_LOGS put failure left earlier unique-key archive objects with no database row and no cleanup.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Node v26.7.0, crabfleet checkout `/tmp/oc-pr-crabfleet-F004` at branch `fix/f004-session-logs-cleanup` on top of [`bdd5083`](https://github.com/openclaw/crabfleet/commit/bdd5083).
- **Exact steps or command run after this patch:**

  ```bash
  node --experimental-strip-types /tmp/crabfleet-F004-proof.mjs
  ```

- **Evidence after fix:** terminal output from the patched archive path above. The failing summary put still surfaces `R2 put failed`. The leftover store is empty, and delete ran for events, transcript, and summary under the same unique attempt prefix.
- **Observed result after fix:** `archiveInteractiveSessionLogs` no longer keeps untracked SESSION_LOGS objects after a partial put failure. The original put error is still thrown, and no archive row is inserted.
- **What was not tested:** A live Cloudflare R2 bucket and a production worker process with real session traffic.

## Summary

The leak has been present since [`df9bdc99`](https://github.com/openclaw/crabfleet/commit/df9bdc99) in [#44](https://github.com/openclaw/crabfleet/pull/44) (2026-06-15, 75 days). Event content later changed in [#76](https://github.com/openclaw/crabfleet/pull/76), but the three-way `Promise.all` put still had no failure cleanup.

Related: `cleanupSessionLogArchiveObjects` already deletes obsolete keys after a successful commit. This change uses that helper when the put set fails, after `Promise.allSettled` so an in-flight sibling put cannot land after cleanup starts.
