### PR TITLE
fix: timeout GitHub issue and PR ref lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fail closed GitHub issue and PR ref lookups after 10 seconds when GitHub never answers, so card issue preview does not wait for the isolate wall clock, thanks @SebTardif.
 - Stop cancelled Share This Mac cursor reconciliation and release video mailbox waits and their timeout tasks promptly, including cancellation before waiter registration, thanks @SebTardif (#114).
 
 ## 0.3.1 - 2026-08-28

--- a/src/worker/github-reference-service.ts
+++ b/src/worker/github-reference-service.ts
@@ -96,6 +96,7 @@ export class GitHubReferenceService {
         query: `query CrabfleetRefs($number: Int!) { ${selections} }`,
         variables: { number },
       }),
+      signal: AbortSignal.timeout(10_000),
     });
     if (response.status === 403 || response.status === 429) {
       throw serviceUnavailable("GitHub lookup rate limited; retry later");
@@ -128,7 +129,7 @@ export class GitHubReferenceService {
     if (!repo) return [];
     const response = await this.dependencies.fetcher(
       `https://api.github.com/repos/${repo}/issues/${number}`,
-      { headers: this.dependencies.headers },
+      { headers: this.dependencies.headers, signal: AbortSignal.timeout(10_000) },
     );
     if (response.status === 404 || response.status === 410) return [];
     if (response.status === 403 || response.status === 429) {

--- a/tests/github-reference-service.test.ts
+++ b/tests/github-reference-service.test.ts
@@ -26,6 +26,24 @@ function status(error: unknown): number | undefined {
     : undefined;
 }
 
+function hungGitHubFetcher(_input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  return new Promise((_resolve, reject) => {
+    const signal = init?.signal;
+    if (!signal) {
+      reject(new Error("missing AbortSignal"));
+      return;
+    }
+    const fail = () => {
+      reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+    };
+    if (signal.aborted) {
+      fail();
+      return;
+    }
+    signal.addEventListener("abort", fail, { once: true });
+  });
+}
+
 test("GitHub reference search rejects invalid numbers before reading repositories", async () => {
   let read = false;
   const service = new GitHubReferenceService(
@@ -129,6 +147,69 @@ test("authenticated GitHub reference search batches and maps enabled repositorie
   assert.equal(requestBody.variables?.number, 7);
   assert.match(requestBody.query ?? "", /r0: repository\(owner: "openclaw", name: "crabfleet"\)/);
   assert.match(requestBody.query ?? "", /r1: repository\(owner: "other", name: "repo"\)/);
+});
+
+test("public and authenticated GitHub reference fetches pass an AbortSignal", async () => {
+  const publicCalls: Array<{ href: string; hasSignal: boolean }> = [];
+  const publicService = new GitHubReferenceService(
+    dependencies(async (input, init) => {
+      publicCalls.push({ href: String(input), hasSignal: init?.signal instanceof AbortSignal });
+      return Response.json({
+        number: 42,
+        title: "Public issue",
+        state: "open",
+        html_url: "https://github.com/openclaw/crabfleet/issues/42",
+        body: null,
+        user: { login: "octocat" },
+        updated_at: "2026-06-15T10:00:00Z",
+      });
+    }),
+  );
+  await publicService.search("42");
+  assert.equal(publicCalls.length, 1);
+  assert.equal(publicCalls[0]?.href, "https://api.github.com/repos/openclaw/crabfleet/issues/42");
+  assert.equal(publicCalls[0]?.hasSignal, true);
+
+  const authCalls: Array<{ href: string; hasSignal: boolean }> = [];
+  const authService = new GitHubReferenceService(
+    dependencies(
+      async (input, init) => {
+        authCalls.push({ href: String(input), hasSignal: init?.signal instanceof AbortSignal });
+        return Response.json({ data: {} });
+      },
+      { authenticated: true },
+    ),
+  );
+  await authService.search(7);
+  assert.equal(authCalls.length, 1);
+  assert.equal(authCalls[0]?.href, "https://api.github.com/graphql");
+  assert.equal(authCalls[0]?.hasSignal, true);
+});
+
+test("GitHub reference search aborts a hung GitHub fetch", async () => {
+  const origTimeout = AbortSignal.timeout.bind(AbortSignal);
+  const requested: number[] = [];
+  AbortSignal.timeout = (ms: number) => {
+    requested.push(ms);
+    return origTimeout(ms === 10_000 ? 20 : ms);
+  };
+  try {
+    const publicService = new GitHubReferenceService(dependencies(hungGitHubFetcher));
+    await assert.rejects(publicService.search(1), (error: unknown) => {
+      assert.equal((error as Error).name, "TimeoutError");
+      return true;
+    });
+    const authService = new GitHubReferenceService(
+      dependencies(hungGitHubFetcher, { authenticated: true }),
+    );
+    await assert.rejects(authService.search(1), (error: unknown) => {
+      assert.equal((error as Error).name, "TimeoutError");
+      return true;
+    });
+    assert.deepEqual(requested, [10_000, 10_000]);
+  } finally {
+    AbortSignal.timeout = origTimeout;
+  }
 });
 
 test("GitHub reference search reports transport and GraphQL rate limits", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers typing an issue or PR number into the card composer would leave the GitHub ref preview spinning when `api.github.com` never answered. `GET /api/github/refs?number=` (`ControlPlane` -> `searchGitHubRefs` -> `GitHubReferenceService`) posted GraphQL and GET REST lookups with headers and body only. A hung GitHub left the Worker request pending until the isolate wall clock. Browser-side fetch timeouts only abort the tab; they do not cancel the outbound Worker call.

## Why This Change Was Made

Both outbound GitHub fetches now pass `signal: AbortSignal.timeout(10_000)`. Authenticated lookup still batches enabled repos in one GraphQL `issueOrPullRequest` query. Public lookup still reads the preferred repo over REST. Rate-limit 503s, 404/410 empty matches, and mapped titles/states are unchanged. Only a stuck `api.github.com` TCP or HTTP response now fails closed after 10 seconds.

This is the same hang class as [#125](https://github.com/openclaw/crabfleet/pull/125) (CRABBOX.md contents), [#127](https://github.com/openclaw/crabfleet/pull/127) (OAuth token exchange), and `runtime-adapter-transport.ts`. It does not change `github-auth.ts`, `workflow-service.ts`, or the browser `api()` helper.

## User Impact

A stalled GitHub API no longer pins card issue/PR preview. After 10 seconds the Worker lookup throws `TimeoutError` and the composer can show the existing "GitHub lookup failed" error instead of staying on loading.

## Evidence

Live `node` against patched `GitHubReferenceService.search`. The unfixed public REST call used headers only (`hasSignal: false`) and was still pending at the 200ms watchdog. The patched public REST and authenticated GraphQL calls requested `AbortSignal.timeout(10000)` (helper shortened to 50ms so the hang proof did not wait the full 10s) and aborted with `TimeoutError`.

```console
$ node --experimental-strip-types .pr-f009-proof.mts
GITHUB_REFS_FETCH_TIMEOUT_MS 10000
{
  "timeoutArgs": [
    10000,
    10000
  ],
  "unfixedSeen": [
    {
      "input": "https://api.github.com/repos/openclaw/crabfleet/issues/1",
      "hasSignal": false,
      "method": "GET"
    }
  ],
  "publicSeen": [
    {
      "input": "https://api.github.com/repos/openclaw/crabfleet/issues/1",
      "hasSignal": true,
      "method": "GET"
    }
  ],
  "authSeen": [
    {
      "input": "https://api.github.com/graphql",
      "hasSignal": true,
      "method": "POST"
    }
  ],
  "unfixed": {
    "label": "unfixed public REST",
    "outcome": "Error: WATCHDOG: hung fetch still pending after 200ms",
    "ms": 208
  },
  "publicFixed": {
    "label": "fixed public REST",
    "outcome": "TimeoutError: The operation was aborted due to timeout",
    "ms": 65
  },
  "authFixed": {
    "label": "fixed authenticated GraphQL",
    "outcome": "TimeoutError: The operation was aborted due to timeout",
    "ms": 63
  }
}
```

The headers-only GitHub ref fetches were introduced in [#44](https://github.com/openclaw/crabfleet/pull/44) (`df9bdc9`, 2026-06-15) and have been present for 82 days. Same-class prior art: [clickclack#168](https://github.com/openclaw/clickclack/pull/168).

## Real behavior proof

- **Behavior or issue addressed:** `GET /api/github/refs?number=` left card issue/PR preview pending when GitHub never answered the public REST or authenticated GraphQL lookup.
- **Real environment tested:** Windows, Node v24.19.0, worktree `C:/Users/sebta/.grok/tmp/pr-gate-batch/crabfleet-f009` on `fix/github-refs-abort`.
- **Exact steps or command run after this patch:** `node --experimental-strip-types .pr-f009-proof.mts` (headers-only public REST, then patched `GitHubReferenceService.search` for a hung public REST GET and a hung authenticated GraphQL POST).
- **Evidence after fix:** terminal output above. Unfixed stay-pending watchdog at 208ms with `hasSignal: false`. Patched public REST requested 10000ms and aborted with `TimeoutError` at 65ms. Patched GraphQL POST requested 10000ms and aborted with `TimeoutError` at 63ms. Both patched calls had `hasSignal: true`.
- **Observed result after fix:** A never-responding GitHub issue or PR lookup now fails with `TimeoutError` instead of remaining pending. Public REST still targets `https://api.github.com/repos/openclaw/crabfleet/issues/:number`. Authenticated lookup still posts to `https://api.github.com/graphql`.
- **What was not tested:** A live `GET /api/github/refs` against production GitHub or a real Cloudflare isolate wall-clock hang.
