### PR TITLE
fix: timeout terminal clipboard upload fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Time out stalled terminal clipboard file uploads after 30s so the session does not stay on "Uploading ..." forever, thanks @SebTardif.
 - Stop cancelled Share This Mac cursor reconciliation and release video mailbox waits and their timeout tasks promptly, including cancellation before waiter registration, thanks @SebTardif (#114).
 
 ## 0.3.1 - 2026-08-28

--- a/src/app/terminal.js
+++ b/src/app/terminal.js
@@ -478,22 +478,31 @@ async function uploadTerminalClipboardBlob(id, blob, name, mediaType = blob?.typ
     return;
   }
   setTerminalStatus(id, `Uploading ${name || "clipboard"}`);
-  const response = await fetch(`/api/interactive-sessions/${encodeURIComponent(id)}/clipboard`, {
-    method: "POST",
-    headers: {
-      "content-type": mediaType || blob.type || "application/octet-stream",
-      "x-clipboard-name": encodeURIComponent(name || clipboardName(mediaType)),
-    },
-    body: blob,
-  });
-  if (!response.ok) {
-    setTerminalStatus(id, `Paste failed (${response.status})`);
-    return;
+  try {
+    const response = await fetch(`/api/interactive-sessions/${encodeURIComponent(id)}/clipboard`, {
+      method: "POST",
+      headers: {
+        "content-type": mediaType || blob.type || "application/octet-stream",
+        "x-clipboard-name": encodeURIComponent(name || clipboardName(mediaType)),
+      },
+      body: blob,
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) {
+      setTerminalStatus(id, `Paste failed (${response.status})`);
+      return;
+    }
+    const result = await response.json();
+    const path = String(result.path || "");
+    setTerminalStatus(id, path ? `Pasted ${result.name || "file"}` : "Paste done");
+    if (path) pasteTerminalText(host, path);
+  } catch (error) {
+    if (error?.name === "TimeoutError" || error?.name === "AbortError") {
+      setTerminalStatus(id, "Paste timed out");
+      return;
+    }
+    throw error;
   }
-  const result = await response.json();
-  const path = String(result.path || "");
-  setTerminalStatus(id, path ? `Pasted ${result.name || "file"}` : "Paste done");
-  if (path) pasteTerminalText(host, path);
 }
 
 function canUploadTerminalClipboardFile(id) {

--- a/tests/app-terminal-access.test.ts
+++ b/tests/app-terminal-access.test.ts
@@ -37,6 +37,23 @@ test("browser terminals consume live control grants and revocations", async () =
   assert.doesNotMatch(source, /encodeResizePayload\(host\.term\.cols,\s*host\.term\.rows\)/);
 });
 
+test("clipboard upload fetch aborts after 30s instead of hanging on Uploading", async () => {
+  const source = await readFile(new URL("../src/app/terminal.js", import.meta.url), "utf8");
+  const start = source.indexOf("async function uploadTerminalClipboardBlob");
+  const end = source.indexOf("function canUploadTerminalClipboardFile");
+  assert.ok(
+    start >= 0 && end > start,
+    "uploadTerminalClipboardBlob must precede canUploadTerminalClipboardFile",
+  );
+  const upload = source.slice(start, end);
+  assert.match(
+    upload,
+    /fetch\(`\/api\/interactive-sessions\/\$\{encodeURIComponent\(id\)\}\/clipboard`, \{[\s\S]*?signal:\s*AbortSignal\.timeout\(30_000\)/,
+  );
+  assert.match(upload, /error\?\.name === "TimeoutError" \|\| error\?\.name === "AbortError"/);
+  assert.match(upload, /setTerminalStatus\(id, "Paste timed out"\)/);
+});
+
 test("server subscription capability authoritatively updates terminal input", () => {
   const readOnly: boolean[] = [];
   const host = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users pasting a file into a live Sandbox terminal would leave the session stuck on "Uploading ..." forever when the Worker or network stalled. File paste posts the blob to `POST /api/interactive-sessions/:id/clipboard` with a raw `fetch` that never attached an `AbortSignal`. That path does not go through the shared JSON `api()` helper, so a hung clipboard upload never failed and never cleared the status.

## Why This Change Was Made

The clipboard POST now passes `signal: AbortSignal.timeout(30_000)`, the same 30 second deadline as the intended browser `api()` default. `TimeoutError` and `AbortError` set status to `Paste timed out` and return, so a stalled upload cannot leave an unhandled rejection or a permanent "Uploading ..." label. Successful pastes and HTTP error statuses are unchanged. This does not change `src/app/api.js`.

## User Impact

A stalled clipboard file upload no longer freezes the terminal status row. After 30 seconds the request aborts and the session shows `Paste timed out`. Successful file pastes still report `Pasted ...` or `Paste done`.

## Evidence

Live `node` against current `origin/main` `src/app/terminal.js` (no signal) and the patched clipboard POST. A silent local HTTP server never writes a response, which is the stalled-Worker case.

Unfixed clipboard `fetch` has no `AbortSignal` and stays pending:

```console
$ node C:\Users\sebta\AppData\Local\Temp\crabfleet-f007-before.mjs C:\Users\sebta\AppData\Local\Temp\crabfleet-f007-terminal-main.js
source: C:\Users\sebta\AppData\Local\Temp\crabfleet-f007-terminal-main.js
clipboard fetch call:
`/api/interactive-sessions/${encodeURIComponent(id)}/clipboard`, {
    method: "POST",
    headers: {
      "content-type": mediaType || blob.type || "application/octet-stream",
      "x-clipboard-name": encodeURIComponent(name || clipboardName(mediaType)),
    },
    body: blob,
  }
has AbortSignal.timeout: false
error.name: Error
error.message: WATCHDOG: hung fetch still pending
elapsed_ms: 412
status: WATCHDOG: hung fetch still pending
```

Patched `src/app/terminal.js` includes `AbortSignal.timeout(30_000)`. The same hung POST with that signal rejects `TimeoutError` and the catch path sets `Paste timed out`:

```console
$ node C:\Users\sebta\AppData\Local\Temp\crabfleet-f007-proof.mjs C:\Users\sebta\.grok\tmp\pr-gate-batch\crabfleet-f007
clipboard fetch call:
`/api/interactive-sessions/${encodeURIComponent(id)}/clipboard`, {
      method: "POST",
      headers: {
        "content-type": mediaType || blob.type || "application/octet-stream",
        "x-clipboard-name": encodeURIComponent(name || clipboardName(mediaType)),
      },
      body: blob,
      signal: AbortSignal.timeout(30_000),
    }

parsed timeout_ms: 30000
paste_timed_out_status: true
handles_timeout_and_abort: true

hung POST against silent local server
url: http://127.0.0.1:56690/api/interactive-sessions/demo/clipboard
signal: AbortSignal.timeout(250)
error.name: TimeoutError
error.constructor: DOMException
elapsed_ms: 264
status: Paste timed out
OK: hung clipboard POST aborted and status is Paste timed out
```

The 250 ms signal in the live hang is only to finish the command quickly. Production uses 30000 ms, as parsed from the patched fetch call.

Related prior art:

- [crabfleet#124](https://github.com/openclaw/crabfleet/pull/124) (open): default 30s timeout on the JSON `api()` helper. Does not cover this clipboard POST.
- [crabfleet#125](https://github.com/openclaw/crabfleet/pull/125) (open): CRABBOX.md GitHub fetch timeout. Different call site.
- [clickclack#168](https://github.com/openclaw/clickclack/pull/168) (merged): default 30s fetch timeout unless a caller signal is set
- [clawrouter#111](https://github.com/openclaw/clawrouter/pull/111) (merged): abort hung dashboard and OAuth token fetches

The clipboard upload `fetch` has had no deadline since [#4](https://github.com/openclaw/crabfleet/pull/4) (2026-05-20), 108 days ago.

## Real behavior proof

- **Behavior or issue addressed:** Terminal file paste posted to `/api/interactive-sessions/:id/clipboard` with no AbortSignal, so a stalled Worker left the session on "Uploading ..." forever.
- **Real environment tested:** Windows 11, Node v24.19.0, worktree `C:\Users\sebta\.grok\tmp\pr-gate-batch\crabfleet-f007` on `fix/clipboard-upload-abort` with patched `src/app/terminal.js`.
- **Exact steps or command run after this patch:**

  ```bash
  node C:\Users\sebta\AppData\Local\Temp\crabfleet-f007-proof.mjs C:\Users\sebta\.grok\tmp\pr-gate-batch\crabfleet-f007
  ```

- **Evidence after fix:** terminal output from the live node command above. The patched clipboard fetch includes `signal: AbortSignal.timeout(30_000)` (parsed timeout_ms 30000). A hung POST to a silent local server rejects `TimeoutError` (DOMException) at 264 ms with a 250 ms demo signal, and the status becomes `Paste timed out`.
- **Observed result after fix:** Hung clipboard uploads abort instead of remaining pending. The session status changes from "Uploading ..." to `Paste timed out` instead of hanging.
- **What was not tested:** A live Crabfleet Worker that is actually wedged in production. Browser DevTools on a real Sandbox terminal paste. Uploads that complete after 30 seconds on a very slow link.
