### PR TITLE
fix(worker): timeout CRABBOX.md GitHub fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Time out hung GitHub CRABBOX.md fetches after 10s so admin workflow evaluate cannot stall on api.github.com, thanks @SebTardif.
 - Stop cancelled Share This Mac cursor reconciliation and release video mailbox waits and their timeout tasks promptly, including cancellation before waiter registration, thanks @SebTardif (#114).
 
 ## 0.3.1 - 2026-08-28

--- a/src/worker/workflow-service.ts
+++ b/src/worker/workflow-service.ts
@@ -88,6 +88,8 @@ export class WorkflowService {
   }
 }
 
+export const WORKFLOW_SOURCE_FETCH_TIMEOUT_MS = 10_000;
+
 export function createWorkflowService(env: RuntimeEnv): WorkflowService {
   return new WorkflowService({
     repository: new WorkflowRepository(env),
@@ -95,6 +97,7 @@ export function createWorkflowService(env: RuntimeEnv): WorkflowService {
     fetchSource: (repo) =>
       fetch(`https://api.github.com/repos/${repo}/contents/CRABBOX.md`, {
         headers: githubHeaders(env),
+        signal: AbortSignal.timeout(WORKFLOW_SOURCE_FETCH_TIMEOUT_MS),
       }),
   });
 }

--- a/tests/workflow-service.test.ts
+++ b/tests/workflow-service.test.ts
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import type { RuntimeEnv } from "../src/worker/env.ts";
+import { githubHeaders } from "../src/worker/github.ts";
 import type { RepoWorkflow } from "../src/worker/workflow-model.ts";
 import type { WorkflowRepositoryStore } from "../src/worker/workflow-repository.ts";
 import {
+  createWorkflowService,
   parseWorkflowMarkdown,
+  WORKFLOW_SOURCE_FETCH_TIMEOUT_MS,
   WorkflowService,
   type WorkflowServiceDependencies,
 } from "../src/worker/workflow-service.ts";
@@ -22,6 +26,57 @@ function workflow(values: Partial<RepoWorkflow> = {}): RepoWorkflow {
     updatedAt: 100,
     ...values,
   };
+}
+
+function defaultFetchSource(env: Pick<RuntimeEnv, "GITHUB_TOKEN">) {
+  const service = createWorkflowService(env as RuntimeEnv);
+  return (service as unknown as { dependencies: WorkflowServiceDependencies }).dependencies
+    .fetchSource;
+}
+
+function hangUntilAborted(_input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  return new Promise((_resolve, reject) => {
+    const signal = init?.signal;
+    if (!signal) return;
+    const fail = () =>
+      reject(signal.reason ?? new DOMException("The operation was aborted.", "AbortError"));
+    if (signal.aborted) {
+      fail();
+      return;
+    }
+    signal.addEventListener("abort", fail, { once: true });
+  });
+}
+
+async function withMockedFetch<T>(
+  mock: typeof fetch,
+  timeoutMs: number | null,
+  run: () => Promise<T>,
+): Promise<{
+  result: T;
+  timeoutArgs: number[];
+  calls: Array<{ input: RequestInfo | URL; init?: RequestInit }>;
+}> {
+  const originalFetch = globalThis.fetch;
+  const originalTimeout = AbortSignal.timeout;
+  const timeoutArgs: number[] = [];
+  const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+  globalThis.fetch = (input, init) => {
+    calls.push({ input, init });
+    return mock(input, init);
+  };
+  if (timeoutMs !== null) {
+    AbortSignal.timeout = (ms: number) => {
+      timeoutArgs.push(ms);
+      return originalTimeout(timeoutMs);
+    };
+  }
+  try {
+    return { result: await run(), timeoutArgs, calls };
+  } finally {
+    globalThis.fetch = originalFetch;
+    AbortSignal.timeout = originalTimeout;
+  }
 }
 
 function dependencies(
@@ -169,4 +224,39 @@ Investigate`;
   assert.deepEqual(result.config, { runtime: "container", policy: "open_pr" });
   assert.equal(result.prompt, "Investigate");
   assert.deepEqual(calls, ["fetch:openclaw/crabfleet", "write:ok:sha-valid:null"]);
+});
+
+test("default workflow fetchSource passes an AbortSignal and GitHub headers", async () => {
+  const env = { GITHUB_TOKEN: "github-secret" } as RuntimeEnv;
+  const { result, calls } = await withMockedFetch(
+    async () => new Response(null, { status: 404 }),
+    null,
+    () => defaultFetchSource(env)("openclaw/crabfleet"),
+  );
+
+  assert.equal(result.status, 404);
+  assert.equal(calls.length, 1);
+  assert.equal(
+    calls[0]?.input,
+    "https://api.github.com/repos/openclaw/crabfleet/contents/CRABBOX.md",
+  );
+  assert.ok(calls[0]?.init?.signal instanceof AbortSignal);
+  assert.equal(calls[0]?.init?.signal.aborted, false);
+  assert.deepEqual(calls[0]?.init?.headers, githubHeaders(env));
+});
+
+test("default workflow fetchSource aborts a hung GitHub lookup", async () => {
+  const { timeoutArgs } = await withMockedFetch(hangUntilAborted, 20, async () => {
+    const pending = defaultFetchSource({ GITHUB_TOKEN: "github-secret" })("openclaw/crabfleet");
+    const watchdog = new Promise<never>((_resolve, reject) => {
+      setTimeout(() => reject(new Error("did not abort hung CRABBOX.md fetch")), 200);
+    });
+    await assert.rejects(Promise.race([pending, watchdog]), (error: unknown) => {
+      assert.ok(error instanceof DOMException);
+      assert.equal(error.name, "TimeoutError");
+      return true;
+    });
+  });
+
+  assert.deepEqual(timeoutArgs, [WORKFLOW_SOURCE_FETCH_TIMEOUT_MS]);
 });


### PR DESCRIPTION
## What Problem This Solves

Owner admin `POST /api/admin/workflows/evaluate` reads each repo's `CRABBOX.md` from GitHub. The default `createWorkflowService` `fetchSource` called `api.github.com` with headers only and no `AbortSignal`. A hung GitHub left that admin request pending until the Worker isolate wall clock.

## Why This Change Was Made

The GitHub contents fetch now passes `signal: AbortSignal.timeout(WORKFLOW_SOURCE_FETCH_TIMEOUT_MS)` (`10_000`). Headers stay `githubHeaders(env)`, including the optional token. Successful lookups, 404 missing files, and rate-limit errors are unchanged. Only a stuck TCP or GitHub response now fails closed after 10 seconds.

## User Impact

A stalled `api.github.com` no longer pins admin workflow evaluate. After 10 seconds the lookup aborts, `refresh` surfaces the existing retry error, and a cached workflow (if any) remains available through `ensure`.

## Evidence

Live `node` against the default `createWorkflowService` `fetchSource`. `fetch` was rewritten onto a local HTTP server that accepted the connection and never wrote a response. The unfixed headers-only call stayed pending until a 200ms watchdog. The patched default `fetchSource` requested `AbortSignal.timeout(10000)` and rejected `TimeoutError` in 53ms (timeout helper shortened to 50ms so the hang proof did not wait the full 10s). GitHub headers were unchanged.

```console
$ node --experimental-strip-types /tmp/crabfleet-f006-proof.mjs
WORKFLOW_SOURCE_FETCH_TIMEOUT_MS 10000
{
  "hangUrl": "http://127.0.0.1:62106/never",
  "timeoutArgs": [
    10000
  ],
  "seen": [
    {
      "input": "https://api.github.com/repos/openclaw/crabfleet/contents/CRABBOX.md",
      "hasSignal": false,
      "headers": {
        "accept": "application/vnd.github+json",
        "authorization": "Bearer github-secret",
        "user-agent": "crabbox-ai",
        "x-github-api-version": "2022-11-28"
      }
    },
    {
      "input": "https://api.github.com/repos/openclaw/crabfleet/contents/CRABBOX.md",
      "hasSignal": true,
      "headers": {
        "accept": "application/vnd.github+json",
        "authorization": "Bearer github-secret",
        "user-agent": "crabbox-ai",
        "x-github-api-version": "2022-11-28"
      }
    }
  ],
  "unfixed": {
    "label": "unfixed fetchSource",
    "outcome": "Error: WATCHDOG: hung fetch still pending after 200ms",
    "ms": 201
  },
  "fixed": {
    "label": "fixed createWorkflowService fetchSource",
    "outcome": "TimeoutError: The operation was aborted due to timeout",
    "ms": 53
  }
}
```

`fetchSource` was introduced without a deadline in [bdd5083](https://github.com/openclaw/crabfleet/commit/bdd5083b0d3d6217c400db80b8e1fbc9caa3d00a) (2026-08-29), 4 days ago.

## Real behavior proof

- **Behavior or issue addressed:** Default `createWorkflowService` `fetchSource` left admin workflow evaluate pending when `api.github.com` never answered.
- **Real environment tested:** macOS, Node v26.7.0, worktree `/tmp/crabfleet-F006` at `fbed2f5`, local `http.createServer` that never responds.
- **Exact steps or command run after this patch:** `node --experimental-strip-types /tmp/crabfleet-f006-proof.mjs` (rewrites the GitHub contents URL onto the hanging loopback server, then calls unfixed `fetch` and the patched default `fetchSource`).
- **Evidence after fix:** terminal output above. Unfixed stay-pending watchdog at 201ms. Patched path requested 10000ms and aborted with `TimeoutError` at 53ms. Both calls kept `githubHeaders(env)`.
- **Observed result after fix:** A never-responding GitHub contents lookup now fails with `TimeoutError` instead of remaining pending. Headers still include accept, user-agent, API version, and the bearer token.
- **What was not tested:** A live `POST /api/admin/workflows/evaluate` against production GitHub or a real Cloudflare isolate wall-clock hang.
