### PR TITLE
fix: timeout GitHub OAuth token exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fail closed GitHub OAuth token exchange and membership refresh after 10 seconds when GitHub never answers, so login callback does not wait for the isolate wall clock, thanks @SebTardif.
 - Stop cancelled Share This Mac cursor reconciliation and release video mailbox waits and their timeout tasks promptly, including cancellation before waiter registration, thanks @SebTardif (#114).
 
 ## 0.3.1 - 2026-08-28

--- a/src/worker/github-auth.ts
+++ b/src/worker/github-auth.ts
@@ -75,7 +75,10 @@ export async function githubCallback(
     return text("Invalid OAuth state.\n", "text/plain; charset=utf-8", {}, 400);
   }
 
-  const tokenResponse = await fetcher("https://github.com/login/oauth/access_token", {
+  const oauthSignal = AbortSignal.timeout(10_000);
+  const timedFetcher: Fetcher = (input, init) =>
+    fetcher(input, { ...init, signal: init?.signal ?? oauthSignal });
+  const tokenResponse = await timedFetcher("https://github.com/login/oauth/access_token", {
     method: "POST",
     headers: {
       accept: "application/json",
@@ -100,7 +103,7 @@ export async function githubCallback(
     );
   }
 
-  const freshUser = await refreshGitHubUser(env, tokenBody.access_token, fetcher).catch(() => {
+  const freshUser = await refreshGitHubUser(env, tokenBody.access_token, timedFetcher).catch(() => {
     throw serviceUnavailable("GitHub membership refresh failed; retry later");
   });
   if (!freshUser) {

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -292,6 +292,92 @@ test("GitHub membership refresh builds one normalized organization identity", as
   );
 });
 
+test("OAuth token exchange and membership refresh pass an AbortSignal", async () => {
+  const env = {
+    GITHUB_CLIENT_ID: "client-id",
+    GITHUB_CLIENT_SECRET: "client-secret",
+    GITHUB_REDIRECT_URI: "https://fleet.example/auth/github/callback",
+  } as RuntimeEnv;
+
+  const seen: Array<{ href: string; hasSignal: boolean }> = [];
+  const fetcher: Fetcher = async (input, init) => {
+    const url = new URL(String(input));
+    seen.push({ href: url.href, hasSignal: init?.signal instanceof AbortSignal });
+    if (url.hostname === "github.com") {
+      return Response.json({ access_token: "github-token" });
+    }
+    if (url.pathname.endsWith("/user/emails") || url.pathname.endsWith("/user/teams")) {
+      return Response.json([]);
+    }
+    if (url.pathname.includes("/memberships/orgs/")) {
+      return Response.json({ state: "pending" });
+    }
+    return Response.json({ id: 42, login: "owner", email: null, name: "Owner" });
+  };
+
+  const callback = await githubCallback(
+    new Request("https://fleet.example/auth/github/callback?code=code&state=state", {
+      headers: { cookie: "crabbox_oauth_state=state" },
+    }),
+    env,
+    fetcher,
+  );
+  assert.equal(callback.status, 403);
+  const tokenCall = seen.find((row) => row.href.includes("/login/oauth/access_token"));
+  assert.ok(tokenCall);
+  assert.equal(tokenCall.hasSignal, true);
+  const refreshCalls = seen.filter((row) => row.href.startsWith("https://api.github.com/"));
+  assert.ok(refreshCalls.length > 0);
+  assert.ok(refreshCalls.every((row) => row.hasSignal));
+});
+
+test("OAuth token exchange aborts when GitHub never answers", async () => {
+  const env = {
+    GITHUB_CLIENT_ID: "client-id",
+    GITHUB_CLIENT_SECRET: "client-secret",
+    GITHUB_REDIRECT_URI: "https://fleet.example/auth/github/callback",
+  } as RuntimeEnv;
+  const origTimeout = AbortSignal.timeout.bind(AbortSignal);
+  const requested: number[] = [];
+  AbortSignal.timeout = (ms: number) => {
+    requested.push(ms);
+    return origTimeout(ms === 10_000 ? 20 : ms);
+  };
+  try {
+    const hung: Fetcher = (_input, init) =>
+      new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          return;
+        }
+        const fail = () => {
+          reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+        };
+        if (signal.aborted) {
+          fail();
+          return;
+        }
+        signal.addEventListener("abort", fail, { once: true });
+      });
+    await assert.rejects(
+      githubCallback(
+        new Request("https://fleet.example/auth/github/callback?code=code&state=state", {
+          headers: { cookie: "crabbox_oauth_state=state" },
+        }),
+        env,
+        hung,
+      ),
+      (error: unknown) => {
+        assert.equal((error as Error).name, "TimeoutError");
+        return true;
+      },
+    );
+    assert.deepEqual(requested, [10_000]);
+  } finally {
+    AbortSignal.timeout = origTimeout;
+  }
+});
+
 test("GitHub membership refresh reports incomplete email evidence without breaking callers", async () => {
   const fetcher: Fetcher = async (input) => {
     const url = new URL(String(input));


### PR DESCRIPTION
## What Problem This Solves

Fixes GitHub sign-in remaining pending when the token exchange or membership lookup stalls.

## User Impact

The callback has one ten-second deadline across its GitHub requests. Membership timeouts retain the retryable 503 response; successful login and existing rejection paths remain unchanged.

## Why This Change Was Made

Preserve @SebTardif's aggregate deadline and adapt the original PR to the desktop-only backend. Regression tests now trigger cancellation deterministically, avoiding an unreferenced timer and global mock leakage. They cover both the token exchange and subsequent membership refresh using the same signal.

## Evidence

`pnpm check`, all 189 tests, and `pnpm test:native` passed on Linux. All 12 focused OAuth tests passed. Independent Codex review found no actionable issues.

The tests exercise callback behavior with controlled GitHub responses and cancellation. They do not claim a live production OAuth exchange or a real GitHub outage.

Maintainer qualification: the OAuth client ID, secret, token and callback state added in the tests are fixed synthetic fixtures supplied only to an injected fake fetcher; no live credentials or network are used. ClawSweeper's input check declined its automated review without reporting a finding. The maintainer inspected the diff and the separate isolated Codex review completed cleanly.
